### PR TITLE
Fix restart tab teardown double-dispose

### DIFF
--- a/src/core/terminal/TerminalTab.test.ts
+++ b/src/core/terminal/TerminalTab.test.ts
@@ -252,6 +252,37 @@ describe("TerminalTab hot-reload addon handling", () => {
       "container",
     ]);
   });
+
+  it("skips the addon manager fallback when tracked addon refs are available", () => {
+    const fitDispose = vi.fn();
+    const addonManagerDispose = vi.fn();
+    const terminalDispose = vi.fn();
+    const tab = Object.assign(Object.create(TerminalTab.prototype), {
+      _sessionTracker: { dispose: vi.fn() },
+      _stateTimer: null,
+      _resizeDebounce: null,
+      _documentCleanups: [],
+      resizeObserver: { disconnect: vi.fn() },
+      process: null,
+      fitAddon: { dispose: fitDispose },
+      searchAddon: undefined,
+      webLinksAddon: undefined,
+      unicode11Addon: undefined,
+      webglAddon: null,
+      webglContextLossListener: null,
+      terminal: {
+        _addonManager: { dispose: addonManagerDispose },
+        dispose: terminalDispose,
+      },
+      containerEl: { remove: vi.fn() },
+    }) as TerminalTab;
+
+    tab.dispose();
+
+    expect(fitDispose).toHaveBeenCalledTimes(1);
+    expect(addonManagerDispose).not.toHaveBeenCalled();
+    expect(terminalDispose).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("TerminalTab WebGL recovery", () => {

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -917,6 +917,13 @@ export class TerminalTab {
     // Dispose addons before terminal.dispose() so they can clean up while
     // xterm's internal services (renderer, buffer) are still alive.
     // Disposing in reverse load order mirrors standard teardown conventions.
+    const hasTrackedAddons = Boolean(
+      this.fitAddon ||
+      this.searchAddon ||
+      this.webLinksAddon ||
+      this.unicode11Addon ||
+      this.webglAddon,
+    );
     this.disposeWebglContextLossListener();
     this.webglAddon?.dispose();
     this.webglAddon = null;
@@ -933,6 +940,8 @@ export class TerminalTab {
     // the anonymous addons above. Drain xterm's addon manager here as a
     // compatibility fallback so restored tabs still dispose addons before the
     // terminal tears down its internals.
-    (this.terminal as TerminalWithAddonManager)._addonManager?.dispose();
+    if (!hasTrackedAddons) {
+      (this.terminal as TerminalWithAddonManager)._addonManager?.dispose();
+    }
   }
 }


### PR DESCRIPTION
## Summary\n- only drain xterm's internal addon manager when a restored tab has no tracked addon refs\n- keep explicit tracked-addon teardown for live and newer restored tabs so restart disposal does not re-dispose addons\n- add a regression test covering the tracked-addon path\n\n## Validation\n- npx vitest run src/core/terminal/TerminalTab.test.ts\n- npx vitest run\n- npm run build\n- npm run lint\n\nFixes #73