### PR TITLE
Fix legacy restored-tab close disposal

### DIFF
--- a/src/core/terminal/TerminalTab.test.ts
+++ b/src/core/terminal/TerminalTab.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => {
   class MockWebglAddon {
     static instances: MockWebglAddon[] = [];
 
+    clearTextureAtlas = vi.fn();
     dispose = vi.fn();
     onContextLoss = vi.fn((handler: () => void) => {
       this.handlers.push(handler);
@@ -433,8 +434,8 @@ describe("TerminalTab hot-reload addon handling", () => {
     expect(webLinksAddon.dispose).toHaveBeenCalledTimes(1);
     expect(unicode11Addon.dispose).toHaveBeenCalledTimes(1);
     expect(webglAddon.dispose).toHaveBeenCalledTimes(1);
-    expect(webglAddon.onContextLoss).not.toHaveBeenCalled();
-    expect(legacyWebglListenerDispose).not.toHaveBeenCalled();
+    expect(webglAddon.onContextLoss).toHaveBeenCalledTimes(1);
+    expect(legacyWebglListenerDispose).toHaveBeenCalledTimes(1);
     expect(addonManagerDispose).toHaveBeenCalledTimes(1);
     expect(containerEl.remove).toHaveBeenCalledTimes(1);
   });
@@ -613,6 +614,57 @@ describe("TerminalTab WebGL recovery", () => {
         .webglAddon,
     ).toBeNull();
     expect(tab.stash().webglAddon).toBeNull();
+  });
+
+  it("rebinds a legacy-restored webgl addon to the new tab's context-loss handler", () => {
+    const addon = new mocks.MockWebglAddon();
+    const terminalRefresh = vi.fn();
+    const containerEl = new FakeElement() as unknown as HTMLElement;
+    const parentEl = new FakeElement() as unknown as HTMLElement;
+    const stored = {
+      id: "term-1",
+      taskPath: "task.md",
+      label: "Claude",
+      claudeSessionId: "session-1",
+      sessionType: "claude" as const,
+      terminal: {
+        focus: vi.fn(),
+        scrollToBottom: vi.fn(),
+        refresh: terminalRefresh,
+        cols: 80,
+        rows: 24,
+        _addonManager: {
+          _addons: [{ instance: addon, isDisposed: false }],
+        },
+      },
+      fitAddon: {},
+      searchAddon: {},
+      containerEl,
+      process: null,
+      webglAddon: null,
+      webglContextLossListener: null,
+      documentListeners: [],
+      resizeObserver: new MockResizeObserver(() => {}) as unknown as ResizeObserver,
+    };
+
+    const tab = TerminalTab.fromStored(stored, parentEl);
+
+    expect(
+      (tab as unknown as { webglAddon: InstanceType<typeof mocks.MockWebglAddon> | null })
+        .webglAddon,
+    ).toBe(addon);
+    expect(addon.onContextLoss).toHaveBeenCalledTimes(1);
+    expect(addon.getHandlerCount()).toBe(1);
+
+    addon.emitContextLoss();
+
+    expect(addon.dispose).toHaveBeenCalledTimes(1);
+    expect(
+      (tab as unknown as { webglAddon: InstanceType<typeof mocks.MockWebglAddon> | null })
+        .webglAddon,
+    ).toBeNull();
+    expect(addon.getHandlerCount()).toBe(0);
+    expect(terminalRefresh).toHaveBeenCalledWith(0, 23);
   });
 
   it("disposes a created webgl addon if terminal.loadAddon throws", () => {

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -850,10 +850,11 @@ export class TerminalTab {
     // Restore the live webglAddon reference so recovered tabs still dispose it
     // correctly, then re-subscribe onContextLoss with a callback bound to the
     // new tab instance created during reload recovery.
-    if (stored.webglAddon) {
-      tab.trackWebglAddon(stored.webglAddon);
-    }
+    const restoredWebglAddon = tab.webglAddon;
     stored.webglContextLossListener?.dispose();
+    if (restoredWebglAddon) {
+      tab.trackWebglAddon(restoredWebglAddon);
+    }
     tab._documentCleanups = [];
     tab._claudeState = "inactive" as ClaudeState;
     tab._recentCleanLines = [];


### PR DESCRIPTION
## Summary\n- recover legacy xterm addon references from restored sessions before teardown\n- stop calling the private addon-manager disposal fallback directly on tab close\n- add regression coverage for restored tabs, including legacy WebGL addon handling\n\n## Testing\n- npx vitest run\n- npm run build\n\nFixes #102