### PR TITLE
Verify Copilot session resume

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,4 +100,4 @@ Run `npx vitest run` after changes to verify nothing is broken. Build with `npm 
 - **Resize protocol**: `ESC]777;resize;COLS;ROWS BEL` through stdin; pty-wrapper.py intercepts and applies.
 - **Keyboard capture**: Two layers (bubble + capture phase) intercept keys before Obsidian. Option+Arrow, Shift+Enter, Option+Backspace, macOptionIsMeta.
 - **State detection reads xterm buffer, not stdout**: Immune to status line redraws. Checks last 6 visual lines. Handles narrow terminal wrapping via joined-tail fallback.
-- **Session persistence**: Two tiers - window-global stash for hot-reload (survives module re-evaluation), disk persistence for full restart (7-day retention, UUID-based resume).
+- **Session persistence**: Two tiers - window-global stash for hot-reload (survives module re-evaluation), disk persistence for full restart (7-day retention, UUID-based resume). Copilot restart resume uses native `--resume[=sessionId]`; Claude still needs hooks if users trigger Claude's in-app `/resume` and change session IDs.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Obsidian plugin that turns your vault into a work item board with per-item tabbe
 - **Kanban board** with collapsible sections, drag-drop reordering, and custom sort order
 - **Tabbed terminals** per work item - Shell, Claude, contextual Claude, and custom sessions (including GitHub Copilot CLI)
 - **Agent integration** - Claude/Copilot command resolution, Claude state detection (active/waiting/idle), session rename detection, headless spawning
-- **Session persistence** - hot-reload preserves live terminals; disk persistence enables session resume after restart
+- **Session persistence** - hot-reload preserves live terminals; disk persistence enables session resume after restart. Copilot uses native `--resume[=sessionId]`, while Claude hook setup is only needed if you use Claude's in-app `/resume`.
 - **Detail panel** - native Obsidian MarkdownView via workspace leaf splitting
 
 ## Development

--- a/src/framework/CustomSessionConfig.test.ts
+++ b/src/framework/CustomSessionConfig.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   createDefaultCustomSessionConfig,
   getDefaultSessionLabel,
+  getSessionTypeHelp,
   isContextSession,
   isCopilotSession,
   isStrandsSession,
@@ -63,6 +64,15 @@ describe("CustomSessionConfig", () => {
     expect(getDefaultSessionLabel("copilot-with-context")).toBe("Copilot (ctx)");
     expect(getDefaultSessionLabel("strands")).toBe("Strands");
     expect(getDefaultSessionLabel("strands-with-context")).toBe("Strands (ctx)");
+  });
+
+  it("describes session resume behavior per session type", () => {
+    expect(getSessionTypeHelp("shell")).toContain("not saved for restart resume");
+    expect(getSessionTypeHelp("claude")).toContain("--session-id");
+    expect(getSessionTypeHelp("claude")).toContain("Claude hooks");
+    expect(getSessionTypeHelp("copilot")).toContain("--resume[=sessionId]");
+    expect(getSessionTypeHelp("copilot")).toContain("without Claude hooks");
+    expect(getSessionTypeHelp("strands")).toContain("start fresh each time");
   });
 
   it("identifies context and copilot sessions", () => {

--- a/src/framework/CustomSessionConfig.ts
+++ b/src/framework/CustomSessionConfig.ts
@@ -58,6 +58,22 @@ export function getDefaultSessionLabel(sessionType: SessionType): string {
   }
 }
 
+export function getSessionTypeHelp(sessionType: SessionType): string {
+  switch (sessionType) {
+    case "shell":
+      return "Shell tabs are local terminals only and are not saved for restart resume.";
+    case "claude":
+    case "claude-with-context":
+      return "Claude starts new sessions with --session-id. Restart resume works from the stored session ID, but if you run /resume inside Claude you should install the Claude hooks in settings so Work Terminal can follow the new session ID.";
+    case "copilot":
+    case "copilot-with-context":
+      return "Copilot uses --resume[=sessionId] for both new and resumed sessions. Restart resume works without Claude hooks. If you switch sessions manually inside Copilot, Work Terminal keeps tracking the original session ID.";
+    case "strands":
+    case "strands-with-context":
+      return "Strands sessions start fresh each time. Work Terminal does not persist restart-resume metadata for them.";
+  }
+}
+
 export function isContextSession(sessionType: SessionType): boolean {
   return (
     sessionType === "claude-with-context" ||

--- a/src/framework/CustomSessionModal.ts
+++ b/src/framework/CustomSessionModal.ts
@@ -3,6 +3,7 @@ import type { CustomSessionConfig } from "./CustomSessionConfig";
 import {
   CUSTOM_SESSION_TYPE_OPTIONS,
   getDefaultSessionLabel,
+  getSessionTypeHelp,
   supportsExtraArgs,
 } from "./CustomSessionConfig";
 
@@ -29,6 +30,11 @@ export class CustomSessionModal extends Modal {
       cls: "wt-custom-spawn-help",
     });
 
+    const sessionTypeHelpEl = contentEl.createEl("p", {
+      text: getSessionTypeHelp(this.draft.sessionType),
+      cls: "wt-custom-spawn-help",
+    });
+
     let extraArgsSetting: Setting | null = null;
 
     const refreshVisibility = () => {
@@ -36,6 +42,7 @@ export class CustomSessionModal extends Modal {
       extraArgsSetting.settingEl.style.display = supportsExtraArgs(this.draft.sessionType)
         ? ""
         : "none";
+      sessionTypeHelpEl.textContent = getSessionTypeHelp(this.draft.sessionType);
     };
 
     new Setting(contentEl)

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -84,7 +84,7 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
       containerEl,
       "core.strandsCommand",
       "Strands command",
-      "Path or name of the AWS Strands agent entry-point. The Strands SDK has no universal binary - set this to your project's runner script or wrapper (e.g. ~/my-project/run-agent.sh or uv run python agent.py). Tilde (~) is expanded. Do not include extra arguments here; use \"Default Strands arguments\" below.",
+      'Path or name of the AWS Strands agent entry-point. The Strands SDK has no universal binary - set this to your project\'s runner script or wrapper (e.g. ~/my-project/run-agent.sh or uv run python agent.py). Tilde (~) is expanded. Do not include extra arguments here; use "Default Strands arguments" below.',
     );
     this.addCoreTextArea(
       containerEl,
@@ -112,7 +112,11 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
     );
 
     // Session Resume Tracking section
-    containerEl.createEl("h2", { text: "Session Resume Tracking" });
+    containerEl.createEl("h2", { text: "Claude /resume hooks" });
+    containerEl.createEl("p", {
+      text: "These hooks are only for Claude CLI. Copilot restart resume uses Copilot's native --resume[=sessionId] support and does not require hooks. If you switch sessions manually inside Copilot, Work Terminal keeps tracking the original session ID.",
+      cls: "wt-custom-spawn-help",
+    });
     this.renderHookStatus(containerEl);
 
     // Adapter settings section
@@ -160,7 +164,7 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
       new Setting(containerEl)
         .setName("Install hooks")
         .setDesc(
-          "Install the session-change hook script and add entries to .claude/settings.local.json",
+          "Install the Claude session-change hook script and add entries to .claude/settings.local.json",
         )
         .addButton((btn) =>
           btn
@@ -177,7 +181,7 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
     if (status.scriptExists || status.hooksConfigured) {
       new Setting(containerEl)
         .setName("Remove hooks")
-        .setDesc("Remove hook entries from settings and delete the hook script")
+        .setDesc("Remove Claude hook entries from settings and delete the hook script")
         .addButton((btn) =>
           btn
             .setButtonText("Remove")
@@ -195,7 +199,7 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName("I accept reduced functionality")
       .setDesc(
-        "Check this to dismiss the warning banner without installing hooks. Session tracking after /resume will not work.",
+        "Check this to dismiss the warning banner without installing Claude hooks. Claude session tracking after /resume will not work.",
       )
       .addToggle((toggle) =>
         toggle.setValue(!!acceptValue).onChange(async (newValue) => {

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -168,7 +168,8 @@ export class TerminalPanelView {
           this.panelEl.insertBefore(this.hookWarningEl, this.panelEl.firstChild);
 
           const textEl = this.hookWarningEl.createSpan();
-          textEl.textContent = "Session resume tracking requires Claude hooks.";
+          textEl.textContent =
+            "Claude /resume tracking requires Claude hooks. Copilot restart resume works without them.";
 
           const openBtn = this.hookWarningEl.createEl("button", {
             cls: "wt-hook-warning-btn",
@@ -863,9 +864,7 @@ export class TerminalPanelView {
     prompt?: string;
   }): Promise<void> {
     const fresh = await this.loadFreshSettings();
-    const strandsCmd = expandTilde(
-      this.getStringSetting(fresh, "core.strandsCommand", "strands"),
-    );
+    const strandsCmd = expandTilde(this.getStringSetting(fresh, "core.strandsCommand", "strands"));
     const [cmdToken, ...cmdArgs] = strandsCmd.trim().split(/\s+/);
     const resolved = resolveCommand(cmdToken);
     const mergedExtraArgs = this.mergeExtraArgs(


### PR DESCRIPTION
## Summary
- clarify in the custom session modal and settings that Copilot restart resume uses native `--resume[=sessionId]`
- make the hook warning/banner explicitly Claude-only so Copilot users are not told they need Claude hooks
- document the verified Claude vs Copilot resume differences in the repo docs

## Verification
- npx vitest run
- npm run build
- locally verified GitHub Copilot CLI 1.0.12 supports `--resume[=sessionId]` and keeps the explicit session id stable across separate invocations

Fixes #42