### PR TITLE
Add _isDisposed guard to show() inner rAF callback

### DIFF
--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -591,6 +591,7 @@ export class TerminalTab {
     // second frame has correct dimensions for fitAddon to measure.
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
+        if (this._isDisposed) return;
         this.safeFit();
         // Force a full re-render of all rows. If the renderer changed while
         // the tab was hidden (e.g. WebGL context loss fell back to canvas),


### PR DESCRIPTION
## Summary

- Adds `if (this._isDisposed) return;` at the start of the inner `requestAnimationFrame` callback in `show()`, preventing calls to `terminal.refresh`, `scrollToBottom`, and `focus` on a disposed xterm instance
- Matches the existing guard pattern used in the `onContextLoss` handler and other async callbacks

Fixes #89

## Test plan

- [x] All 211 tests pass (`npx vitest run`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual: open a tab, trigger `show()`, dispose the tab before the RAF fires - confirm no throw