### PR TITLE
Fix #60 hide hook warning for Copilot-only users

### DIFF
--- a/src/framework/CustomSessionConfig.test.ts
+++ b/src/framework/CustomSessionConfig.test.ts
@@ -3,6 +3,7 @@ import {
   createDefaultCustomSessionConfig,
   getDefaultSessionLabel,
   getSessionTypeHelp,
+  isClaudeSession,
   isContextSession,
   isCopilotSession,
   isStrandsSession,
@@ -81,6 +82,9 @@ describe("CustomSessionConfig", () => {
     expect(isContextSession("strands-with-context")).toBe(true);
     expect(isContextSession("copilot")).toBe(false);
     expect(isContextSession("strands")).toBe(false);
+    expect(isClaudeSession("claude")).toBe(true);
+    expect(isClaudeSession("claude-with-context")).toBe(true);
+    expect(isClaudeSession("copilot")).toBe(false);
     expect(isCopilotSession("copilot")).toBe(true);
     expect(isCopilotSession("copilot-with-context")).toBe(true);
     expect(isCopilotSession("claude")).toBe(false);

--- a/src/framework/CustomSessionConfig.ts
+++ b/src/framework/CustomSessionConfig.ts
@@ -86,6 +86,10 @@ export function isCopilotSession(sessionType: SessionType): boolean {
   return sessionType === "copilot" || sessionType === "copilot-with-context";
 }
 
+export function isClaudeSession(sessionType: SessionType): boolean {
+  return sessionType === "claude" || sessionType === "claude-with-context";
+}
+
 export function isStrandsSession(sessionType: SessionType): boolean {
   return sessionType === "strands" || sessionType === "strands-with-context";
 }

--- a/src/framework/TerminalPanelView.test.ts
+++ b/src/framework/TerminalPanelView.test.ts
@@ -1,0 +1,350 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { JSDOM } from "jsdom";
+import type { PersistedSession } from "../core/session/types";
+import { TerminalPanelView } from "./TerminalPanelView";
+
+const mockState = vi.hoisted(() => ({
+  activeSessions: new Map<string, Array<{ sessionType: string }>>(),
+  persistedSessions: [] as PersistedSession[],
+  hookStatus: {
+    scriptExists: false,
+    hooksConfigured: false,
+  },
+  latestTabManager: null as {
+    onSessionChange?: () => void;
+    onClaudeStateChange?: (itemId: string, state: string) => void;
+    onPersistRequest?: () => void;
+  } | null,
+  stopPeriodicPersist: vi.fn(),
+}));
+
+vi.mock("obsidian", () => ({
+  App: class {},
+  Menu: class {
+    addSeparator() {}
+    addItem(callback: (item: { setTitle: () => any; onClick: () => any }) => void) {
+      callback({
+        setTitle() {
+          return this;
+        },
+        onClick() {
+          return this;
+        },
+      });
+    }
+    showAtMouseEvent() {}
+  },
+  Notice: class {
+    constructor(_message: string) {}
+  },
+  Modal: class {
+    app: unknown;
+    contentEl: HTMLElement;
+
+    constructor(app: unknown) {
+      this.app = app;
+      this.contentEl = document.createElement("div");
+    }
+
+    open() {}
+    close() {}
+  },
+  Setting: class {
+    settingEl: HTMLElement;
+
+    constructor(_containerEl: HTMLElement) {
+      this.settingEl = document.createElement("div");
+    }
+
+    setName() {
+      return this;
+    }
+
+    setDesc() {
+      return this;
+    }
+
+    addDropdown() {
+      return this;
+    }
+
+    addText() {
+      return this;
+    }
+
+    addTextArea() {
+      return this;
+    }
+  },
+}));
+
+vi.mock("../core/terminal/TabManager", () => ({
+  TabManager: class {
+    onSessionChange?: () => void;
+    onClaudeStateChange?: (itemId: string, state: string) => void;
+    onPersistRequest?: () => void;
+
+    constructor(_terminalWrapperEl: HTMLElement) {
+      mockState.latestTabManager = this;
+    }
+
+    getSessions() {
+      return mockState.activeSessions as any;
+    }
+
+    getActiveItemId() {
+      return null;
+    }
+
+    getTabs() {
+      return [];
+    }
+
+    getActiveTabIndex() {
+      return 0;
+    }
+
+    setActiveItem(_itemId: string | null) {}
+  },
+}));
+
+vi.mock("../core/session/SessionPersistence", () => ({
+  PERSIST_INTERVAL_MS: 30000,
+  SessionPersistence: {
+    startPeriodicPersist: vi.fn(() => mockState.stopPeriodicPersist),
+    loadFromDisk: vi.fn(async () => mockState.persistedSessions),
+    setPersistedSessions: vi.fn(),
+  },
+}));
+
+vi.mock("../core/claude/ClaudeHookManager", () => ({
+  checkHookStatus: vi.fn(() => mockState.hookStatus),
+}));
+
+type DomGlobals = {
+  window: Window & typeof globalThis;
+  document: Document;
+  HTMLElement: typeof HTMLElement;
+  Element: typeof Element;
+  Node: typeof Node;
+};
+
+function installDomHelpers(globals: DomGlobals) {
+  const { HTMLElement } = globals;
+  const createEl = function (
+    this: HTMLElement,
+    tag: string,
+    options: { cls?: string; text?: string; attr?: Record<string, string> } = {},
+  ) {
+    const el = globals.document.createElement(tag) as HTMLElement;
+    if (options.cls) el.className = options.cls;
+    if (options.text) el.textContent = options.text;
+    if (options.attr) {
+      for (const [key, value] of Object.entries(options.attr)) {
+        el.setAttribute(key, value);
+      }
+    }
+    this.appendChild(el);
+    return el;
+  };
+
+  HTMLElement.prototype.createEl = createEl;
+  HTMLElement.prototype.createDiv = function (
+    options: { cls?: string; text?: string; attr?: Record<string, string> } = {},
+  ) {
+    return createEl.call(this, "div", options);
+  };
+  HTMLElement.prototype.createSpan = function (
+    options: { cls?: string; text?: string; attr?: Record<string, string> } = {},
+  ) {
+    return createEl.call(this, "span", options);
+  };
+  HTMLElement.prototype.addClass = function (...classes: string[]) {
+    this.classList.add(...classes);
+  };
+  HTMLElement.prototype.removeClass = function (...classes: string[]) {
+    this.classList.remove(...classes);
+  };
+  HTMLElement.prototype.empty = function () {
+    this.replaceChildren();
+  };
+  HTMLElement.prototype.appendText = function (text: string) {
+    this.appendChild(globals.document.createTextNode(text));
+  };
+}
+
+function createPlugin(settings: Record<string, unknown> = {}) {
+  const loadData = vi.fn(async () => ({ settings }));
+  return {
+    loadData,
+    saveData: vi.fn(async () => {}),
+    app: {
+      setting: {
+        open: vi.fn(),
+        openTabById: vi.fn(),
+      },
+    },
+    manifest: {
+      id: "work-terminal",
+    },
+  };
+}
+
+function createView(
+  settings: Record<string, unknown> = {},
+  pluginOverrides: Partial<ReturnType<typeof createPlugin>> = {},
+) {
+  const panelEl = document.createElement("div") as HTMLElement & {
+    createDiv: HTMLElement["createDiv"];
+  };
+  const terminalWrapperEl = document.createElement("div") as HTMLElement & {
+    createDiv: HTMLElement["createDiv"];
+  };
+  panelEl.appendChild(terminalWrapperEl);
+  document.body.appendChild(panelEl);
+
+  const plugin = {
+    ...createPlugin(settings),
+    ...pluginOverrides,
+  };
+  const view = new TerminalPanelView(
+    panelEl,
+    terminalWrapperEl,
+    plugin as any,
+    { config: { itemName: "task" } } as any,
+    { "core.defaultTerminalCwd": "~" },
+    {} as any,
+    vi.fn(),
+    vi.fn(),
+  );
+
+  return { panelEl, plugin, view };
+}
+
+async function flushAsync() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function makePersistedSession(sessionType: PersistedSession["sessionType"]): PersistedSession {
+  return {
+    version: 1,
+    taskPath: "Tasks/task-1.md",
+    claudeSessionId: "session-1",
+    label: "Session",
+    sessionType,
+    savedAt: "2026-03-28T20:00:00.000Z",
+  };
+}
+
+describe("TerminalPanelView hook warning", () => {
+  let dom: JSDOM;
+
+  beforeEach(() => {
+    dom = new JSDOM("<!doctype html><html><body></body></html>");
+    vi.stubGlobal("window", dom.window);
+    vi.stubGlobal("document", dom.window.document);
+    vi.stubGlobal("HTMLElement", dom.window.HTMLElement);
+    vi.stubGlobal("Element", dom.window.Element);
+    vi.stubGlobal("Node", dom.window.Node);
+    installDomHelpers({
+      window: dom.window,
+      document: dom.window.document,
+      HTMLElement: dom.window.HTMLElement,
+      Element: dom.window.Element,
+      Node: dom.window.Node,
+    });
+
+    mockState.activeSessions = new Map();
+    mockState.persistedSessions = [];
+    mockState.hookStatus = { scriptExists: false, hooksConfigured: false };
+    mockState.latestTabManager = null;
+    mockState.stopPeriodicPersist.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    dom.window.close();
+  });
+
+  it("hides the warning when only Copilot sessions exist", async () => {
+    mockState.activeSessions.set("task-1", [{ sessionType: "copilot" }]);
+
+    const { panelEl } = createView();
+    await flushAsync();
+
+    expect(panelEl.querySelector(".wt-hook-warning-banner")).toBeNull();
+  });
+
+  it("shows the warning when an active Claude session exists", async () => {
+    mockState.activeSessions.set("task-1", [{ sessionType: "claude" }]);
+
+    const { panelEl } = createView();
+    await flushAsync();
+
+    expect(panelEl.querySelector(".wt-hook-warning-banner")?.textContent).toContain(
+      "Claude /resume tracking requires Claude hooks",
+    );
+  });
+
+  it("shows the warning when persisted Claude resume state exists", async () => {
+    mockState.persistedSessions = [makePersistedSession("claude")];
+
+    const { panelEl } = createView();
+    await flushAsync();
+
+    expect(panelEl.querySelector(".wt-hook-warning-banner")).not.toBeNull();
+  });
+
+  it("hides the warning when persisted sessions are Copilot-only", async () => {
+    mockState.persistedSessions = [makePersistedSession("copilot")];
+
+    const { panelEl } = createView();
+    await flushAsync();
+
+    expect(panelEl.querySelector(".wt-hook-warning-banner")).toBeNull();
+  });
+
+  it("re-checks when session mix changes so Claude usage starts warning immediately", async () => {
+    const { panelEl } = createView();
+    await flushAsync();
+    expect(panelEl.querySelector(".wt-hook-warning-banner")).toBeNull();
+
+    mockState.activeSessions.set("task-1", [{ sessionType: "claude-with-context" }]);
+    mockState.latestTabManager?.onSessionChange?.();
+    await flushAsync();
+
+    expect(panelEl.querySelector(".wt-hook-warning-banner")).not.toBeNull();
+  });
+
+  it("keeps the warning hidden after dismissal even with Claude sessions", async () => {
+    mockState.activeSessions.set("task-1", [{ sessionType: "claude" }]);
+
+    const { panelEl } = createView({ "core.acceptNoResumeHooks": true });
+    await flushAsync();
+
+    expect(panelEl.querySelector(".wt-hook-warning-banner")).toBeNull();
+  });
+
+  it("replays a skipped startup check after persisted Claude sessions finish loading", async () => {
+    mockState.persistedSessions = [makePersistedSession("claude")];
+
+    let resolveLoadData: ((value: { settings: Record<string, unknown> }) => void) | null = null;
+    const loadData = vi.fn(
+      () =>
+        new Promise<{ settings: Record<string, unknown> }>((resolve) => {
+          resolveLoadData = resolve;
+        }),
+    );
+
+    const { panelEl } = createView({}, { loadData });
+    await Promise.resolve();
+
+    expect(panelEl.querySelector(".wt-hook-warning-banner")).toBeNull();
+    resolveLoadData?.({ settings: {} });
+    await flushAsync();
+
+    expect(panelEl.querySelector(".wt-hook-warning-banner")).not.toBeNull();
+  });
+});

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -32,7 +32,7 @@ import {
   buildStrandsArgs,
 } from "../core/claude/ClaudeLauncher";
 import { SessionPersistence, PERSIST_INTERVAL_MS } from "../core/session/SessionPersistence";
-import type { PersistedSession, SessionType } from "../core/session/types";
+import type { PersistedSession } from "../core/session/types";
 import { expandTilde } from "../core/utils";
 import { checkHookStatus } from "../core/claude/ClaudeHookManager";
 import type { AdapterBundle, WorkItem, WorkItemPromptBuilder } from "../core/interfaces";
@@ -40,6 +40,7 @@ import { buildClaudeContextPrompt } from "./ClaudeContextPrompt";
 import { CustomSessionModal } from "./CustomSessionModal";
 import {
   getDefaultSessionLabel,
+  isClaudeSession,
   isContextSession,
   isCopilotSession,
   isStrandsSession,
@@ -82,6 +83,7 @@ export class TerminalPanelView {
 
   // In-flight guard to prevent overlapping async checkHookWarning() calls
   private hookWarningCheckInFlight = false;
+  private hookWarningCheckQueued = false;
 
   // Serialises plugin data writes to avoid clobbering unrelated keys.
   private pluginDataWrite: Promise<void> = Promise.resolve();
@@ -118,6 +120,7 @@ export class TerminalPanelView {
     this.tabManager = new TabManager(terminalWrapperEl);
     this.tabManager.onSessionChange = () => {
       this.renderTabBar();
+      void this.checkHookWarning();
       this.onSessionChange();
     };
     this.tabManager.onClaudeStateChange = (itemId: string, state: ClaudeState) => {
@@ -149,7 +152,10 @@ export class TerminalPanelView {
   // ---------------------------------------------------------------------------
 
   private async checkHookWarning(): Promise<void> {
-    if (this.hookWarningCheckInFlight) return;
+    if (this.hookWarningCheckInFlight) {
+      this.hookWarningCheckQueued = true;
+      return;
+    }
     this.hookWarningCheckInFlight = true;
     try {
       const fresh = ((await this.plugin.loadData()) || {}).settings || {};
@@ -159,8 +165,9 @@ export class TerminalPanelView {
       );
       const status = checkHookStatus(cwd);
       const hooksOk = status.scriptExists && status.hooksConfigured;
+      const hasClaudeUsage = this.hasClaudeHookDependentUsage();
 
-      if (!hooksOk && !accepted) {
+      if (!hooksOk && !accepted && hasClaudeUsage) {
         // Only create the banner on the transition from no-banner -> banner needed
         if (!this.hookWarningEl) {
           this.hookWarningEl = this.panelEl.createDiv({ cls: "wt-hook-warning-banner" });
@@ -209,6 +216,10 @@ export class TerminalPanelView {
       }
     } finally {
       this.hookWarningCheckInFlight = false;
+      if (this.hookWarningCheckQueued) {
+        this.hookWarningCheckQueued = false;
+        void this.checkHookWarning();
+      }
     }
   }
 
@@ -226,6 +237,18 @@ export class TerminalPanelView {
       clearInterval(this.hookWarningPollId);
       this.hookWarningPollId = null;
     }
+  }
+
+  private hasClaudeHookDependentUsage(): boolean {
+    for (const tabs of this.tabManager.getSessions().values()) {
+      for (const tab of tabs) {
+        if (isClaudeSession(tab.sessionType)) {
+          return true;
+        }
+      }
+    }
+
+    return this.persistedSessions.some((session) => isClaudeSession(session.sessionType));
   }
 
   // ---------------------------------------------------------------------------
@@ -625,6 +648,7 @@ export class TerminalPanelView {
 
   private async loadPersistedSessions(): Promise<void> {
     this.persistedSessions = await SessionPersistence.loadFromDisk(this.plugin);
+    await this.checkHookWarning();
   }
 
   async persistSessions(): Promise<void> {


### PR DESCRIPTION
## Summary\n- only show the Claude hook warning when there is active or persisted Claude usage that actually depends on Claude hooks\n- re-check the warning when session mix changes and replay skipped startup checks after persisted sessions load\n- add regression coverage for Copilot-only, Claude, persisted resume, and startup-race cases\n\n## Testing\n- npm run build\n- npm run test\n- npm run lint