### PR TITLE
Fix blank tab after WebGL context loss

### DIFF
--- a/src/core/terminal/TerminalTab.test.ts
+++ b/src/core/terminal/TerminalTab.test.ts
@@ -414,7 +414,9 @@ describe("TerminalTab WebGL recovery", () => {
       terminal: {
         focus: vi.fn(),
         scrollToBottom: vi.fn(),
+        refresh: vi.fn(),
         cols: 80,
+        rows: 24,
       },
       fitAddon: {},
       searchAddon: {},
@@ -471,7 +473,9 @@ describe("TerminalTab WebGL recovery", () => {
       terminal: {
         focus: vi.fn(),
         scrollToBottom: vi.fn(),
+        refresh: vi.fn(),
         cols: 80,
+        rows: 24,
       },
       fitAddon: {},
       searchAddon: {},

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -260,6 +260,13 @@ export class TerminalTab {
       console.warn("[work-terminal] WebGL context lost, falling back to canvas renderer");
       addon.dispose();
       this.webglAddon = null;
+      // After disposing the WebGL addon, xterm falls back to its canvas
+      // renderer. Force a refresh so the canvas renderer paints the buffer
+      // content immediately, preventing a blank terminal.
+      requestAnimationFrame(() => {
+        if (this._isDisposed) return;
+        this.terminal.refresh(0, this.terminal.rows - 1);
+      });
     });
   }
 
@@ -585,6 +592,11 @@ export class TerminalTab {
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         this.safeFit();
+        // Force a full re-render of all rows. If the renderer changed while
+        // the tab was hidden (e.g. WebGL context loss fell back to canvas),
+        // xterm may not have painted anything. Refreshing ensures the canvas
+        // renderer draws the buffer content.
+        this.terminal.refresh(0, this.terminal.rows - 1);
         this.terminal.scrollToBottom();
         this.terminal.focus();
       });


### PR DESCRIPTION
## Summary

- Force `terminal.refresh()` after WebGL context loss so xterm's canvas fallback renderer paints the buffer content, preventing blank terminals
- Also refresh on `show()` to handle the case where context loss happened while the tab was hidden

Fixes #79

## Root cause

PR #47 added WebGL context loss handling that correctly disposes the WebGL addon so xterm falls back to canvas rendering. However, if context loss occurs on a hidden (background) tab, the canvas renderer has no visible surface to paint on. When the tab is later made visible, `safeFit()` recalculates dimensions but does not trigger a full re-render, leaving the terminal area blank despite the session still running underneath.

## Test plan

- [x] All 211 tests pass
- [x] Build succeeds
- [ ] Open multiple agent tabs, switch between them, leave some idle long enough for WebGL context reclamation - verify no blank tabs
- [ ] Restart a tab while another is active, switch back - verify content is visible