### PR TITLE
Fix #55 serialize plugin data writes

### DIFF
--- a/src/core/PluginDataStore.test.ts
+++ b/src/core/PluginDataStore.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { mergeAndSavePluginData } from "./PluginDataStore";
+
+function createMockPlugin(initialData: Record<string, any> = {}) {
+  let data = { ...initialData };
+  return {
+    loadData: vi.fn(async () => ({ ...data })),
+    saveData: vi.fn(async (next: Record<string, any>) => {
+      await Promise.resolve();
+      data = next;
+    }),
+    getData: () => data,
+  };
+}
+
+describe("mergeAndSavePluginData", () => {
+  it("preserves unrelated keys across concurrent writes", async () => {
+    const plugin = createMockPlugin();
+
+    await Promise.all([
+      mergeAndSavePluginData(plugin, async (data) => {
+        await Promise.resolve();
+        data.settings = { "core.defaultShell": "/bin/zsh" };
+      }),
+      mergeAndSavePluginData(plugin, async (data) => {
+        data.customOrder = { todo: ["task-1"] };
+      }),
+      mergeAndSavePluginData(plugin, async (data) => {
+        data.persistedSessions = [{ claudeSessionId: "session-1" }];
+      }),
+    ]);
+
+    expect(plugin.getData()).toEqual({
+      settings: { "core.defaultShell": "/bin/zsh" },
+      customOrder: { todo: ["task-1"] },
+      persistedSessions: [{ claudeSessionId: "session-1" }],
+    });
+  });
+
+  it("continues processing queued writes after a failure", async () => {
+    const plugin = createMockPlugin();
+
+    await expect(
+      mergeAndSavePluginData(plugin, async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    await mergeAndSavePluginData(plugin, async (data) => {
+      data.settings = { foo: "bar" };
+    });
+
+    expect(plugin.getData()).toEqual({
+      settings: { foo: "bar" },
+    });
+  });
+});

--- a/src/core/PluginDataStore.ts
+++ b/src/core/PluginDataStore.ts
@@ -1,0 +1,25 @@
+export interface PluginDataStore {
+  loadData(): Promise<Record<string, any> | null | undefined>;
+  saveData(data: Record<string, any>): Promise<void>;
+}
+
+const writeQueues = new WeakMap<PluginDataStore, Promise<void>>();
+
+export async function mergeAndSavePluginData(
+  plugin: PluginDataStore,
+  update: (data: Record<string, any>) => void | Promise<void>,
+): Promise<void> {
+  const run = async () => {
+    const data = ((await plugin.loadData()) || {}) as Record<string, any>;
+    await update(data);
+    await plugin.saveData(data);
+  };
+
+  const prior = writeQueues.get(plugin) || Promise.resolve();
+  const queued = prior.then(run, run);
+  writeQueues.set(
+    plugin,
+    queued.catch(() => {}),
+  );
+  return queued;
+}

--- a/src/core/session/SessionPersistence.test.ts
+++ b/src/core/session/SessionPersistence.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { SessionPersistence } from "./SessionPersistence";
+import { mergeAndSavePluginData } from "../PluginDataStore";
 
 /** Minimal mock of the DataPlugin interface */
 function createMockPlugin(initialData: Record<string, any> = {}) {
@@ -86,6 +87,37 @@ describe("SessionPersistence", () => {
       const saved = plugin.saveData.mock.calls[0][0];
       expect(saved.settings).toEqual({ foo: "bar" });
       expect(saved.persistedSessions).toEqual([]);
+    });
+
+    it("shares the queued merge path with other plugin data writes", async () => {
+      const plugin = createMockPlugin();
+      const sessions = new Map<string, any[]>();
+      sessions.set("task-1", [
+        {
+          isResumableAgent: true,
+          claudeSessionId: "s1",
+          label: "Claude",
+          taskPath: "task-1",
+          sessionType: "claude",
+        },
+      ]);
+
+      await Promise.all([
+        SessionPersistence.saveToDisk(plugin, sessions),
+        mergeAndSavePluginData(plugin, async (data) => {
+          data.settings = { foo: "bar" };
+        }),
+      ]);
+
+      expect(plugin._getData()).toEqual({
+        settings: { foo: "bar" },
+        persistedSessions: [
+          expect.objectContaining({
+            claudeSessionId: "s1",
+            sessionType: "claude",
+          }),
+        ],
+      });
     });
   });
 

--- a/src/core/session/SessionPersistence.ts
+++ b/src/core/session/SessionPersistence.ts
@@ -9,12 +9,7 @@
  * Sessions older than 7 days are pruned on load.
  */
 import type { PersistedSession, SessionType } from "./types";
-
-/** Plugin-like interface for data persistence (avoids importing Obsidian types). */
-interface DataPlugin {
-  loadData(): Promise<any>;
-  saveData(data: any): Promise<void>;
-}
+import { mergeAndSavePluginData, type PluginDataStore } from "../PluginDataStore";
 
 /** Tab-like interface for extracting persistable data. */
 interface PersistableTab {
@@ -63,14 +58,14 @@ export class SessionPersistence {
    * Merges into existing plugin data under "persistedSessions" key.
    */
   static async saveToDisk(
-    plugin: DataPlugin,
+    plugin: PluginDataStore,
     sessions: Map<string, PersistableTab[]>,
   ): Promise<void> {
-    const data = (await plugin.loadData()) || {};
-    this.setPersistedSessions(data, sessions);
-    await plugin.saveData(data);
-    const persisted = data.persistedSessions as PersistedSession[];
-    // Only log when there are sessions to save (avoid noise from periodic persist)
+    let persisted: PersistedSession[] = [];
+    await mergeAndSavePluginData(plugin, async (data) => {
+      this.setPersistedSessions(data, sessions);
+      persisted = data.persistedSessions as PersistedSession[];
+    });
     if (persisted.length > 0) {
       console.log("[work-terminal] Saved", persisted.length, "resumable sessions to disk");
     }
@@ -80,7 +75,7 @@ export class SessionPersistence {
    * Load persisted resumable session metadata from disk.
    * Filters out sessions older than 7 days.
    */
-  static async loadFromDisk(plugin: DataPlugin): Promise<PersistedSession[]> {
+  static async loadFromDisk(plugin: PluginDataStore): Promise<PersistedSession[]> {
     const data = (await plugin.loadData()) || {};
     const raw: PersistedSession[] = data.persistedSessions || [];
     const cutoff = Date.now() - SESSION_MAX_AGE_MS;
@@ -94,10 +89,10 @@ export class SessionPersistence {
   /**
    * Clear persisted sessions from disk (e.g. after all have been resumed or are stale).
    */
-  static async clearPersistedFromDisk(plugin: DataPlugin): Promise<void> {
-    const data = (await plugin.loadData()) || {};
-    delete data.persistedSessions;
-    await plugin.saveData(data);
+  static async clearPersistedFromDisk(plugin: PluginDataStore): Promise<void> {
+    await mergeAndSavePluginData(plugin, async (data) => {
+      delete data.persistedSessions;
+    });
   }
 
   /**

--- a/src/framework/MainView.ts
+++ b/src/framework/MainView.ts
@@ -19,6 +19,7 @@ import { TerminalPanelView } from "./TerminalPanelView";
 import { PromptBox } from "./PromptBox";
 import { loadAllSettings } from "./SettingsTab";
 import { SessionStore } from "../core/session/SessionStore";
+import { mergeAndSavePluginData } from "../core/PluginDataStore";
 
 interface PendingRename {
   uuid: string | null;
@@ -331,9 +332,9 @@ export class MainView extends ItemView {
       },
       // onCustomOrderChange callback
       async (order: Record<string, string[]>) => {
-        const data = (await this.pluginRef.loadData()) || {};
-        data.customOrder = order;
-        await this.pluginRef.saveData(data);
+        await mergeAndSavePluginData(this.pluginRef, async (data) => {
+          data.customOrder = order;
+        });
       },
     );
   }

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -11,6 +11,7 @@ import { App, PluginSettingTab, Setting } from "obsidian";
 import type { Plugin } from "obsidian";
 import type { AdapterBundle, SettingField } from "../core/interfaces";
 import { checkHookStatus, installHooks, removeHooks } from "../core/claude/ClaudeHookManager";
+import { mergeAndSavePluginData } from "../core/PluginDataStore";
 import { expandTilde } from "../core/utils";
 
 interface CoreSettings {
@@ -130,10 +131,10 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
   }
 
   private async saveSettings(update: (settings: Record<string, unknown>) => void): Promise<void> {
-    const data = (await this.plugin.loadData()) || {};
-    if (!data.settings) data.settings = {};
-    update(data.settings);
-    await this.plugin.saveData(data);
+    await mergeAndSavePluginData(this.plugin, async (data) => {
+      if (!data.settings) data.settings = {};
+      update(data.settings);
+    });
   }
 
   private async renderHookStatus(containerEl: HTMLElement): Promise<void> {

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -36,6 +36,7 @@ import type { PersistedSession } from "../core/session/types";
 import { expandTilde } from "../core/utils";
 import { checkHookStatus } from "../core/claude/ClaudeHookManager";
 import type { AdapterBundle, WorkItem, WorkItemPromptBuilder } from "../core/interfaces";
+import { mergeAndSavePluginData } from "../core/PluginDataStore";
 import { buildClaudeContextPrompt } from "./ClaudeContextPrompt";
 import { CustomSessionModal } from "./CustomSessionModal";
 import {
@@ -84,9 +85,6 @@ export class TerminalPanelView {
   // In-flight guard to prevent overlapping async checkHookWarning() calls
   private hookWarningCheckInFlight = false;
   private hookWarningCheckQueued = false;
-
-  // Serialises plugin data writes to avoid clobbering unrelated keys.
-  private pluginDataWrite: Promise<void> = Promise.resolve();
 
   constructor(
     panelEl: HTMLElement,
@@ -192,10 +190,10 @@ export class TerminalPanelView {
             text: "Dismiss",
           });
           dismissBtn.addEventListener("click", async () => {
-            const d = (await this.plugin.loadData()) || {};
-            if (!d.settings) d.settings = {};
-            d.settings["core.acceptNoResumeHooks"] = true;
-            await this.plugin.saveData(d);
+            await mergeAndSavePluginData(this.plugin, async (data) => {
+              if (!data.settings) data.settings = {};
+              data.settings["core.acceptNoResumeHooks"] = true;
+            });
             this.hookWarningEl?.remove();
             this.hookWarningEl = null;
             this.stopHookWarningPoller();
@@ -652,7 +650,7 @@ export class TerminalPanelView {
   }
 
   async persistSessions(): Promise<void> {
-    await this.updatePluginData(async (data) => {
+    await mergeAndSavePluginData(this.plugin, async (data) => {
       SessionPersistence.setPersistedSessions(data, this.tabManager.getSessions());
     });
   }
@@ -681,19 +679,6 @@ export class TerminalPanelView {
     return buildClaudeContextPrompt(item, fresh);
   }
 
-  private async updatePluginData(
-    update: (data: Record<string, any>) => void | Promise<void>,
-  ): Promise<void> {
-    const run = async () => {
-      const data = ((await this.plugin.loadData()) || {}) as Record<string, any>;
-      await update(data);
-      await this.plugin.saveData(data);
-    };
-    const queued = this.pluginDataWrite.then(run, run);
-    this.pluginDataWrite = queued.catch(() => {});
-    return queued;
-  }
-
   private getActiveItem(): WorkItem | null {
     const activeItemId = this.tabManager.getActiveItemId();
     if (!activeItemId) return null;
@@ -718,7 +703,7 @@ export class TerminalPanelView {
     itemId: string,
     config: CustomSessionConfig,
   ): Promise<void> {
-    await this.updatePluginData(async (data) => {
+    await mergeAndSavePluginData(this.plugin, async (data) => {
       if (!data.customSessionDefaults) data.customSessionDefaults = {};
       data.customSessionDefaults[itemId] = config;
     });


### PR DESCRIPTION
## Summary
- add a shared queued merge-and-save helper for plugin data writes
- route settings, custom order, persisted sessions, and custom session defaults through it
- add regression tests covering concurrent writes preserving unrelated keys

Closes #55