### PR TITLE
Fix terminal scroll button update thrash

### DIFF
--- a/src/core/terminal/ScrollButton.test.ts
+++ b/src/core/terminal/ScrollButton.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { attachScrollButton } from "./ScrollButton";
+
+describe("attachScrollButton", () => {
+  let rafQueue: FrameRequestCallback[] = [];
+
+  beforeEach(() => {
+    rafQueue = [];
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      rafQueue.push(cb);
+      return rafQueue.length;
+    });
+  });
+
+  it("updates visibility from scroll events without subscribing to parsed writes", () => {
+    const containerEl = document.createElement("div");
+    const viewport = document.createElement("div");
+    viewport.className = "xterm-viewport";
+    containerEl.appendChild(viewport);
+
+    const onScroll = vi.fn();
+    const onWriteParsed = vi.fn();
+    const terminal = {
+      buffer: {
+        active: {
+          viewportY: 0,
+          baseY: 5,
+        },
+      },
+      onScroll,
+      onWriteParsed,
+      scrollToBottom: vi.fn(),
+      focus: vi.fn(),
+    };
+
+    attachScrollButton(containerEl, terminal as any);
+    rafQueue.shift()?.(0);
+
+    expect(onScroll).toHaveBeenCalledTimes(1);
+    expect(onWriteParsed).not.toHaveBeenCalled();
+    expect(containerEl.querySelector(".wt-scroll-bottom")).not.toBeNull();
+    expect((containerEl.querySelector(".wt-scroll-bottom") as HTMLButtonElement).style.display).toBe(
+      "flex",
+    );
+
+    terminal.buffer.active.viewportY = 5;
+    const scrollHandler = onScroll.mock.calls[0][0] as () => void;
+    scrollHandler();
+    rafQueue.shift()?.(0);
+
+    expect((containerEl.querySelector(".wt-scroll-bottom") as HTMLButtonElement).style.display).toBe(
+      "none",
+    );
+  });
+
+  it("scrolls to bottom and focuses when clicked", () => {
+    const containerEl = document.createElement("div");
+    const viewport = document.createElement("div");
+    viewport.className = "xterm-viewport";
+    containerEl.appendChild(viewport);
+
+    const terminal = {
+      buffer: {
+        active: {
+          viewportY: 0,
+          baseY: 5,
+        },
+      },
+      onScroll: vi.fn(),
+      onWriteParsed: vi.fn(),
+      scrollToBottom: vi.fn(),
+      focus: vi.fn(),
+    };
+
+    attachScrollButton(containerEl, terminal as any);
+    rafQueue.shift()?.(0);
+    const button = containerEl.querySelector(".wt-scroll-bottom") as HTMLButtonElement;
+
+    button.click();
+    rafQueue.shift()?.(0);
+
+    expect(terminal.scrollToBottom).toHaveBeenCalledTimes(1);
+    expect(terminal.focus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/core/terminal/ScrollButton.ts
+++ b/src/core/terminal/ScrollButton.ts
@@ -17,25 +17,38 @@ export function attachScrollButton(containerEl: HTMLElement, terminal: Terminal)
   scrollBtn.style.display = "none";
   containerEl.appendChild(scrollBtn);
 
+  let visibilityRaf: number | null = null;
+  let lastVisible = false;
+
   const updateVisibility = () => {
+    visibilityRaf = null;
     const buf = terminal.buffer.active;
-    const atBottom = buf.viewportY >= buf.baseY;
-    scrollBtn.style.display = atBottom ? "none" : "flex";
+    const shouldShow = buf.viewportY < buf.baseY;
+    if (shouldShow === lastVisible) return;
+    lastVisible = shouldShow;
+    scrollBtn.style.display = shouldShow ? "flex" : "none";
   };
 
-  terminal.onScroll(updateVisibility);
-  terminal.onWriteParsed(updateVisibility);
+  const scheduleVisibilityUpdate = () => {
+    if (visibilityRaf !== null) return;
+    visibilityRaf = requestAnimationFrame(updateVisibility);
+  };
+
+  terminal.onScroll(scheduleVisibilityUpdate);
 
   // Also listen for native scroll on the viewport element, since xterm's
   // onScroll only fires for programmatic scrolls, not user trackpad/wheel.
   const viewport = containerEl.querySelector(".xterm-viewport");
   if (viewport) {
-    viewport.addEventListener("scroll", updateVisibility, { passive: true });
+    viewport.addEventListener("scroll", scheduleVisibilityUpdate, { passive: true });
   }
 
   scrollBtn.addEventListener("click", (e) => {
     e.stopPropagation();
     terminal.scrollToBottom();
     terminal.focus();
+    scheduleVisibilityUpdate();
   });
+
+  scheduleVisibilityUpdate();
 }


### PR DESCRIPTION
## Summary\n- stop the terminal scroll button from updating on every xterm parsed-write event\n- coalesce visibility updates through requestAnimationFrame and keep native/programmatic scroll handling\n- add a regression test covering the new subscription behavior and button interaction\n\n## Validation\n- npm run lint -- --quiet\n- npm test\n- npm run build\n\nFixes #57