### PR TITLE
Pass settings to factory methods and add async onLoad hook

### DIFF
--- a/src/adapters/stub.ts
+++ b/src/adapters/stub.ts
@@ -86,11 +86,11 @@ export class StubAdapter extends BaseAdapter {
     itemName: "item",
   };
 
-  createParser(app: App, basePath: string): WorkItemParser {
+  createParser(app: App, basePath: string, _settings?: Record<string, unknown>): WorkItemParser {
     return new StubParser(app, basePath);
   }
 
-  createMover(_app: App, _basePath: string): WorkItemMover {
+  createMover(_app: App, _basePath: string, _settings?: Record<string, unknown>): WorkItemMover {
     return new StubMover();
   }
 

--- a/src/adapters/task-agent/index.ts
+++ b/src/adapters/task-agent/index.ts
@@ -20,8 +20,7 @@ import type { KanbanColumn } from "./types";
 export class TaskAgentAdapter extends BaseAdapter {
   config: PluginConfig = TASK_AGENT_CONFIG;
 
-  // Cached from framework calls - the framework always passes app to factory methods,
-  // and settings are passed via onItemCreated's settings parameter
+  // Cached from framework calls - the framework passes app and settings to factory methods
   private _app: App | null = null;
   private detailView: TaskDetailView | null = null;
 

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -156,9 +156,9 @@ export interface AdapterBundle {
    */
   onLoad?(app: App, settings: Record<string, unknown>): Promise<void>;
   /** Create a parser for loading/parsing work items from the vault. */
-  createParser(app: App, basePath: string, settings: Record<string, unknown>): WorkItemParser;
+  createParser(app: App, basePath: string, settings?: Record<string, unknown>): WorkItemParser;
   /** Create a mover for state transitions between columns. */
-  createMover(app: App, basePath: string, settings: Record<string, unknown>): WorkItemMover;
+  createMover(app: App, basePath: string, settings?: Record<string, unknown>): WorkItemMover;
   /** Create a card renderer for the list panel. */
   createCardRenderer(): CardRenderer;
   /** Create a prompt builder for Claude context sessions. */
@@ -198,12 +198,12 @@ export interface AdapterBundle {
  */
 export abstract class BaseAdapter implements AdapterBundle {
   abstract config: PluginConfig;
-  abstract createParser(app: App, basePath: string, settings: Record<string, unknown>): WorkItemParser;
-  abstract createMover(app: App, basePath: string, settings: Record<string, unknown>): WorkItemMover;
+  abstract createParser(app: App, basePath: string, settings?: Record<string, unknown>): WorkItemParser;
+  abstract createMover(app: App, basePath: string, settings?: Record<string, unknown>): WorkItemMover;
   abstract createCardRenderer(): CardRenderer;
   abstract createPromptBuilder(): WorkItemPromptBuilder;
 
-  async onLoad?(_app: App, _settings: Record<string, unknown>): Promise<void> {
+  async onLoad(_app: App, _settings: Record<string, unknown>): Promise<void> {
     // no-op by default
   }
 

--- a/src/framework/MainView.ts
+++ b/src/framework/MainView.ts
@@ -228,9 +228,7 @@ export class MainView extends ItemView {
     this.settings = settings;
 
     // Allow adapter to perform async initialization (credential fetch, API sync, etc.)
-    if (typeof this.adapter.onLoad === "function") {
-      await this.adapter.onLoad(this.app, settings);
-    }
+    await this.adapter.onLoad?.(this.app, settings);
 
     const parser = this.adapter.createParser(this.app, "", settings);
     const mover = this.adapter.createMover(this.app, "", settings);


### PR DESCRIPTION
## Summary
- **#13**: Add `settings` parameter to `createParser()` and `createMover()` in the `AdapterBundle` interface/`BaseAdapter`, pass settings from `MainView.initPanels()` and `refreshList()`, update task-agent adapter to forward settings instead of empty object
- **#11**: Add optional `onLoad(app, settings)` async initialization hook to `AdapterBundle`, with no-op default in `BaseAdapter`, called in `MainView.initPanels()` before parser/mover creation

Both changes are backwards-compatible - existing adapters that don't use the new settings parameter or onLoad hook are unaffected.

Closes #13
Closes #11

## Test plan
- [x] All 111 existing tests pass (`npx vitest run`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual verification: plugin loads and functions normally in Obsidian
- [ ] Verify adapters can access settings in createParser/createMover
- [ ] Verify onLoad hook is called before parser/mover creation