### PR TITLE
Fix #123 Copilot ask_user waiting-state detection

### DIFF
--- a/src/core/claude/ClaudeStateDetector.test.ts
+++ b/src/core/claude/ClaudeStateDetector.test.ts
@@ -99,6 +99,129 @@ describe("ClaudeStateDetector", () => {
       expect(detector.state).toBe("idle");
       detector.stop();
     });
+
+    it("keeps a visible asking-user prompt in range even with a full recent-output tail", () => {
+      const terminal = mockTerminal([
+        "  ○ Asking user What kind of question would you like me to ask?",
+      ]);
+      const detector = new ClaudeStateDetector(terminal, () => false);
+      detector.trackOutput(
+        [
+          "╭────────────────────────────────────────────────────────────╮",
+          "│ What kind of question would you like me to ask?           │",
+          "│ ❯ 1. Something thoughtful (Recommended)                   │",
+          "│   2. Something fun                                        │",
+          "│   3. Something practical                                  │",
+          "│   4. Surprise me                                          │",
+          "│   5. Other (type your answer)                             │",
+          "│ ↑↓ to select · Enter to confirm · Esc to cancel           │",
+          "╰────────────────────────────────────────────────────────────╯",
+          "○ Asking user What kind of question would you like me to ask?",
+          "history line 1",
+          "history line 2",
+          "history line 3",
+          "history line 4",
+          "history line 5",
+        ].join("\n"),
+      );
+      detector.start();
+
+      vi.advanceTimersByTime(2100);
+      expect(detector.state).toBe("waiting");
+      detector.stop();
+    });
+
+    it("detects boxed Copilot ask_user prompts on the visible screen", () => {
+      const terminal = mockTerminal([
+        "╭────────────────────────────────────────────────────────────╮",
+        "│ What kind of question would you like me to ask?           │",
+        "│ ❯ 1. Something thoughtful (Recommended)                   │",
+        "│   2. Something fun                                        │",
+        "│ ↑↓ to select · Enter to confirm · Esc to cancel           │",
+        "╰────────────────────────────────────────────────────────────╯",
+      ]);
+      const detector = new ClaudeStateDetector(terminal, () => false);
+      detector.start();
+
+      vi.advanceTimersByTime(2100);
+      expect(detector.state).toBe("waiting");
+      detector.stop();
+    });
+
+    it("prefers a newer active status below an older visible prompt box", () => {
+      const terminal = mockTerminal([
+        "╭────────────────────────────────────────────────────────────╮",
+        "│ What kind of question would you like me to ask?           │",
+        "│ ❯ 1. Something thoughtful (Recommended)                   │",
+        "│   2. Something fun                                        │",
+        "╰────────────────────────────────────────────────────────────╯",
+        "○ Thinking (Esc to cancel)",
+      ]);
+      const detector = new ClaudeStateDetector(terminal, () => false);
+      detector.start();
+
+      vi.advanceTimersByTime(2100);
+      expect(detector.state).toBe("active");
+      detector.stop();
+    });
+
+    it("does not keep waiting from stale boxed recent output after the screen moves on", () => {
+      const terminal = mockTerminal(["  ○ Thinking (Esc to cancel)"]);
+      const detector = new ClaudeStateDetector(terminal, () => false);
+      detector.trackOutput(
+        [
+          "╭────────────────────────────────────────────────────────────╮",
+          "│ What kind of question would you like me to ask?           │",
+          "│ ❯ 1. Something thoughtful (Recommended)                   │",
+          "│   2. Something fun                                        │",
+          "│ ↑↓ to select · Enter to confirm · Esc to cancel           │",
+          "╰────────────────────────────────────────────────────────────╯",
+        ].join("\n"),
+      );
+      detector.start();
+
+      vi.advanceTimersByTime(2100);
+      expect(detector.state).toBe("active");
+      detector.stop();
+    });
+
+    it("does not treat ordinary boxed output as waiting", () => {
+      const terminal = mockTerminal(["  some previous output"]);
+      const detector = new ClaudeStateDetector(terminal, () => false);
+      detector.trackOutput(
+        [
+          "╭────────────────────────────────────────────────────────────╮",
+          "│ Repository summary                                        │",
+          "│ Build completed successfully                              │",
+          "╰────────────────────────────────────────────────────────────╯",
+        ].join("\n"),
+      );
+      detector.start();
+
+      vi.advanceTimersByTime(2100);
+      expect(detector.state).toBe("idle");
+      detector.stop();
+    });
+
+    it("falls back to recent boxed output only when the visible screen is empty", () => {
+      const terminal = mockTerminal([]);
+      const detector = new ClaudeStateDetector(terminal, () => false);
+      detector.trackOutput(
+        [
+          "╭────────────────────────────────────────────────────────────╮",
+          "│ What kind of question would you like me to ask?           │",
+          "│ ❯ 1. Something thoughtful (Recommended)                   │",
+          "│   2. Something fun                                        │",
+          "│ ↑↓ to select · Enter to confirm · Esc to cancel           │",
+          "╰────────────────────────────────────────────────────────────╯",
+        ].join("\n"),
+      );
+      detector.start();
+
+      vi.advanceTimersByTime(2100);
+      expect(detector.state).toBe("waiting");
+      detector.stop();
+    });
   });
 
   describe("active indicator detection", () => {

--- a/src/core/claude/ClaudeStateDetector.ts
+++ b/src/core/claude/ClaudeStateDetector.ts
@@ -10,6 +10,56 @@ import { stripAnsi } from "../utils";
 
 export type ClaudeState = "inactive" | "active" | "idle" | "waiting";
 
+function normalizeWaitingLine(line: string): string {
+  return line.replace(/[│┃║╭╮╰╯─═]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function findLastWaitingLineIndex(lines: string[]): number {
+  if (lines.length === 0) return -1;
+
+  const tailStart = Math.max(0, lines.length - 20);
+  const tail = lines.slice(tailStart);
+
+  for (let i = tail.length - 1; i >= Math.max(0, tail.length - 15); i--) {
+    const normalizedLine = normalizeWaitingLine(tail[i]);
+    if (!normalizedLine) continue;
+
+    if (/Enter to (?:select|confirm)|to navigate/i.test(normalizedLine)) return tailStart + i;
+
+    if (/\bAllow\b.*\?/i.test(normalizedLine)) return tailStart + i;
+    if (/\ballowOnce\b|\bdenyOnce\b|\ballowAlways\b/i.test(normalizedLine)) return tailStart + i;
+
+    if (/^\s*[>\u276f]\s*\d+\.\s+\S/.test(normalizedLine)) return tailStart + i;
+    if (/^\s*\(?\d+\)?\s+\S/.test(normalizedLine) && i > 0) {
+      for (let j = i - 1; j >= Math.max(0, i - 5); j--) {
+        const normalizedPreviousLine = normalizeWaitingLine(tail[j]);
+        if (normalizedPreviousLine.endsWith("?")) return tailStart + i;
+      }
+    }
+
+    if (i >= tail.length - 5 && normalizedLine.endsWith("?") && normalizedLine.length > 10) {
+      return tailStart + i;
+    }
+
+    if (/^\s*(Yes|No)\s*$/i.test(normalizedLine)) return tailStart + i;
+  }
+
+  return -1;
+}
+
+export function hasAgentWaitingIndicator(
+  screenLines: string[] = [],
+  recentCleanLines: string[] = [],
+): boolean {
+  const waitingIndex = findLastWaitingLineIndex(screenLines);
+  if (waitingIndex !== -1) {
+    if (hasAgentActiveIndicator(screenLines.slice(waitingIndex + 1))) return false;
+    return true;
+  }
+  if (screenLines.length > 0) return false;
+  return findLastWaitingLineIndex(recentCleanLines.slice(-15)) !== -1;
+}
+
 export class ClaudeStateDetector {
   private _state: ClaudeState = "inactive";
   private _timer: ReturnType<typeof setInterval> | null = null;
@@ -118,38 +168,7 @@ export class ClaudeStateDetector {
    * source since it shows the current rendered state.
    */
   private _looksLikeWaiting(screenLines?: string[]): boolean {
-    // Merge screen lines and recent output for comprehensive detection
-    const sources = [...(screenLines || []), ...(this._recentCleanLines || []).slice(-15)];
-    if (sources.length === 0) return false;
-
-    const tail = sources.slice(-20);
-
-    for (let i = tail.length - 1; i >= Math.max(0, tail.length - 15); i--) {
-      const line = tail[i].trim();
-
-      // Interactive selection UI: "Enter to select", "up/down to navigate"
-      if (/Enter to select|to navigate/i.test(line)) return true;
-
-      // Permission prompt patterns: "Allow", "allowOnce", "denyOnce"
-      if (/\bAllow\b.*\?/i.test(line)) return true;
-      if (/\ballowOnce\b|\bdenyOnce\b|\ballowAlways\b/i.test(line)) return true;
-
-      // AskUserQuestion patterns: numbered options with ">" selector or "(N)"
-      if (/^\s*[>\u276f]\s*\d+\.\s+\S/.test(line)) return true;
-      if (/^\s*\(?\d+\)?\s+\S/.test(line) && i > 0) {
-        for (let j = i - 1; j >= Math.max(0, i - 5); j--) {
-          if (tail[j].trim().endsWith("?")) return true;
-        }
-      }
-
-      // Generic question pattern: line ends with "?" and is near the bottom
-      if (i >= tail.length - 5 && line.endsWith("?") && line.length > 10) return true;
-
-      // "Yes" / "No" option pair
-      if (/^\s*(Yes|No)\s*$/i.test(line)) return true;
-    }
-
-    return false;
+    return hasAgentWaitingIndicator(screenLines || [], this._recentCleanLines || []);
   }
 
   /** Clear the waiting state (e.g. when the user activates this tab). */

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -18,7 +18,7 @@ import { attachScrollButton } from "./ScrollButton";
 import { attachBubbleCapture, attachCapturePhase } from "./KeyboardCapture";
 import { type StoredSession, type SessionType, isResumableSessionType } from "../session/types";
 import { ClaudeSessionTracker } from "../claude/ClaudeSessionTracker";
-import { hasAgentActiveIndicator } from "../claude/ClaudeStateDetector";
+import { hasAgentActiveIndicator, hasAgentWaitingIndicator } from "../claude/ClaudeStateDetector";
 
 export type ClaudeState = "inactive" | "active" | "idle" | "waiting";
 
@@ -780,37 +780,7 @@ export class TerminalTab {
    * screen buffer and recent output lines.
    */
   private _looksLikeWaiting(screenLines?: string[]): boolean {
-    const sources = [...(screenLines || []), ...(this._recentCleanLines || []).slice(-15)];
-    if (sources.length === 0) return false;
-
-    const tail = sources.slice(-20);
-
-    for (let i = tail.length - 1; i >= Math.max(0, tail.length - 15); i--) {
-      const line = tail[i].trim();
-
-      // Interactive selection UI: "Enter to select", "up/down to navigate"
-      if (/Enter to select|to navigate/i.test(line)) return true;
-
-      // Permission prompt patterns
-      if (/\bAllow\b.*\?/i.test(line)) return true;
-      if (/\ballowOnce\b|\bdenyOnce\b|\ballowAlways\b/i.test(line)) return true;
-
-      // AskUserQuestion patterns: numbered options with ">" selector or "(N)"
-      if (/^\s*[>\u276f]\s*\d+\.\s+\S/.test(line)) return true;
-      if (/^\s*\(?\d+\)?\s+\S/.test(line) && i > 0) {
-        for (let j = i - 1; j >= Math.max(0, i - 5); j--) {
-          if (tail[j].trim().endsWith("?")) return true;
-        }
-      }
-
-      // Generic question pattern near the bottom
-      if (i >= tail.length - 5 && line.endsWith("?") && line.length > 10) return true;
-
-      // "Yes" / "No" option pair
-      if (/^\s*(Yes|No)\s*$/i.test(line)) return true;
-    }
-
-    return false;
+    return hasAgentWaitingIndicator(screenLines || [], this._recentCleanLines || []);
   }
 
   /** Clear the waiting state (e.g. when the user activates this tab to respond). */


### PR DESCRIPTION
## Summary
- share waiting-prompt detection between TerminalTab and ClaudeStateDetector
- detect boxed Copilot ask_user prompts without letting stale prompt history keep the tab in waiting
- add regression coverage for prompt ordering, boxed prompts, and active-state precedence

## Testing
- npx vitest run src/core/claude/ClaudeStateDetector.test.ts src/core/terminal/TerminalTab.test.ts
- npm run build
- npx vitest run