### PR TITLE
Implement custom session spawner with Copilot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Obsidian plugin that turns your vault into a work item board with per-item tabbe
 ## What you get
 
 - **Kanban board** with collapsible sections, drag-drop reordering, and custom sort order
-- **Tabbed terminals** per work item - Shell, Claude, and Claude-with-context sessions
-- **Claude integration** - binary resolution, state detection (active/waiting/idle), session rename detection, headless spawning
+- **Tabbed terminals** per work item - Shell, Claude, contextual Claude, and custom sessions (including GitHub Copilot CLI)
+- **Agent integration** - Claude/Copilot command resolution, Claude state detection (active/waiting/idle), session rename detection, headless spawning
 - **Session persistence** - hot-reload preserves live terminals; disk persistence enables session resume after restart
 - **Detail panel** - native Obsidian MarkdownView via workspace leaf splitting
 

--- a/src/adapters/task-agent/TaskCard.ts
+++ b/src/adapters/task-agent/TaskCard.ts
@@ -153,7 +153,7 @@ export class TaskCard implements CardRenderer {
       callback: async () => {
         const prompt = await ctx.getContextPrompt();
         if (!prompt) {
-          new Notice("Set 'Claude (ctx) prompt template' in settings to copy the context prompt");
+          new Notice("Set 'Context prompt template' in settings to copy the context prompt");
           return;
         }
         await navigator.clipboard.writeText(prompt);

--- a/src/core/claude/ClaudeLauncher.test.ts
+++ b/src/core/claude/ClaudeLauncher.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { buildClaudeArgs, buildCopilotArgs } from "./ClaudeLauncher";
+
+describe("ClaudeLauncher", () => {
+  it("builds Claude args with session id and prompt", () => {
+    expect(
+      buildClaudeArgs(
+        {
+          claudeExtraArgs: "--model sonnet",
+          additionalAgentContext: "Follow repo rules.",
+        },
+        "session-123",
+        "Review this task",
+      ),
+    ).toEqual([
+      "--model",
+      "sonnet",
+      "--session-id",
+      "session-123",
+      "Review this task\n\nFollow repo rules.",
+    ]);
+  });
+
+  it("builds Copilot args with prompt injection", () => {
+    expect(
+      buildCopilotArgs(
+        {
+          copilotExtraArgs: "--model gpt-5.4 --allow-all-tools",
+        },
+        "Review this task",
+      ),
+    ).toEqual(["--model", "gpt-5.4", "--allow-all-tools", "-i", "Review this task"]);
+  });
+
+  it("builds Copilot args without prompt when launching plain interactive sessions", () => {
+    expect(buildCopilotArgs({ copilotExtraArgs: "--model gpt-5.4" })).toEqual([
+      "--model",
+      "gpt-5.4",
+    ]);
+  });
+});

--- a/src/core/claude/ClaudeLauncher.ts
+++ b/src/core/claude/ClaudeLauncher.ts
@@ -1,5 +1,5 @@
 /**
- * Claude CLI launch helpers: PATH augmentation, command resolution, argument building.
+ * CLI launch helpers: PATH augmentation, command resolution, and agent argument builders.
  */
 import { expandTilde, electronRequire } from "../utils";
 
@@ -65,6 +65,25 @@ export function buildClaudeArgs(
     // Pass as positional arg (initial message in interactive session),
     // not -p (which is one-shot print mode that exits after response).
     args.push(fullPrompt);
+  }
+  return args;
+}
+
+/**
+ * Build GitHub Copilot CLI argument array from settings and optional prompt.
+ */
+export function buildCopilotArgs(
+  settings: {
+    copilotExtraArgs?: string;
+  },
+  prompt?: string,
+): string[] {
+  const args: string[] = [];
+  if (settings.copilotExtraArgs) {
+    args.push(...settings.copilotExtraArgs.split(/\s+/).filter(Boolean));
+  }
+  if (prompt) {
+    args.push("-i", prompt);
   }
   return args;
 }

--- a/src/core/session/SessionPersistence.test.ts
+++ b/src/core/session/SessionPersistence.test.ts
@@ -34,7 +34,7 @@ function makePersisted(
 
 describe("SessionPersistence", () => {
   describe("saveToDisk", () => {
-    it("saves only claude sessions with session IDs", async () => {
+    it("saves resumable agent sessions with session IDs", async () => {
       const plugin = createMockPlugin();
       const sessions = new Map<string, any[]>();
       sessions.set("task-1", [
@@ -44,6 +44,13 @@ describe("SessionPersistence", () => {
           label: "Claude",
           taskPath: "task-1",
           sessionType: "claude",
+        },
+        {
+          isClaudeSession: true,
+          claudeSessionId: "s2",
+          label: "Copilot",
+          taskPath: "task-1",
+          sessionType: "copilot",
         },
         {
           isClaudeSession: false,
@@ -64,8 +71,10 @@ describe("SessionPersistence", () => {
       await SessionPersistence.saveToDisk(plugin, sessions);
 
       const saved = plugin.saveData.mock.calls[0][0];
-      expect(saved.persistedSessions).toHaveLength(1);
+      expect(saved.persistedSessions).toHaveLength(2);
       expect(saved.persistedSessions[0].claudeSessionId).toBe("s1");
+      expect(saved.persistedSessions[1].claudeSessionId).toBe("s2");
+      expect(saved.persistedSessions[1].sessionType).toBe("copilot");
     });
 
     it("merges into existing plugin data without clobbering", async () => {

--- a/src/core/session/SessionPersistence.ts
+++ b/src/core/session/SessionPersistence.ts
@@ -1,12 +1,12 @@
 /**
- * Disk persistence for Claude session metadata.
+ * Disk persistence for resumable agent session metadata.
  *
- * Saves/loads session metadata via Obsidian's plugin data API so Claude
- * sessions can be resumed after a full plugin close/restart (not just
+ * Saves/loads session metadata via Obsidian's plugin data API so supported
+ * agent sessions can be resumed after a full plugin close/restart (not just
  * hot-reload). Uses a merge pattern to avoid clobbering other plugin data
  * (settings, taskOrder, etc.) stored in the same data.json file.
  *
- * Sessions older than 7 days are pruned on load (Claude's default retention).
+ * Sessions older than 7 days are pruned on load.
  */
 import type { PersistedSession, SessionType } from "./types";
 
@@ -32,14 +32,7 @@ const SESSION_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 export const PERSIST_INTERVAL_MS = 30_000;
 
 export class SessionPersistence {
-  /**
-   * Save Claude session metadata to disk via Obsidian's plugin data API.
-   * Merges into existing plugin data under "persistedSessions" key.
-   */
-  static async saveToDisk(
-    plugin: DataPlugin,
-    sessions: Map<string, PersistableTab[]>,
-  ): Promise<void> {
+  static buildPersistedSessions(sessions: Map<string, PersistableTab[]>): PersistedSession[] {
     const persisted: PersistedSession[] = [];
     for (const [taskPath, tabs] of sessions) {
       for (const tab of tabs) {
@@ -55,19 +48,37 @@ export class SessionPersistence {
         }
       }
     }
+    return persisted;
+  }
 
+  static setPersistedSessions(
+    data: Record<string, any>,
+    sessions: Map<string, PersistableTab[]>,
+  ): void {
+    data.persistedSessions = this.buildPersistedSessions(sessions);
+  }
+
+  /**
+   * Save resumable session metadata to disk via Obsidian's plugin data API.
+   * Merges into existing plugin data under "persistedSessions" key.
+   */
+  static async saveToDisk(
+    plugin: DataPlugin,
+    sessions: Map<string, PersistableTab[]>,
+  ): Promise<void> {
     const data = (await plugin.loadData()) || {};
-    data.persistedSessions = persisted;
+    this.setPersistedSessions(data, sessions);
     await plugin.saveData(data);
+    const persisted = data.persistedSessions as PersistedSession[];
     // Only log when there are sessions to save (avoid noise from periodic persist)
     if (persisted.length > 0) {
-      console.log("[work-terminal] Saved", persisted.length, "Claude sessions to disk");
+      console.log("[work-terminal] Saved", persisted.length, "resumable sessions to disk");
     }
   }
 
   /**
-   * Load persisted Claude session metadata from disk.
-   * Filters out sessions older than 7 days (Claude's default retention).
+   * Load persisted resumable session metadata from disk.
+   * Filters out sessions older than 7 days.
    */
   static async loadFromDisk(plugin: DataPlugin): Promise<PersistedSession[]> {
     const data = (await plugin.loadData()) || {};

--- a/src/core/session/types.test.ts
+++ b/src/core/session/types.test.ts
@@ -37,7 +37,13 @@ describe("PersistedSession", () => {
   });
 
   it("supports all session types", () => {
-    const types: SessionType[] = ["shell", "claude", "claude-with-context"];
+    const types: SessionType[] = [
+      "shell",
+      "claude",
+      "claude-with-context",
+      "copilot",
+      "copilot-with-context",
+    ];
     for (const sessionType of types) {
       const session: PersistedSession = {
         version: 1,

--- a/src/core/session/types.ts
+++ b/src/core/session/types.ts
@@ -6,7 +6,12 @@ import type { FitAddon } from "@xterm/addon-fit";
 import type { SearchAddon } from "@xterm/addon-search";
 import type { ChildProcess } from "child_process";
 
-export type SessionType = "shell" | "claude" | "claude-with-context";
+export type SessionType =
+  | "shell"
+  | "claude"
+  | "claude-with-context"
+  | "copilot"
+  | "copilot-with-context";
 
 /**
  * State extracted from a TerminalTab that can survive a plugin hot-reload.

--- a/src/core/terminal/TabManager.ts
+++ b/src/core/terminal/TabManager.ts
@@ -305,7 +305,7 @@ export class TabManager {
     return Array.from(this.sessions.keys());
   }
 
-  /** Return the count of shell and Claude tabs for an item. */
+  /** Return the count of shell and agent tabs for an item. */
   getSessionCounts(itemId: string): { shells: number; claudes: number } {
     const tabs = this.sessions.get(itemId) || [];
     let claudes = 0;

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -564,7 +564,7 @@ export class TerminalTab {
   }
 
   private _detectClaudeSession(): boolean {
-    return !!this.claudeSessionId;
+    return this.sessionType !== "shell" && !!this.claudeSessionId;
   }
 
   /** Called on each chunk of output data to track activity. */

--- a/src/framework/CustomSessionConfig.test.ts
+++ b/src/framework/CustomSessionConfig.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  createDefaultCustomSessionConfig,
+  getDefaultSessionLabel,
+  isContextSession,
+  isCopilotSession,
+  sanitizeCustomSessionConfig,
+  supportsExtraArgs,
+} from "./CustomSessionConfig";
+
+describe("CustomSessionConfig", () => {
+  it("creates Claude defaults using the provided cwd", () => {
+    expect(createDefaultCustomSessionConfig("~/work")).toEqual({
+      sessionType: "claude",
+      cwd: "~/work",
+      extraArgs: "",
+      label: "",
+    });
+  });
+
+  it("sanitizes partial saved config", () => {
+    expect(
+      sanitizeCustomSessionConfig(
+        {
+          sessionType: "copilot-with-context",
+          cwd: "  ~/repo  ",
+          extraArgs: "  --model gpt-5.4  ",
+          label: "  Pairing  ",
+        },
+        "~",
+      ),
+    ).toEqual({
+      sessionType: "copilot-with-context",
+      cwd: "~/repo",
+      extraArgs: "--model gpt-5.4",
+      label: "Pairing",
+    });
+  });
+
+  it("falls back to Claude and default cwd for invalid saved config", () => {
+    expect(
+      sanitizeCustomSessionConfig(
+        {
+          sessionType: "not-real" as never,
+          cwd: "   ",
+        },
+        "~/default",
+      ),
+    ).toEqual({
+      sessionType: "claude",
+      cwd: "~/default",
+      extraArgs: "",
+      label: "",
+    });
+  });
+
+  it("provides default labels for built-in session types", () => {
+    expect(getDefaultSessionLabel("shell")).toBe("Shell");
+    expect(getDefaultSessionLabel("claude")).toBe("Claude");
+    expect(getDefaultSessionLabel("claude-with-context")).toBe("Claude (ctx)");
+    expect(getDefaultSessionLabel("copilot")).toBe("Copilot");
+    expect(getDefaultSessionLabel("copilot-with-context")).toBe("Copilot (ctx)");
+  });
+
+  it("identifies context and copilot sessions", () => {
+    expect(isContextSession("claude-with-context")).toBe(true);
+    expect(isContextSession("copilot-with-context")).toBe(true);
+    expect(isContextSession("copilot")).toBe(false);
+    expect(isCopilotSession("copilot")).toBe(true);
+    expect(isCopilotSession("copilot-with-context")).toBe(true);
+    expect(isCopilotSession("claude")).toBe(false);
+  });
+
+  it("only allows extra args for non-shell sessions", () => {
+    expect(supportsExtraArgs("shell")).toBe(false);
+    expect(supportsExtraArgs("claude")).toBe(true);
+    expect(supportsExtraArgs("copilot")).toBe(true);
+  });
+});

--- a/src/framework/CustomSessionConfig.ts
+++ b/src/framework/CustomSessionConfig.ts
@@ -1,0 +1,69 @@
+import type { SessionType } from "../core/session/types";
+
+export interface CustomSessionConfig {
+  sessionType: SessionType;
+  cwd: string;
+  extraArgs: string;
+  label: string;
+}
+
+export const CUSTOM_SESSION_TYPE_OPTIONS: Array<{ value: SessionType; label: string }> = [
+  { value: "shell", label: "Shell" },
+  { value: "claude", label: "Claude" },
+  { value: "claude-with-context", label: "Claude (ctx)" },
+  { value: "copilot", label: "Copilot" },
+  { value: "copilot-with-context", label: "Copilot (ctx)" },
+];
+
+export function createDefaultCustomSessionConfig(defaultCwd: string): CustomSessionConfig {
+  return {
+    sessionType: "claude",
+    cwd: defaultCwd,
+    extraArgs: "",
+    label: "",
+  };
+}
+
+export function sanitizeCustomSessionConfig(
+  value: Partial<CustomSessionConfig> | null | undefined,
+  defaultCwd: string,
+): CustomSessionConfig {
+  const sessionType = isSessionType(value?.sessionType) ? value.sessionType : "claude";
+  return {
+    sessionType,
+    cwd: typeof value?.cwd === "string" && value.cwd.trim() ? value.cwd.trim() : defaultCwd,
+    extraArgs: typeof value?.extraArgs === "string" ? value.extraArgs.trim() : "",
+    label: typeof value?.label === "string" ? value.label.trim() : "",
+  };
+}
+
+export function getDefaultSessionLabel(sessionType: SessionType): string {
+  switch (sessionType) {
+    case "shell":
+      return "Shell";
+    case "claude":
+      return "Claude";
+    case "claude-with-context":
+      return "Claude (ctx)";
+    case "copilot":
+      return "Copilot";
+    case "copilot-with-context":
+      return "Copilot (ctx)";
+  }
+}
+
+export function isContextSession(sessionType: SessionType): boolean {
+  return sessionType === "claude-with-context" || sessionType === "copilot-with-context";
+}
+
+export function isCopilotSession(sessionType: SessionType): boolean {
+  return sessionType === "copilot" || sessionType === "copilot-with-context";
+}
+
+export function supportsExtraArgs(sessionType: SessionType): boolean {
+  return sessionType !== "shell";
+}
+
+function isSessionType(value: unknown): value is SessionType {
+  return CUSTOM_SESSION_TYPE_OPTIONS.some((option) => option.value === value);
+}

--- a/src/framework/CustomSessionModal.ts
+++ b/src/framework/CustomSessionModal.ts
@@ -1,0 +1,114 @@
+import { App, Modal, Setting } from "obsidian";
+import type { CustomSessionConfig } from "./CustomSessionConfig";
+import {
+  CUSTOM_SESSION_TYPE_OPTIONS,
+  getDefaultSessionLabel,
+  supportsExtraArgs,
+} from "./CustomSessionConfig";
+
+export class CustomSessionModal extends Modal {
+  private draft: CustomSessionConfig;
+
+  constructor(
+    app: App,
+    initial: CustomSessionConfig,
+    private onSubmit: (config: CustomSessionConfig) => void,
+  ) {
+    super(app);
+    this.draft = { ...initial };
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.addClass("wt-custom-spawn-modal");
+
+    contentEl.createEl("h3", { text: "Custom session" });
+    contentEl.createEl("p", {
+      text: "Choose a session type and overrides for this task. The last custom settings you use are remembered per task.",
+      cls: "wt-custom-spawn-help",
+    });
+
+    let extraArgsSetting: Setting | null = null;
+
+    const refreshVisibility = () => {
+      if (!extraArgsSetting) return;
+      extraArgsSetting.settingEl.style.display = supportsExtraArgs(this.draft.sessionType)
+        ? ""
+        : "none";
+    };
+
+    new Setting(contentEl)
+      .setName("Session type")
+      .setDesc("What kind of tab to spawn")
+      .addDropdown((dropdown) => {
+        for (const option of CUSTOM_SESSION_TYPE_OPTIONS) {
+          dropdown.addOption(option.value, option.label);
+        }
+        dropdown.setValue(this.draft.sessionType).onChange((value) => {
+          this.draft.sessionType = value as CustomSessionConfig["sessionType"];
+          refreshVisibility();
+        });
+      });
+
+    new Setting(contentEl)
+      .setName("Working directory")
+      .setDesc("Override the terminal working directory for this spawned tab")
+      .addText((text) => {
+        text
+          .setPlaceholder("~")
+          .setValue(this.draft.cwd)
+          .onChange((value) => {
+            this.draft.cwd = value;
+          });
+        text.inputEl.addClass("wt-custom-spawn-input");
+      });
+
+    new Setting(contentEl)
+      .setName("Tab label")
+      .setDesc("Optional tab label override; leave blank to use the default label")
+      .addText((text) => {
+        text
+          .setPlaceholder(getDefaultSessionLabel(this.draft.sessionType))
+          .setValue(this.draft.label)
+          .onChange((value) => {
+            this.draft.label = value;
+          });
+        text.inputEl.addClass("wt-custom-spawn-input");
+      });
+
+    extraArgsSetting = new Setting(contentEl)
+      .setName("Extra arguments")
+      .setDesc("Additional CLI arguments for this tab only (space-separated)")
+      .addTextArea((text) => {
+        text
+          .setPlaceholder("--model gpt-5.4")
+          .setValue(this.draft.extraArgs)
+          .onChange((value) => {
+            this.draft.extraArgs = value;
+          });
+        text.inputEl.addClass("wt-custom-spawn-textarea");
+      });
+    extraArgsSetting.settingEl.addClass("wt-custom-spawn-setting");
+    refreshVisibility();
+
+    const buttons = contentEl.createDiv({ cls: "wt-custom-spawn-buttons" });
+    const cancelBtn = buttons.createEl("button", { text: "Cancel" });
+    cancelBtn.addEventListener("click", () => this.close());
+
+    const spawnBtn = buttons.createEl("button", { text: "Spawn", cls: "mod-cta" });
+    spawnBtn.addEventListener("click", () => {
+      this.onSubmit({
+        sessionType: this.draft.sessionType,
+        cwd: this.draft.cwd,
+        extraArgs: this.draft.extraArgs,
+        label: this.draft.label,
+      });
+      this.close();
+    });
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -2,7 +2,8 @@
  * WorkTerminalSettingsTab - single settings UI combining core framework
  * settings with adapter-provided settings via namespaced keys.
  *
- * Core settings: core.claudeCommand, core.claudeExtraArgs (default args), core.additionalAgentContext (ctx template),
+ * Core settings: core.claudeCommand/core.copilotCommand, their default args,
+ *                core.additionalAgentContext (ctx template),
  *                core.defaultShell, core.defaultTerminalCwd
  * Adapter settings: adapter.* (from adapter.config.settingsSchema)
  */
@@ -15,6 +16,8 @@ import { expandTilde } from "../core/utils";
 interface CoreSettings {
   "core.claudeCommand": string;
   "core.claudeExtraArgs": string;
+  "core.copilotCommand": string;
+  "core.copilotExtraArgs": string;
   "core.additionalAgentContext": string;
   "core.defaultShell": string;
   "core.defaultTerminalCwd": string;
@@ -24,6 +27,8 @@ interface CoreSettings {
 const CORE_DEFAULTS: CoreSettings = {
   "core.claudeCommand": "claude",
   "core.claudeExtraArgs": "",
+  "core.copilotCommand": "copilot",
+  "core.copilotExtraArgs": "",
   "core.additionalAgentContext": "",
   "core.defaultShell": process.env.SHELL || "/bin/zsh",
   "core.defaultTerminalCwd": "~",
@@ -59,11 +64,23 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
       "Default Claude arguments",
       "Arguments passed to every Claude session (space-separated). Applied to both + Claude and + Claude (ctx).",
     );
+    this.addCoreSetting(
+      containerEl,
+      "core.copilotCommand",
+      "Copilot command",
+      "Path or name of the GitHub Copilot CLI binary",
+    );
+    this.addCoreTextArea(
+      containerEl,
+      "core.copilotExtraArgs",
+      "Default Copilot arguments",
+      "Arguments passed to Copilot sessions launched from the custom session spawner.",
+    );
     this.addCoreTextArea(
       containerEl,
       "core.additionalAgentContext",
-      "Claude (ctx) prompt template",
-      "Template for '+ Claude (ctx)' button. Placeholders: $title, $state, $filePath, $id. When empty, the button shows a notice instead of launching.",
+      "Context prompt template",
+      "Template for contextual Claude and Copilot sessions. Placeholders: $title, $state, $filePath, $id. When empty, contextual launches show a notice instead of spawning.",
     );
     this.addCoreSetting(
       containerEl,

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -1,6 +1,7 @@
 /**
- * TerminalPanelView - wraps TabManager with Claude launch buttons,
- * state aggregation, session resume, tab context menu, and inline rename.
+ * TerminalPanelView - wraps TabManager with terminal launch buttons,
+ * custom session spawning, state aggregation, session resume, tab context
+ * menu, and inline rename.
  */
 import { Menu, Notice } from "obsidian";
 
@@ -24,13 +25,21 @@ function createClaudeLogo(size = 14): SVGSVGElement {
 import type { Plugin } from "obsidian";
 import { TabManager } from "../core/terminal/TabManager";
 import type { TerminalTab, ClaudeState } from "../core/terminal/TerminalTab";
-import { resolveCommand, augmentPath, buildClaudeArgs } from "../core/claude/ClaudeLauncher";
+import { resolveCommand, buildClaudeArgs, buildCopilotArgs } from "../core/claude/ClaudeLauncher";
 import { SessionPersistence, PERSIST_INTERVAL_MS } from "../core/session/SessionPersistence";
 import type { PersistedSession, SessionType } from "../core/session/types";
 import { expandTilde } from "../core/utils";
 import { checkHookStatus } from "../core/claude/ClaudeHookManager";
 import type { AdapterBundle, WorkItem, WorkItemPromptBuilder } from "../core/interfaces";
 import { buildClaudeContextPrompt } from "./ClaudeContextPrompt";
+import { CustomSessionModal } from "./CustomSessionModal";
+import {
+  getDefaultSessionLabel,
+  isContextSession,
+  isCopilotSession,
+  sanitizeCustomSessionConfig,
+  type CustomSessionConfig,
+} from "./CustomSessionConfig";
 
 export class TerminalPanelView {
   private tabManager: TabManager;
@@ -61,6 +70,9 @@ export class TerminalPanelView {
 
   // Hook warning banner element
   private hookWarningEl: HTMLElement | null = null;
+
+  // Serialises plugin data writes to avoid clobbering unrelated keys.
+  private pluginDataWrite: Promise<void> = Promise.resolve();
 
   constructor(
     panelEl: HTMLElement,
@@ -247,6 +259,14 @@ export class TerminalPanelView {
     claudeCtxBtn.appendChild(createClaudeLogo());
     claudeCtxBtn.appendText("Claude (ctx)");
     claudeCtxBtn.addEventListener("click", () => void this.spawnClaudeWithContext());
+
+    const customBtn = buttonsContainer.createEl("button", {
+      cls: "wt-spawn-btn wt-spawn-custom",
+      text: "...",
+    });
+    customBtn.setAttribute("aria-label", "Custom session");
+    customBtn.setAttribute("title", "Custom session");
+    customBtn.addEventListener("click", () => void this.openCustomSessionModal());
   }
 
   /** Update Claude state classes on existing tab elements without full re-render. */
@@ -478,106 +498,37 @@ export class TerminalPanelView {
   }
 
   private async spawnClaude(): Promise<void> {
-    const fresh = await this.loadFreshSettings();
-    const claudeCmd = this.getStringSetting(fresh, "core.claudeCommand", "claude");
-    const resolved = resolveCommand(claudeCmd);
-    const sessionId = crypto.randomUUID();
-    const args = buildClaudeArgs(
-      {
-        claudeExtraArgs: this.getStringSetting(fresh, "core.claudeExtraArgs", ""),
-      },
-      sessionId,
-    );
-
-    const cwd = expandTilde(this.getStringSetting(fresh, "core.defaultTerminalCwd", "~"));
-    const tab = this.tabManager.createTab(
-      resolved,
-      cwd,
-      "Claude",
-      "claude",
-      undefined,
-      [resolved, ...args],
-      sessionId,
-    );
-    if (tab && this.adapter.transformSessionLabel) {
-      tab.transformLabel = (old, detected) => this.adapter.transformSessionLabel!(old, detected);
-    }
-    this.renderTabBar();
+    await this.spawnClaudeSession({ sessionType: "claude" });
   }
 
   private async spawnClaudeWithContext(): Promise<void> {
-    const activeItemId = this.tabManager.getActiveItemId();
-    if (!activeItemId) {
-      new Notice("Select a task first to launch Claude with context");
-      return;
-    }
-
-    const item = this.allItems.find((i) => i.id === activeItemId);
-    if (!item) {
-      new Notice("Could not find the selected task");
-      return;
-    }
-
-    const prompt = await this.getClaudeContextPrompt(item);
-    if (!prompt) {
-      new Notice("Set 'Claude (ctx) prompt template' in settings to use Claude (ctx)");
-      return;
-    }
-    const fresh = await this.loadFreshSettings();
-
-    const claudeCmd = this.getStringSetting(fresh, "core.claudeCommand", "claude");
-    const resolved = resolveCommand(claudeCmd);
-    const sessionId = crypto.randomUUID();
-    const extraArgs = this.getStringSetting(fresh, "core.claudeExtraArgs", "");
-    const args = buildClaudeArgs({ claudeExtraArgs: extraArgs }, sessionId, prompt);
-
-    const cwd = expandTilde(this.getStringSetting(fresh, "core.defaultTerminalCwd", "~"));
-    const tab = this.tabManager.createTab(
-      resolved,
-      cwd,
-      "Claude (ctx)",
-      "claude-with-context",
-      undefined,
-      [resolved, ...args],
-      sessionId,
-    );
-    if (tab && this.adapter.transformSessionLabel) {
-      tab.transformLabel = (old, detected) => this.adapter.transformSessionLabel!(old, detected);
-    }
-    this.renderTabBar();
+    await this.spawnClaudeSession({ sessionType: "claude-with-context" });
   }
 
   async spawnClaudeWithPrompt(prompt: string, label?: string): Promise<void> {
-    const fresh = await this.loadFreshSettings();
-    const claudeCmd = this.getStringSetting(fresh, "core.claudeCommand", "claude");
-    const resolved = resolveCommand(claudeCmd);
-    const sessionId = crypto.randomUUID();
-    const extraArgs = this.getStringSetting(fresh, "core.claudeExtraArgs", "");
-    const args = buildClaudeArgs({ claudeExtraArgs: extraArgs }, sessionId, prompt);
-
-    const cwd = expandTilde(this.getStringSetting(fresh, "core.defaultTerminalCwd", "~"));
-    const tab = this.tabManager.createTab(
-      resolved,
-      cwd,
-      label || "Claude (ctx)",
-      "claude-with-context",
-      undefined,
-      [resolved, ...args],
-      sessionId,
-    );
-    if (tab && this.adapter.transformSessionLabel) {
-      tab.transformLabel = (old, detected) => this.adapter.transformSessionLabel!(old, detected);
-    }
-    this.renderTabBar();
+    await this.spawnClaudeSession({
+      sessionType: "claude-with-context",
+      prompt,
+      label: label || "Claude (ctx)",
+    });
   }
 
   resumeSession(persisted: PersistedSession): void {
-    const claudeCmd = this.settings["core.claudeCommand"] || "claude";
-    const resolved = resolveCommand(claudeCmd);
-    const args = ["--resume", persisted.claudeSessionId];
+    const isCopilot =
+      persisted.sessionType === "copilot" || persisted.sessionType === "copilot-with-context";
+    const command = isCopilot
+      ? this.settings["core.copilotCommand"] || "copilot"
+      : this.settings["core.claudeCommand"] || "claude";
+    const resolved = resolveCommand(command);
+    const args = isCopilot
+      ? [`--resume=${persisted.claudeSessionId}`]
+      : ["--resume", persisted.claudeSessionId];
+    const extraArgs = isCopilot
+      ? this.settings["core.copilotExtraArgs"]
+      : this.settings["core.claudeExtraArgs"];
 
-    if (this.settings["core.claudeExtraArgs"]) {
-      args.unshift(...this.settings["core.claudeExtraArgs"].split(/\s+/).filter(Boolean));
+    if (extraArgs) {
+      args.unshift(...String(extraArgs).split(/\s+/).filter(Boolean));
     }
 
     const cwd = expandTilde(this.settings["core.defaultTerminalCwd"] || "~");
@@ -628,7 +579,9 @@ export class TerminalPanelView {
   }
 
   async persistSessions(): Promise<void> {
-    await SessionPersistence.saveToDisk(this.plugin, this.tabManager.getSessions());
+    await this.updatePluginData(async (data) => {
+      SessionPersistence.setPersistedSessions(data, this.tabManager.getSessions());
+    });
   }
 
   // ---------------------------------------------------------------------------
@@ -653,6 +606,198 @@ export class TerminalPanelView {
   async getClaudeContextPrompt(item: WorkItem): Promise<string | null> {
     const fresh = await this.loadFreshSettings();
     return buildClaudeContextPrompt(item, fresh);
+  }
+
+  private async updatePluginData(
+    update: (data: Record<string, any>) => void | Promise<void>,
+  ): Promise<void> {
+    const run = async () => {
+      const data = ((await this.plugin.loadData()) || {}) as Record<string, any>;
+      await update(data);
+      await this.plugin.saveData(data);
+    };
+    const queued = this.pluginDataWrite.then(run, run);
+    this.pluginDataWrite = queued.catch(() => {});
+    return queued;
+  }
+
+  private getActiveItem(): WorkItem | null {
+    const activeItemId = this.tabManager.getActiveItemId();
+    if (!activeItemId) return null;
+    return this.allItems.find((item) => item.id === activeItemId) || null;
+  }
+
+  private mergeExtraArgs(baseArgs: string, extraArgs: string): string {
+    return [baseArgs.trim(), extraArgs.trim()].filter(Boolean).join(" ");
+  }
+
+  private async loadCustomSessionDefaults(
+    itemId: string,
+    freshSettings: Record<string, unknown>,
+  ): Promise<CustomSessionConfig> {
+    const data = (await this.plugin.loadData()) || {};
+    const saved = data.customSessionDefaults?.[itemId];
+    const defaultCwd = this.getStringSetting(freshSettings, "core.defaultTerminalCwd", "~");
+    return sanitizeCustomSessionConfig(saved, defaultCwd);
+  }
+
+  private async saveCustomSessionDefaults(
+    itemId: string,
+    config: CustomSessionConfig,
+  ): Promise<void> {
+    await this.updatePluginData(async (data) => {
+      if (!data.customSessionDefaults) data.customSessionDefaults = {};
+      data.customSessionDefaults[itemId] = config;
+    });
+  }
+
+  private async openCustomSessionModal(): Promise<void> {
+    const item = this.getActiveItem();
+    if (!item) {
+      new Notice(`Select a ${this.adapter.config.itemName} first to launch a custom session`);
+      return;
+    }
+
+    const fresh = await this.loadFreshSettings();
+    const initial = await this.loadCustomSessionDefaults(item.id, fresh);
+    new CustomSessionModal(this.plugin.app, initial, (config) => {
+      void this.spawnCustomSession(item, config);
+    }).open();
+  }
+
+  private async spawnCustomSession(item: WorkItem, rawConfig: CustomSessionConfig): Promise<void> {
+    const fresh = await this.loadFreshSettings();
+    const defaultCwd = this.getStringSetting(fresh, "core.defaultTerminalCwd", "~");
+    const config = sanitizeCustomSessionConfig(rawConfig, defaultCwd);
+    const prompt = isContextSession(config.sessionType)
+      ? await this.getClaudeContextPrompt(item)
+      : undefined;
+
+    if (isContextSession(config.sessionType) && !prompt) {
+      new Notice("Set 'Context prompt template' in settings to use contextual sessions");
+      return;
+    }
+
+    await this.saveCustomSessionDefaults(item.id, config);
+
+    if (config.sessionType === "shell") {
+      const shell = this.getStringSetting(
+        fresh,
+        "core.defaultShell",
+        process.env.SHELL || "/bin/zsh",
+      );
+      this.tabManager.createTab(
+        shell,
+        expandTilde(config.cwd),
+        config.label || getDefaultSessionLabel(config.sessionType),
+        "shell",
+      );
+      this.renderTabBar();
+      return;
+    }
+
+    if (isCopilotSession(config.sessionType)) {
+      await this.spawnCopilotSession({
+        sessionType: config.sessionType,
+        cwd: config.cwd,
+        extraArgs: config.extraArgs,
+        label: config.label || getDefaultSessionLabel(config.sessionType),
+        prompt,
+      });
+      return;
+    }
+
+    await this.spawnClaudeSession({
+      sessionType: config.sessionType as "claude" | "claude-with-context",
+      cwd: config.cwd,
+      extraArgs: config.extraArgs,
+      label: config.label || getDefaultSessionLabel(config.sessionType),
+      prompt,
+    });
+  }
+
+  private async spawnClaudeSession(options: {
+    sessionType: "claude" | "claude-with-context";
+    cwd?: string;
+    extraArgs?: string;
+    label?: string;
+    prompt?: string;
+  }): Promise<void> {
+    let prompt = options.prompt;
+    if (options.sessionType === "claude-with-context" && !prompt) {
+      const item = this.getActiveItem();
+      if (!item) {
+        new Notice(`Select a ${this.adapter.config.itemName} first to launch Claude with context`);
+        return;
+      }
+      prompt = await this.getClaudeContextPrompt(item);
+      if (!prompt) {
+        new Notice("Set 'Context prompt template' in settings to use contextual sessions");
+        return;
+      }
+    }
+
+    const fresh = await this.loadFreshSettings();
+    const claudeCmd = this.getStringSetting(fresh, "core.claudeCommand", "claude");
+    const resolved = resolveCommand(claudeCmd);
+    const sessionId = crypto.randomUUID();
+    const mergedExtraArgs = this.mergeExtraArgs(
+      this.getStringSetting(fresh, "core.claudeExtraArgs", ""),
+      options.extraArgs || "",
+    );
+    const args = buildClaudeArgs({ claudeExtraArgs: mergedExtraArgs }, sessionId, prompt);
+    const cwd = expandTilde(
+      options.cwd || this.getStringSetting(fresh, "core.defaultTerminalCwd", "~"),
+    );
+    const label = options.label || getDefaultSessionLabel(options.sessionType);
+    const tab = this.tabManager.createTab(
+      resolved,
+      cwd,
+      label,
+      options.sessionType,
+      undefined,
+      [resolved, ...args],
+      sessionId,
+    );
+    if (tab && this.adapter.transformSessionLabel) {
+      tab.transformLabel = (old, detected) => this.adapter.transformSessionLabel!(old, detected);
+    }
+    this.renderTabBar();
+  }
+
+  private async spawnCopilotSession(options: {
+    sessionType: "copilot" | "copilot-with-context";
+    cwd?: string;
+    extraArgs?: string;
+    label?: string;
+    prompt?: string;
+  }): Promise<void> {
+    const fresh = await this.loadFreshSettings();
+    const copilotCmd = this.getStringSetting(fresh, "core.copilotCommand", "copilot");
+    const resolved = resolveCommand(copilotCmd);
+    const sessionId = crypto.randomUUID();
+    const mergedExtraArgs = this.mergeExtraArgs(
+      this.getStringSetting(fresh, "core.copilotExtraArgs", ""),
+      options.extraArgs || "",
+    );
+    const args = [
+      `--resume=${sessionId}`,
+      ...buildCopilotArgs({ copilotExtraArgs: mergedExtraArgs }, options.prompt),
+    ];
+    const cwd = expandTilde(
+      options.cwd || this.getStringSetting(fresh, "core.defaultTerminalCwd", "~"),
+    );
+    const label = options.label || getDefaultSessionLabel(options.sessionType);
+    this.tabManager.createTab(
+      resolved,
+      cwd,
+      label,
+      options.sessionType,
+      undefined,
+      [resolved, ...args],
+      sessionId,
+    );
+    this.renderTabBar();
   }
 
   getRecoveredItemId(): string | null {

--- a/styles.css
+++ b/styles.css
@@ -568,6 +568,12 @@
   color: var(--text-normal);
 }
 
+.wt-spawn-custom {
+  min-width: 32px;
+  padding-inline: 10px;
+  font-weight: 600;
+}
+
 .wt-spawn-claude,
 .wt-spawn-claude-ctx {
   display: flex;
@@ -606,6 +612,37 @@ button.wt-spawn-claude-ctx:hover {
 
 button.wt-spawn-claude-ctx:hover svg {
   color: white;
+}
+
+.wt-custom-spawn-modal .setting-item-control {
+  width: 100%;
+}
+
+.wt-custom-spawn-help {
+  color: var(--text-muted);
+  margin-top: 0;
+  margin-bottom: 16px;
+}
+
+.wt-custom-spawn-input,
+.wt-custom-spawn-textarea {
+  width: 100%;
+}
+
+.wt-custom-spawn-textarea {
+  min-height: 72px;
+  resize: vertical;
+}
+
+.wt-custom-spawn-setting .setting-item-control {
+  align-items: stretch;
+}
+
+.wt-custom-spawn-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
 }
 
 /* =============================================================================


### PR DESCRIPTION
## Summary
- add a ... custom session spawner alongside the existing spawn buttons
- remember the last custom spawn options per task and support Shell, Claude, Claude (ctx), Copilot, and Copilot (ctx)
- add configurable Copilot command/args settings and wire Copilot sessions into resumable session persistence

## Testing
- npx vitest run
- npm run build

Closes #33
Closes #35
