### PR TITLE
Fix xterm link-provider disposal on tab restart

### DIFF
--- a/src/core/session/types.ts
+++ b/src/core/session/types.ts
@@ -35,6 +35,7 @@ export interface StoredSession {
   fitAddon: FitAddon;
   searchAddon: SearchAddon;
   webLinksAddon?: WebLinksAddon;
+  linkProviderDisposable?: IDisposable | null;
   unicode11Addon?: Unicode11Addon;
   webglAddon?: WebglAddon | null;
   webglContextLossListener?: IDisposable | null;

--- a/src/core/terminal/TerminalTab.test.ts
+++ b/src/core/terminal/TerminalTab.test.ts
@@ -138,6 +138,7 @@ describe("TerminalTab hot-reload addon handling", () => {
     const fitAddon = { dispose: vi.fn(), fit: vi.fn() };
     const searchAddon = { dispose: vi.fn() };
     const webLinksAddon = { dispose: vi.fn() };
+    const linkProviderDisposable = { dispose: vi.fn() };
     const unicode11Addon = { dispose: vi.fn() };
     const webglAddon = { dispose: vi.fn() };
     const resizeObserver = { disconnect: vi.fn(), observe: vi.fn() };
@@ -152,6 +153,7 @@ describe("TerminalTab hot-reload addon handling", () => {
       fitAddon,
       searchAddon,
       webLinksAddon,
+      linkProviderDisposable,
       unicode11Addon,
       webglAddon,
       containerEl: {},
@@ -167,6 +169,7 @@ describe("TerminalTab hot-reload addon handling", () => {
     expect(stored.fitAddon).toBe(fitAddon);
     expect(stored.searchAddon).toBe(searchAddon);
     expect(stored.webLinksAddon).toBe(webLinksAddon);
+    expect(stored.linkProviderDisposable).toBe(linkProviderDisposable);
     expect(stored.unicode11Addon).toBe(unicode11Addon);
     expect(stored.webglAddon).toBe(webglAddon);
   });
@@ -178,6 +181,7 @@ describe("TerminalTab hot-reload addon handling", () => {
     const fitAddon = { dispose: vi.fn(), fit: vi.fn() };
     const searchAddon = { dispose: vi.fn() };
     const webLinksAddon = { dispose: vi.fn() };
+    const linkProviderDisposable = { dispose: vi.fn() };
     const unicode11Addon = { dispose: vi.fn() };
     const webglAddon = { dispose: vi.fn(), onContextLoss: vi.fn(() => ({ dispose: vi.fn() })) };
     const resizeObserver = { disconnect: vi.fn(), observe: vi.fn() };
@@ -199,6 +203,7 @@ describe("TerminalTab hot-reload addon handling", () => {
         fitAddon: fitAddon as any,
         searchAddon: searchAddon as any,
         webLinksAddon: webLinksAddon as any,
+        linkProviderDisposable: linkProviderDisposable as any,
         unicode11Addon: unicode11Addon as any,
         webglAddon: webglAddon as any,
         webglContextLossListener: null,
@@ -213,10 +218,72 @@ describe("TerminalTab hot-reload addon handling", () => {
     expect((restored as any).fitAddon).toBe(fitAddon);
     expect((restored as any).searchAddon).toBe(searchAddon);
     expect((restored as any).webLinksAddon).toBe(webLinksAddon);
+    expect((restored as any).linkProviderDisposable).toBe(linkProviderDisposable);
     expect((restored as any).unicode11Addon).toBe(unicode11Addon);
     expect((restored as any).webglAddon).toBe(webglAddon);
     expect(parentEl.appendChild).toHaveBeenCalledWith(containerEl);
     expect(scrollToBottom).toHaveBeenCalled();
+  });
+
+  it("disposes the custom link provider before terminal teardown", () => {
+    const order: string[] = [];
+    const tab = Object.assign(Object.create(TerminalTab.prototype), {
+      _sessionTracker: { dispose: vi.fn(() => order.push("tracker")) },
+      _stateTimer: null,
+      _resizeDebounce: null,
+      _spawnTimeout: null,
+      _documentCleanups: [],
+      resizeObserver: { disconnect: vi.fn(() => order.push("resize-observer")) },
+      process: null,
+      fitAddon: undefined,
+      searchAddon: undefined,
+      webLinksAddon: undefined,
+      linkProviderDisposable: { dispose: vi.fn(() => order.push("link-provider")) },
+      unicode11Addon: undefined,
+      webglAddon: null,
+      webglContextLossListener: null,
+      terminal: {
+        _addonManager: { dispose: vi.fn(() => order.push("addon-manager")) },
+        dispose: vi.fn(() => order.push("terminal")),
+      },
+      containerEl: { remove: vi.fn(() => order.push("container")) },
+    }) as TerminalTab;
+
+    tab.dispose();
+
+    expect(order).toEqual(["tracker", "resize-observer", "link-provider", "terminal", "container"]);
+  });
+
+  it("clears legacy link providers for restored sessions created before tracking them", () => {
+    const linkProviders = [{ id: "custom-provider" }];
+    const terminalDispose = vi.fn();
+    const tab = Object.assign(Object.create(TerminalTab.prototype), {
+      _sessionTracker: { dispose: vi.fn() },
+      _stateTimer: null,
+      _resizeDebounce: null,
+      _spawnTimeout: null,
+      _documentCleanups: [],
+      resizeObserver: { disconnect: vi.fn() },
+      process: null,
+      fitAddon: { dispose: vi.fn() },
+      searchAddon: undefined,
+      webLinksAddon: undefined,
+      linkProviderDisposable: null,
+      unicode11Addon: undefined,
+      webglAddon: null,
+      webglContextLossListener: null,
+      terminal: {
+        _linkProviderService: { linkProviders },
+        _addonManager: { dispose: vi.fn() },
+        dispose: terminalDispose,
+      },
+      containerEl: { remove: vi.fn() },
+    }) as TerminalTab;
+
+    tab.dispose();
+
+    expect(linkProviders).toEqual([]);
+    expect(terminalDispose).toHaveBeenCalledTimes(1);
   });
 
   it("drains xterm's addon manager before terminal disposal for older restored tabs", () => {

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -28,6 +28,9 @@ type TerminalWithAddonManager = Terminal & {
   _addonManager?: {
     dispose(): void;
   };
+  _linkProviderService?: {
+    linkProviders: unknown[];
+  };
 };
 
 export class TerminalTab {
@@ -49,6 +52,7 @@ export class TerminalTab {
   private fitAddon: FitAddon | undefined;
   private searchAddon: SearchAddon | undefined;
   private webLinksAddon: WebLinksAddon | undefined;
+  private linkProviderDisposable: IDisposable | null = null;
   private unicode11Addon: Unicode11Addon | undefined;
   private webglAddon: WebglAddon | null = null;
   private webglContextLossListener: IDisposable | null = null;
@@ -56,6 +60,8 @@ export class TerminalTab {
   private _documentCleanups: (() => void)[] = [];
   private _searchBarEl: HTMLElement | null = null;
   private _resizeDebounce: ReturnType<typeof setTimeout> | null = null;
+  private _spawnTimeout: ReturnType<typeof setTimeout> | null = null;
+  private _isDisposed = false;
 
   // Minimum container width for fitAddon.fit(). When the plugin view is
   // momentarily narrow (e.g. switching between plugins), skip the fit so the
@@ -173,6 +179,7 @@ export class TerminalTab {
 
     // Ensure clicking the terminal area gives xterm focus
     this.containerEl.addEventListener("click", () => {
+      if (this._isDisposed) return;
       this.terminal.focus();
     });
 
@@ -203,10 +210,15 @@ export class TerminalTab {
     };
 
     // Delay spawn to let CSS layout happen first
-    setTimeout(spawnWithFit, 150);
+    this._spawnTimeout = setTimeout(() => {
+      this._spawnTimeout = null;
+      if (this._isDisposed) return;
+      spawnWithFit();
+    }, 150);
 
     // Send resize control sequence to PTY wrapper on terminal resize
     this.terminal.onResize(({ cols, rows }) => {
+      if (this._isDisposed) return;
       if (this.process?.stdin && !this.process.stdin.destroyed) {
         // Custom OSC sequence that pty-wrapper.py intercepts
         const resizeCmd = `\x1b]777;resize;${cols};${rows}\x07`;
@@ -217,9 +229,11 @@ export class TerminalTab {
     // Resize observer - debounced to avoid fitting during tab transition
     // animations where the container has intermediate (narrow) widths.
     this.resizeObserver = new ResizeObserver(() => {
+      if (this._isDisposed) return;
       if (this.containerEl.hasClass("hidden")) return;
       if (this._resizeDebounce) clearTimeout(this._resizeDebounce);
       this._resizeDebounce = setTimeout(() => {
+        if (this._isDisposed) return;
         if (this.containerEl.hasClass("hidden")) return;
         const prevCols = this.terminal.cols;
         this.safeFit();
@@ -271,6 +285,7 @@ export class TerminalTab {
 
   private wireProcess(proc: ChildProcess): void {
     this.terminal.onData((data) => {
+      if (this._isDisposed) return;
       this._sessionTracker?.feedInput(data);
       if (proc.stdin && !proc.stdin.destroyed) {
         proc.stdin.write(data);
@@ -278,6 +293,7 @@ export class TerminalTab {
     });
 
     proc.stdout?.on("data", (data: Buffer) => {
+      if (this._isDisposed) return;
       this._checkRename(data);
       this._trackOutput(data);
       this.onOutputData?.(data);
@@ -285,6 +301,7 @@ export class TerminalTab {
     });
 
     proc.stderr?.on("data", (data: Buffer) => {
+      if (this._isDisposed) return;
       this._checkRename(data);
       this._trackOutput(data);
       this.onOutputData?.(data);
@@ -292,11 +309,13 @@ export class TerminalTab {
     });
 
     proc.on("error", (err) => {
+      if (this._isDisposed) return;
       console.error("[work-terminal] Process error:", err);
       this.terminal.write(`\r\n[Process error: ${err.message}]\r\n`);
     });
 
     proc.on("exit", (code, signal) => {
+      if (this._isDisposed) return;
       this.terminal.write(`\r\n[Process exited (code: ${code}, signal: ${signal})]\r\n`);
       this.onProcessExit?.(code, signal);
     });
@@ -311,6 +330,7 @@ export class TerminalTab {
    *  good dimensions and content doesn't reflow. */
   private safeFit(): void {
     try {
+      if (this._isDisposed) return;
       const width = this.containerEl.clientWidth;
       if (width < TerminalTab.MIN_FIT_WIDTH) return;
       this.fitAddon?.fit();
@@ -332,8 +352,12 @@ export class TerminalTab {
     // Match paths with optional line:col - e.g. src/main.ts, ./foo/bar.js:42, /abs/path.ts:10:5
     const pathRegex = /(?:\.\/|\.\.\/|\/|[a-zA-Z][\w.-]*\/)[^\s:,;'")\]}>]+?(?::\d+(?::\d+)?)?/g;
 
-    this.terminal.registerLinkProvider({
+    this.linkProviderDisposable = this.terminal.registerLinkProvider({
       provideLinks: (lineNumber: number, callback: (links: any[] | undefined) => void) => {
+        if (this._isDisposed) {
+          callback(undefined);
+          return;
+        }
         const line = this.terminal.buffer.active.getLine(lineNumber - 1)?.translateToString() || "";
         const links: any[] = [];
         let match: RegExpExecArray | null;
@@ -767,6 +791,7 @@ export class TerminalTab {
       fitAddon: this.fitAddon!,
       searchAddon: this.searchAddon!,
       webLinksAddon: this.webLinksAddon,
+      linkProviderDisposable: this.linkProviderDisposable,
       unicode11Addon: this.unicode11Addon,
       webglAddon: this.webglAddon,
       webglContextLossListener: this.webglContextLossListener,
@@ -800,6 +825,7 @@ export class TerminalTab {
     tab.fitAddon = stored.fitAddon;
     tab.searchAddon = stored.searchAddon;
     tab.webLinksAddon = stored.webLinksAddon;
+    tab.linkProviderDisposable = stored.linkProviderDisposable ?? null;
     tab.unicode11Addon = stored.unicode11Addon;
     tab.containerEl = stored.containerEl;
     tab.process = stored.process;
@@ -817,6 +843,7 @@ export class TerminalTab {
     tab._recentCleanLines = [];
     tab._stateTimer = null;
     tab._isResumableAgent = false;
+    tab._isDisposed = false;
     tab._sessionTracker = null;
     tab._renameDecoder = new StringDecoder("utf8");
     tab._renameLineBuffer = "";
@@ -847,9 +874,11 @@ export class TerminalTab {
     stored.resizeObserver.disconnect();
     tab._resizeDebounce = null;
     tab.resizeObserver = new ResizeObserver(() => {
+      if (tab._isDisposed) return;
       if (stored.containerEl.hasClass("hidden")) return;
       if (tab._resizeDebounce) clearTimeout(tab._resizeDebounce);
       tab._resizeDebounce = setTimeout(() => {
+        if (tab._isDisposed) return;
         if (stored.containerEl.hasClass("hidden")) return;
         const prevCols = tab.terminal.cols;
         tab.safeFit();
@@ -869,6 +898,7 @@ export class TerminalTab {
     // Scroll to bottom after recovery - terminal buffer is preserved but
     // viewport resets to top during the DOM re-attach.
     requestAnimationFrame(() => {
+      if (tab._isDisposed) return;
       stored.terminal.scrollToBottom();
     });
 
@@ -880,6 +910,8 @@ export class TerminalTab {
   // ---------------------------------------------------------------------------
 
   dispose(): void {
+    if (this._isDisposed) return;
+    this._isDisposed = true;
     // Stop session tracker
     this._sessionTracker?.dispose();
     this._sessionTracker = null;
@@ -891,6 +923,10 @@ export class TerminalTab {
     if (this._resizeDebounce) {
       clearTimeout(this._resizeDebounce);
       this._resizeDebounce = null;
+    }
+    if (this._spawnTimeout) {
+      clearTimeout(this._spawnTimeout);
+      this._spawnTimeout = null;
     }
     // Remove document-level keyboard listeners
     for (const cleanup of this._documentCleanups) {
@@ -921,9 +957,20 @@ export class TerminalTab {
       this.fitAddon ||
       this.searchAddon ||
       this.webLinksAddon ||
+      this.linkProviderDisposable ||
       this.unicode11Addon ||
       this.webglAddon,
     );
+    if (this.linkProviderDisposable) {
+      this.linkProviderDisposable.dispose();
+      this.linkProviderDisposable = null;
+    } else {
+      // Hot-reload sessions stashed before the link-provider disposable was
+      // tracked still carry the custom provider inside xterm's private
+      // service registry. Clear that registry before terminal.dispose() so the
+      // provider cannot outlive the buffer teardown sequence.
+      (this.terminal as TerminalWithAddonManager)._linkProviderService?.linkProviders.splice(0);
+    }
     this.disposeWebglContextLossListener();
     this.webglAddon?.dispose();
     this.webglAddon = null;


### PR DESCRIPTION
## Summary
- track the custom xterm link-provider registration as part of TerminalTab lifecycle
- dispose legacy and current link-provider registrations before terminal teardown
- preserve the registration across hot-reload stash/restore and add regression coverage

## Validation
- npm run build
- npx vitest run

Closes #77