### PR TITLE
Fix context prompt lost through shell quoting

### DIFF
--- a/pty-wrapper.py
+++ b/pty-wrapper.py
@@ -48,13 +48,13 @@ def main():
             pass
 
         # If the command is already a shell, exec directly (e.g. /bin/zsh -i).
-        # Otherwise, wrap in a login shell so the full user environment (PATH,
-        # env vars from .zprofile/.zshrc) is available. This is needed because
-        # Electron's process.env.PATH is minimal and commands like `claude`
-        # live in profile-sourced dirs like ~/.local/bin.
+        # If the command is an absolute path, exec directly to avoid shell
+        # quoting issues with arguments (e.g. multi-line context prompts).
+        # The caller (ClaudeLauncher.ts) resolves commands to absolute paths.
+        # Otherwise, wrap in a login shell for the full user environment.
         shells = {"/bin/zsh", "/bin/bash", "/bin/sh", "/usr/bin/zsh", "/usr/bin/bash",
                   "zsh", "bash", "sh"}
-        if args[0] in shells:
+        if args[0] in shells or args[0].startswith("/"):
             os.execvp(args[0], args)
         else:
             shell = os.environ.get("SHELL", "/bin/zsh")


### PR DESCRIPTION
## Summary
- When launching a Claude (ctx) session, the context prompt was passed as a positional CLI argument through pty-wrapper.py's `zsh -l -i -c` shell wrapping with `shlex.quote()`. Multi-line prompts could be mangled by the shell interpretation layer, producing a lone backslash instead of the full prompt.
- Fix: when the command is an absolute path (which `resolveCommand()` always produces), exec it directly via `os.execvp` without wrapping in a login shell. The shell fallback is preserved for bare command names.

Fixes #81

## Test plan
- [x] All 211 existing tests pass
- [x] Build succeeds
- [ ] Manual test: open a Claude (ctx) session and verify the full context prompt is sent

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>