### PR TITLE
CSS cleanup: deduplicate tab spinner keyframes, fix box-sizing and border-radius

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -575,11 +575,6 @@
   50% { opacity: 1; }
 }
 
-@keyframes wt-tab-active-spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
-}
-
 /* Active tab: green line scrolling around the tab border.
    Uses a rotating conic-gradient masked to the border, same concept as the
    card badge arc spinner but adapted for rectangular tab geometry. */
@@ -593,7 +588,8 @@
   content: "";
   position: absolute;
   inset: -1px;
-  border-radius: 4px 4px 0 0;
+  border-radius: inherit;
+  box-sizing: border-box;
   background: conic-gradient(#38a169 0deg, #38a169 90deg, transparent 90deg, transparent 360deg);
   mask:
     linear-gradient(#000, #000) content-box,
@@ -604,7 +600,7 @@
     linear-gradient(#000, #000);
   -webkit-mask-composite: xor;
   padding: 1.5px;
-  animation: wt-tab-active-spin 1.2s linear infinite;
+  animation: wt-arc-spin 1.2s linear infinite;
   z-index: -1;
   pointer-events: none;
 }


### PR DESCRIPTION
## Summary

- Remove duplicate `@keyframes wt-tab-active-spin` (identical to `wt-arc-spin`), update `.wt-tab-agent-active::before` to use `wt-arc-spin`
- Add `box-sizing: border-box` to `.wt-tab-agent-active::before` so `inset: -1px` + `padding: 1.5px` size correctly
- Replace hard-coded `border-radius: 4px 4px 0 0` with `border-radius: inherit` to match the waiting indicator pattern

Fixes #88

## Test plan

- [x] `npx vitest run` - 211 tests pass
- [x] `npm run build` - clean build
- [ ] Visual check: active tab spinner renders correctly with inherited border-radius