### PR TITLE
Make copied ctx prompt match Claude ctx

### DIFF
--- a/src/adapters/task-agent/TaskCard.test.ts
+++ b/src/adapters/task-agent/TaskCard.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TaskCard } from "./TaskCard";
+import type { CardActionContext, WorkItem } from "../../core/interfaces";
+
+vi.mock("obsidian", () => ({
+  Notice: class Notice {
+    constructor(_message: string) {}
+  },
+}));
+
+function makeItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    id: "task-1",
+    path: "2 - Areas/Tasks/priority/task.md",
+    title: "Fix context prompt",
+    state: "priority",
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function makeContext(overrides: Partial<CardActionContext> = {}): CardActionContext {
+  return {
+    onSelect: vi.fn(),
+    onMoveToTop: vi.fn(),
+    onMoveToColumn: vi.fn(),
+    onInsertAfter: vi.fn(),
+    onSplitTask: vi.fn(),
+    onDelete: vi.fn(),
+    onCloseSessions: vi.fn(),
+    getContextPrompt: vi.fn().mockResolvedValue("Task: Fix context prompt\nState: priority"),
+    ...overrides,
+  };
+}
+
+describe("TaskCard", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  it("copies the exact context prompt from the framework callback", async () => {
+    const item = makeItem();
+    const ctx = makeContext();
+    const card = new TaskCard();
+
+    const menuItems = card.getContextMenuItems(item, ctx);
+    const copyItem = menuItems.find(
+      (menuItem) => (menuItem as any).title === "Copy Context Prompt",
+    ) as { callback: () => Promise<void> } | undefined;
+
+    expect(copyItem).toBeDefined();
+
+    await copyItem?.callback();
+
+    expect(ctx.getContextPrompt).toHaveBeenCalledTimes(1);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "Task: Fix context prompt\nState: priority",
+    );
+  });
+
+  it("does not write to the clipboard when no Claude context prompt is available", async () => {
+    const item = makeItem();
+    const ctx = makeContext({
+      getContextPrompt: vi.fn().mockResolvedValue(null),
+    });
+    const card = new TaskCard();
+
+    const menuItems = card.getContextMenuItems(item, ctx);
+    const copyItem = menuItems.find(
+      (menuItem) => (menuItem as any).title === "Copy Context Prompt",
+    ) as { callback: () => Promise<void> } | undefined;
+
+    await copyItem?.callback();
+
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    expect(ctx.getContextPrompt).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/adapters/task-agent/TaskCard.ts
+++ b/src/adapters/task-agent/TaskCard.ts
@@ -1,4 +1,4 @@
-import type { MenuItem } from "obsidian";
+import { Notice, type MenuItem } from "obsidian";
 import type { WorkItem, CardRenderer, CardActionContext } from "../../core/interfaces";
 import { KANBAN_COLUMNS, COLUMN_LABELS, SOURCE_LABELS, type KanbanColumn } from "./types";
 
@@ -150,9 +150,13 @@ export class TaskCard implements CardRenderer {
     });
     (items as any[]).push({
       title: "Copy Context Prompt",
-      callback: () => {
-        const prompt = this.buildQuickPrompt(item);
-        navigator.clipboard.writeText(prompt);
+      callback: async () => {
+        const prompt = await ctx.getContextPrompt();
+        if (!prompt) {
+          new Notice("Set 'Claude (ctx) prompt template' in settings to copy the context prompt");
+          return;
+        }
+        await navigator.clipboard.writeText(prompt);
       },
     });
 
@@ -166,18 +170,5 @@ export class TaskCard implements CardRenderer {
     });
 
     return items;
-  }
-
-  private buildQuickPrompt(item: WorkItem): string {
-    const meta = (item.metadata || {}) as Record<string, any>;
-    const priority = meta.priority || {};
-    let prompt = `Task: ${item.title}\nState: ${item.state}\nPath: ${item.path}`;
-    if (priority.deadline) {
-      prompt += `\nDeadline: ${priority.deadline}`;
-    }
-    if (priority["has-blocker"] && priority["blocker-context"]) {
-      prompt += `\nBlocker: ${priority["blocker-context"]}`;
-    }
-    return prompt;
   }
 }

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -117,6 +117,8 @@ export interface CardActionContext {
   onDelete(): void;
   /** Close all terminal sessions for this item. */
   onCloseSessions(): void;
+  /** Build the exact prompt used by "Claude (ctx)" for this item, or null when unavailable. */
+  getContextPrompt(): Promise<string | null>;
 }
 
 /**

--- a/src/framework/ClaudeContextPrompt.test.ts
+++ b/src/framework/ClaudeContextPrompt.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import type { WorkItem } from "../core/interfaces";
+import { buildClaudeContextPrompt } from "./ClaudeContextPrompt";
+
+const item: WorkItem = {
+  id: "task-123",
+  path: "2 - Areas/Tasks/priority/task.md",
+  title: "Fix prompt sync",
+  state: "priority",
+  metadata: {},
+};
+
+describe("buildClaudeContextPrompt", () => {
+  it("uses the fresh template when available", () => {
+    const prompt = buildClaudeContextPrompt(item, {
+      "core.additionalAgentContext": "Task: $title\nState: $state\nPath: $filePath\nId: $id",
+    });
+
+    expect(prompt).toBe(
+      "Task: Fix prompt sync\nState: priority\nPath: 2 - Areas/Tasks/priority/task.md\nId: task-123",
+    );
+  });
+
+  it("treats an explicitly cleared template as unavailable", () => {
+    const prompt = buildClaudeContextPrompt(item, {
+      "core.additionalAgentContext": "",
+    });
+
+    expect(prompt).toBeNull();
+  });
+
+  it("returns null when no template is saved", () => {
+    const prompt = buildClaudeContextPrompt(item, {});
+
+    expect(prompt).toBeNull();
+  });
+});

--- a/src/framework/ClaudeContextPrompt.ts
+++ b/src/framework/ClaudeContextPrompt.ts
@@ -1,0 +1,17 @@
+import type { WorkItem } from "../core/interfaces";
+
+export function buildClaudeContextPrompt(
+  item: WorkItem,
+  settings: Record<string, unknown>,
+): string | null {
+  const template = settings["core.additionalAgentContext"];
+  if (typeof template !== "string" || template === "") {
+    return null;
+  }
+
+  return template
+    .replace(/\$title/g, item.title)
+    .replace(/\$state/g, item.state)
+    .replace(/\$filePath/g, item.path)
+    .replace(/\$id/g, item.id);
+}

--- a/src/framework/ListPanel.ts
+++ b/src/framework/ListPanel.ts
@@ -263,6 +263,7 @@ export class ListPanel {
       },
       onDelete: () => this.deleteItem(item),
       onCloseSessions: () => this.terminalPanel.closeAllSessions(item.id),
+      getContextPrompt: () => this.terminalPanel.getClaudeContextPrompt(item),
     };
   }
 
@@ -702,7 +703,14 @@ export class ListPanel {
         menu.addSeparator();
       } else {
         menu.addItem((menuItem) => {
-          menuItem.setTitle(ai.title || "Action").onClick(() => ai.callback?.());
+          menuItem.setTitle(ai.title || "Action").onClick(() => {
+            void Promise.resolve()
+              .then(() => ai.callback?.())
+              .catch((err) => {
+                console.error("[work-terminal] Card action failed:", err);
+                new Notice("Card action failed; see console for details");
+              });
+          });
         });
       }
     }

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -63,7 +63,7 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
       containerEl,
       "core.additionalAgentContext",
       "Claude (ctx) prompt template",
-      "Template for '+ Claude (ctx)' button. Placeholders: $title, $state, $filePath, $id. Button hidden when empty.",
+      "Template for '+ Claude (ctx)' button. Placeholders: $title, $state, $filePath, $id. When empty, the button shows a notice instead of launching.",
     );
     this.addCoreSetting(
       containerEl,
@@ -90,6 +90,13 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
         this.addAdapterSetting(containerEl, field);
       }
     }
+  }
+
+  private async saveSettings(update: (settings: Record<string, unknown>) => void): Promise<void> {
+    const data = (await this.plugin.loadData()) || {};
+    if (!data.settings) data.settings = {};
+    update(data.settings);
+    await this.plugin.saveData(data);
   }
 
   private async renderHookStatus(containerEl: HTMLElement): Promise<void> {
@@ -159,10 +166,9 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
       )
       .addToggle((toggle) =>
         toggle.setValue(!!acceptValue).onChange(async (newValue) => {
-          const d = (await this.plugin.loadData()) || {};
-          if (!d.settings) d.settings = {};
-          d.settings["core.acceptNoResumeHooks"] = newValue;
-          await this.plugin.saveData(d);
+          await this.saveSettings((settings) => {
+            settings["core.acceptNoResumeHooks"] = newValue;
+          });
         }),
       );
   }
@@ -182,10 +188,9 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
       .setDesc(description)
       .addText((text) =>
         text.setValue(String(value)).onChange(async (newValue) => {
-          const d = (await this.plugin.loadData()) || {};
-          if (!d.settings) d.settings = {};
-          d.settings[key] = newValue;
-          await this.plugin.saveData(d);
+          await this.saveSettings((settings) => {
+            settings[key] = newValue;
+          });
         }),
       );
   }
@@ -205,10 +210,9 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
       .setDesc(description)
       .addTextArea((ta) => {
         ta.setValue(String(value)).onChange(async (newValue) => {
-          const d = (await this.plugin.loadData()) || {};
-          if (!d.settings) d.settings = {};
-          d.settings[key] = newValue;
-          await this.plugin.saveData(d);
+          await this.saveSettings((settings) => {
+            settings[key] = newValue;
+          });
         });
         ta.inputEl.style.width = "100%";
         ta.inputEl.style.minHeight = "80px";
@@ -230,19 +234,17 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
     if (field.type === "text") {
       setting.addText((text) =>
         text.setValue(String(value)).onChange(async (newValue) => {
-          const d = (await this.plugin.loadData()) || {};
-          if (!d.settings) d.settings = {};
-          d.settings[key] = newValue;
-          await this.plugin.saveData(d);
+          await this.saveSettings((settings) => {
+            settings[key] = newValue;
+          });
         }),
       );
     } else if (field.type === "toggle") {
       setting.addToggle((toggle) =>
         toggle.setValue(!!value).onChange(async (newValue) => {
-          const d = (await this.plugin.loadData()) || {};
-          if (!d.settings) d.settings = {};
-          d.settings[key] = newValue;
-          await this.plugin.saveData(d);
+          await this.saveSettings((settings) => {
+            settings[key] = newValue;
+          });
         }),
       );
     }

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -30,6 +30,7 @@ import type { PersistedSession, SessionType } from "../core/session/types";
 import { expandTilde } from "../core/utils";
 import { checkHookStatus } from "../core/claude/ClaudeHookManager";
 import type { AdapterBundle, WorkItem, WorkItemPromptBuilder } from "../core/interfaces";
+import { buildClaudeContextPrompt } from "./ClaudeContextPrompt";
 
 export class TerminalPanelView {
   private tabManager: TabManager;
@@ -233,21 +234,19 @@ export class TerminalPanelView {
 
     // Spawn buttons (always visible)
     const shellBtn = buttonsContainer.createEl("button", { cls: "wt-spawn-btn", text: "+ Shell" });
-    shellBtn.addEventListener("click", () => this.spawnShell());
+    shellBtn.addEventListener("click", () => void this.spawnShell());
 
     const claudeBtn = buttonsContainer.createEl("button", { cls: "wt-spawn-btn wt-spawn-claude" });
     claudeBtn.appendChild(createClaudeLogo());
     claudeBtn.appendText("Claude");
-    claudeBtn.addEventListener("click", () => this.spawnClaude());
+    claudeBtn.addEventListener("click", () => void this.spawnClaude());
 
-    if (this.settings["core.additionalAgentContext"]) {
-      const claudeCtxBtn = buttonsContainer.createEl("button", {
-        cls: "wt-spawn-btn wt-spawn-claude-ctx",
-      });
-      claudeCtxBtn.appendChild(createClaudeLogo());
-      claudeCtxBtn.appendText("Claude (ctx)");
-      claudeCtxBtn.addEventListener("click", () => this.spawnClaudeWithContext());
-    }
+    const claudeCtxBtn = buttonsContainer.createEl("button", {
+      cls: "wt-spawn-btn wt-spawn-claude-ctx",
+    });
+    claudeCtxBtn.appendChild(createClaudeLogo());
+    claudeCtxBtn.appendText("Claude (ctx)");
+    claudeCtxBtn.addEventListener("click", () => void this.spawnClaudeWithContext());
   }
 
   /** Update Claude state classes on existing tab elements without full re-render. */
@@ -453,30 +452,44 @@ export class TerminalPanelView {
   // Spawn operations
   // ---------------------------------------------------------------------------
 
-  private spawnShell(): void {
-    const shell = this.settings["core.defaultShell"] || process.env.SHELL || "/bin/zsh";
-    const cwd = expandTilde(this.settings["core.defaultTerminalCwd"] || "~");
+  private async loadFreshSettings(): Promise<Record<string, unknown>> {
+    return ((await this.plugin.loadData()) || {}).settings || {};
+  }
+
+  private getStringSetting(
+    settings: Record<string, unknown>,
+    key: string,
+    defaultValue: string,
+  ): string {
+    const value = settings[key];
+    return typeof value === "string" ? value : defaultValue;
+  }
+
+  private async spawnShell(): Promise<void> {
+    const fresh = await this.loadFreshSettings();
+    const shell = this.getStringSetting(
+      fresh,
+      "core.defaultShell",
+      process.env.SHELL || "/bin/zsh",
+    );
+    const cwd = expandTilde(this.getStringSetting(fresh, "core.defaultTerminalCwd", "~"));
     this.tabManager.createTab(shell, cwd, "Shell", "shell");
     this.renderTabBar();
   }
 
   private async spawnClaude(): Promise<void> {
-    const fresh = ((await this.plugin.loadData()) || {}).settings || {};
-    const claudeCmd =
-      fresh["core.claudeCommand"] || this.settings["core.claudeCommand"] || "claude";
+    const fresh = await this.loadFreshSettings();
+    const claudeCmd = this.getStringSetting(fresh, "core.claudeCommand", "claude");
     const resolved = resolveCommand(claudeCmd);
     const sessionId = crypto.randomUUID();
     const args = buildClaudeArgs(
       {
-        claudeExtraArgs:
-          fresh["core.claudeExtraArgs"] || this.settings["core.claudeExtraArgs"] || "",
+        claudeExtraArgs: this.getStringSetting(fresh, "core.claudeExtraArgs", ""),
       },
       sessionId,
     );
 
-    const cwd = expandTilde(
-      fresh["core.defaultTerminalCwd"] || this.settings["core.defaultTerminalCwd"] || "~",
-    );
+    const cwd = expandTilde(this.getStringSetting(fresh, "core.defaultTerminalCwd", "~"));
     const tab = this.tabManager.createTab(
       resolved,
       cwd,
@@ -505,31 +518,20 @@ export class TerminalPanelView {
       return;
     }
 
-    // Read settings fresh from disk so edits take effect without reload
-    const fresh = ((await this.plugin.loadData()) || {}).settings || {};
-    const template = fresh["core.additionalAgentContext"] || "";
-    if (!template) {
+    const prompt = await this.getClaudeContextPrompt(item);
+    if (!prompt) {
       new Notice("Set 'Claude (ctx) prompt template' in settings to use Claude (ctx)");
       return;
     }
+    const fresh = await this.loadFreshSettings();
 
-    // Substitute placeholders in the template
-    const prompt = template
-      .replace(/\$title/g, item.title)
-      .replace(/\$state/g, item.state)
-      .replace(/\$filePath/g, item.path)
-      .replace(/\$id/g, item.id);
-
-    const claudeCmd =
-      fresh["core.claudeCommand"] || this.settings["core.claudeCommand"] || "claude";
+    const claudeCmd = this.getStringSetting(fresh, "core.claudeCommand", "claude");
     const resolved = resolveCommand(claudeCmd);
     const sessionId = crypto.randomUUID();
-    const extraArgs = fresh["core.claudeExtraArgs"] || this.settings["core.claudeExtraArgs"] || "";
+    const extraArgs = this.getStringSetting(fresh, "core.claudeExtraArgs", "");
     const args = buildClaudeArgs({ claudeExtraArgs: extraArgs }, sessionId, prompt);
 
-    const cwd = expandTilde(
-      fresh["core.defaultTerminalCwd"] || this.settings["core.defaultTerminalCwd"] || "~",
-    );
+    const cwd = expandTilde(this.getStringSetting(fresh, "core.defaultTerminalCwd", "~"));
     const tab = this.tabManager.createTab(
       resolved,
       cwd,
@@ -546,17 +548,14 @@ export class TerminalPanelView {
   }
 
   async spawnClaudeWithPrompt(prompt: string, label?: string): Promise<void> {
-    const fresh = ((await this.plugin.loadData()) || {}).settings || {};
-    const claudeCmd =
-      fresh["core.claudeCommand"] || this.settings["core.claudeCommand"] || "claude";
+    const fresh = await this.loadFreshSettings();
+    const claudeCmd = this.getStringSetting(fresh, "core.claudeCommand", "claude");
     const resolved = resolveCommand(claudeCmd);
     const sessionId = crypto.randomUUID();
-    const extraArgs = fresh["core.claudeExtraArgs"] || this.settings["core.claudeExtraArgs"] || "";
+    const extraArgs = this.getStringSetting(fresh, "core.claudeExtraArgs", "");
     const args = buildClaudeArgs({ claudeExtraArgs: extraArgs }, sessionId, prompt);
 
-    const cwd = expandTilde(
-      fresh["core.defaultTerminalCwd"] || this.settings["core.defaultTerminalCwd"] || "~",
-    );
+    const cwd = expandTilde(this.getStringSetting(fresh, "core.defaultTerminalCwd", "~"));
     const tab = this.tabManager.createTab(
       resolved,
       cwd,
@@ -649,6 +648,11 @@ export class TerminalPanelView {
       this.titleEl.textContent = "";
       this.titleEl.style.display = "none";
     }
+  }
+
+  async getClaudeContextPrompt(item: WorkItem): Promise<string | null> {
+    const fresh = await this.loadFreshSettings();
+    return buildClaudeContextPrompt(item, fresh);
   }
 
   getRecoveredItemId(): string | null {


### PR DESCRIPTION
## Summary
- make card-menu `Copy Context Prompt` use the same runtime Claude (ctx) prompt source
- add tests around context prompt generation and card-menu copy behavior
- keep the implementation aligned with #37 by reading the ctx template fresh at execution time

## Testing
- npx vitest run
- npm run build