### PR TITLE
Fix #141: use file.path fallback for missing task IDs

### DIFF
--- a/src/adapters/task-agent/TaskParser.test.ts
+++ b/src/adapters/task-agent/TaskParser.test.ts
@@ -150,6 +150,20 @@ describe("TaskParser", () => {
       expect(item!.title).toBe("my-task");
     });
 
+    it("uses file.path as the ID when frontmatter id is missing", () => {
+      const file = makeFile("2 - Areas/Tasks/active/task-without-id.md");
+      const app = mockApp([file], {
+        [file.path]: makeFrontmatter({ id: undefined }),
+      });
+      const parser = new TaskParser(app, "", defaultSettings);
+      const item = parser.parse(file as unknown as TFile);
+
+      expect(item).not.toBeNull();
+      expect(item!.id).toBe(file.path);
+      expect(item!.path).toBe(file.path);
+      expect(item!.state).toBe("active");
+    });
+
     it("defaults source.type to 'other' when missing", () => {
       const file = makeFile("2 - Areas/Tasks/active/task.md");
       const app = mockApp([file], {

--- a/src/adapters/task-agent/TaskParser.ts
+++ b/src/adapters/task-agent/TaskParser.ts
@@ -48,7 +48,7 @@ export class TaskParser implements WorkItemParser {
     const goal: string[] = Array.isArray(fm.goal) ? fm.goal : fm.goal ? [fm.goal] : [];
 
     return {
-      id: fm.id || "",
+      id: fm.id || file.path,
       path: file.path,
       filename: file.name,
       state,


### PR DESCRIPTION
## Summary
- use `file.path` as the parsed task id when frontmatter exists but `id` is missing
- keep the change narrowly scoped to the parser path already discussed in #141
- add regression coverage for the frontmatter-present missing-id case

## Testing
- npx vitest run src/adapters/task-agent/TaskParser.test.ts
- npx vitest run
- npm run build