### PR TITLE
Refresh README and CLAUDE documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ To create a custom adapter: extend `BaseAdapter`, implement the abstract methods
 - **UUID-based keying** - Sessions, custom order, and selection all use frontmatter UUIDs, not file paths. Survives renames without re-keying.
 - **2-panel ItemView + workspace leaf detail** - The detail panel is a native Obsidian MarkdownView created via `createLeafBySplit`, not a custom CSS column. Gives live preview, frontmatter editing, backlinks for free.
 - **CSS prefix `wt-`** - All plugin CSS classes use `wt-` prefix. No CSS modules.
-- **Recovery stays in framework code** - hot-reload stash/restore, recent-session reopening, durable Claude/Copilot session persistence, and WebGL recovery are not adapter concerns.
+- **Recovery stays in framework code** - hot-reload stash/restore, global recent-session reopening onto the original item, durable Claude/Copilot session persistence, and WebGL recovery are not adapter concerns.
 
 ## Development workflow
 
@@ -77,7 +77,7 @@ To create a custom adapter: extend `BaseAdapter`, implement the abstract methods
 
 - **Session types**: shell, Claude, Claude-with-context, Copilot, Copilot-with-context, Strands, and Strands-with-context. The custom session modal remembers per-item defaults for new sessions.
 - **Recent-session restore**: the custom session modal shows up to 5 entries from a global recent-session list and always reopens the selected tab on its original item within a 30-minute recovery window.
-- **Durable recovery**: after a full close, only Claude/Copilot sessions with persisted metadata resume. Shell and Strands are not durably restored after restart, but can be relaunched from the recent-session flow while still inside that 30-minute window.
+- **Durable recovery**: after a full close, only resumable Claude/Copilot sessions with persisted metadata are restored. Shell and Strands are never part of durable restart recovery, but can be relaunched from the separate recent-session flow while still inside that 30-minute window.
 - **Diagnostics**: command palette action "Copy Session Diagnostics" snapshots session/process state, renderer health, recovery status, and persisted metadata for issue reports.
 
 ## Development rules
@@ -114,5 +114,5 @@ Run `npm test` after changes to verify nothing is broken. Build with `npm run bu
 - **Resize protocol**: `ESC]777;resize;COLS;ROWS BEL` through stdin; pty-wrapper.py intercepts and applies.
 - **Keyboard capture**: Two layers (bubble + capture phase) intercept keys before Obsidian. Option+Arrow, Shift+Enter, Option+Backspace, macOptionIsMeta.
 - **State detection reads xterm buffer, not stdout**: Immune to status line redraws. Checks last 6 visual lines. Handles narrow terminal wrapping via joined-tail fallback.
-- **Session persistence**: Three layers - window-global stash for hot-reload, recent closed-session tracking for short-term reopen flows, and disk persistence for full restart recovery of Claude/Copilot session metadata (7-day retention). Copilot restart resume uses native `--resume[=sessionId]`; Claude still needs hooks if users trigger Claude's in-app `/resume` and change session IDs; Strands sessions always relaunch fresh, and shell sessions are never durably persisted.
+- **Session persistence**: Three layers - window-global stash for hot-reload, recent closed-session tracking for short-term reopen flows on the original item, and disk persistence for full restart recovery of Claude/Copilot session metadata only (7-day retention). Copilot restart resume uses native `--resume[=sessionId]`; Claude still needs hooks if users trigger Claude's in-app `/resume` and change session IDs; Strands sessions always relaunch fresh, and shell sessions are never durably persisted.
 - **WebGL recovery**: TerminalTab owns addon/context-loss cleanup so fresh tabs and restored tabs can recover from disposed or blank renderers without crashing on close.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Obsidian plugin that turns your vault into a work item board with per-item tabbe
 - **Kanban board** with collapsible sections, drag-drop reordering, and custom sort order
 - **Tabbed terminals** per work item - Shell, Claude, Claude (ctx), Copilot, Copilot (ctx), Strands, Strands (ctx), and per-item custom sessions
 - **Agent integration** - Claude/Copilot/Strands command resolution, Claude and Copilot state detection, Claude session rename detection, and headless enrichment hooks
-- **Session recovery** - hot-reload preserves live terminals, the custom session modal can reopen a global list of recently closed tabs onto their original work item, and durable restart recovery resumes Claude/Copilot sessions from persisted metadata. Shell and Strands can be relaunched from the recent-session flow, but are not durably restored after a full close
+- **Session recovery** - hot-reload preserves live terminals, the custom session modal can reopen up to 5 entries from a global recently closed list onto each tab's original work item within 30 minutes, and durable restart recovery resumes persisted Claude/Copilot sessions only. Shell and Strands are not part of durable restart recovery after a full close, but can still be relaunched from that separate recent-session flow while the window remains open
 - **Built-in diagnostics** - the command palette action "Copy Session Diagnostics" copies a JSON snapshot of session, renderer, recovery, and persistence state without reloading the plugin
 - **Detail panel** - native Obsidian MarkdownView via workspace leaf splitting
 
@@ -116,8 +116,9 @@ export class MyAdapter extends BaseAdapter {
   }
 
   createPromptBuilder(): WorkItemPromptBuilder {
-    // Build work-item prompts for contextual agent sessions such as
-    // Claude (ctx), Copilot (ctx), and Strands (ctx)
+    // Build work-item prompts for contextual agent sessions.
+    // The shipped integrations currently use this for
+    // Claude (ctx), Copilot (ctx), and Strands (ctx).
     // See task-agent/TaskPromptBuilder.ts for a full example
   }
 }
@@ -138,8 +139,8 @@ const adapter = new MyAdapter();
 
 Your adapter inherits all of this without writing any terminal code:
 
-- Shell plus built-in Claude, Copilot, and Strands terminal tabs per item, including contextual `(ctx)` variants powered by your prompt builder
-- Hot-reload stash/restore, recent-session reopen flows, and 7-day persisted metadata for Claude/Copilot restart resume
+- Shell plus built-in agent terminal tabs per item, including contextual `(ctx)` variants powered by your prompt builder. The shipped session types are Claude, Copilot, and Strands
+- Hot-reload stash/restore, a global recent-session reopen flow that restores the selected tab on its original item, and 7-day persisted metadata for durable Claude/Copilot restart resume only
 - Claude and Copilot state detection (active/waiting/idle) with card indicators
 - Claude session rename detection with adapter hook
 - Keyboard capture (Option+Arrow, Shift+Enter, macOptionIsMeta)


### PR DESCRIPTION
## Summary
- refresh README feature and workflow details to match the current plugin plus queued recovery/diagnostics work
- update CLAUDE.md architecture and runtime notes for session recovery, recent-session restore, WebGL ownership, and validation commands
- add explicit GitHub issue-reporting guidance for bugs and feature requests

## Testing
- npm test
- npm run build
- npm run lint *(fails on pre-existing src lint issues unrelated to this docs-only change)*

Closes #121