### PR TITLE
Fix Copilot active state detection

### DIFF
--- a/src/core/claude/ClaudeStateDetector.test.ts
+++ b/src/core/claude/ClaudeStateDetector.test.ts
@@ -145,6 +145,16 @@ describe("ClaudeStateDetector", () => {
       detector.stop();
     });
 
+    it("does not detect Copilot cancel hint without intent text as active", () => {
+      const terminal = mockTerminal(["  some output", "  \u25ce (Esc to cancel)"]);
+      const detector = new ClaudeStateDetector(terminal, () => false);
+      detector.start();
+
+      vi.advanceTimersByTime(2100);
+      expect(detector.state).toBe("idle");
+      detector.stop();
+    });
+
     it("detects Copilot executing status as active", () => {
       const terminal = mockTerminal(["  some output", "  \u25cb Executing"]);
       const detector = new ClaudeStateDetector(terminal, () => false);
@@ -216,6 +226,16 @@ describe("ClaudeStateDetector", () => {
 
       vi.advanceTimersByTime(2100);
       expect(detector.state).toBe("active");
+      detector.stop();
+    });
+
+    it("does not detect wrapped Copilot cancel hint without intent text as active", () => {
+      const terminal = mockTerminal(["  some output", "  \u25ce", "  (Esc to cancel)"]);
+      const detector = new ClaudeStateDetector(terminal, () => false);
+      detector.start();
+
+      vi.advanceTimersByTime(2100);
+      expect(detector.state).toBe("idle");
       detector.stop();
     });
 

--- a/src/core/claude/ClaudeStateDetector.ts
+++ b/src/core/claude/ClaudeStateDetector.ts
@@ -199,7 +199,7 @@ export function hasAgentActiveIndicator(screenLines: string[]): boolean {
   const tail = screenLines.slice(-6);
   const tailJoined = tail.join(" ");
   const tailCompactJoined = tail.map((line) => line.trim()).join("");
-  const copilotSpinnerRowPattern = /^\s*[\u25c9\u25ce\u25cb\u25cf]\s+\S/;
+  const copilotSpinnerRowPattern = /^\s*[\u25c9\u25ce\u25cb\u25cf]\s+(?!\(Esc\b)\S/;
   const copilotKnownStatusPattern = /\b(?:Thinking|Executing|Cancelling)\b/;
   const copilotCancelHintPattern = /\(Esc\s+to\s+cancel(?:\s+\u00b7\s+[^)]*)?\)/;
   const hasClaudeActiveIndicator =
@@ -216,7 +216,7 @@ export function hasAgentActiveIndicator(screenLines: string[]): boolean {
     tail.some(
       (line) =>
         /^\s*[\u25c9\u25ce\u25cb\u25cf]\s+(?:Thinking|Executing|Cancelling)\b/.test(line) ||
-        (/^\s*[\u25c9\u25ce\u25cb\u25cf]\s+\S/.test(line) && copilotCancelHintPattern.test(line)),
+        (copilotSpinnerRowPattern.test(line) && copilotCancelHintPattern.test(line)),
     ) ||
     (tail.some((line) => copilotSpinnerRowPattern.test(line)) &&
       (copilotKnownStatusPattern.test(tailCompactJoined) ||


### PR DESCRIPTION
## Summary
- broaden Copilot active-state detection beyond the literal `Thinking` label
- treat Copilot spinner rows with arbitrary current-intent text plus the `Esc to cancel` hint as active
- cover `Executing`, `Cancelling`, and wrapped cancel-hint cases in detector tests

## Testing
- npx vitest run
- npm run build

Fixes #63
