### PR TITLE
Fix #148 enforce public npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.0.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
       "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
       "dev": true,
       "license": "MIT",
@@ -53,7 +53,7 @@
     },
     "node_modules/@asamuzakjp/dom-selector": {
       "version": "7.0.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
       "integrity": "sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==",
       "dev": true,
       "license": "MIT",
@@ -70,14 +70,14 @@
     },
     "node_modules/@asamuzakjp/nwsapi": {
       "version": "2.3.9",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
@@ -87,7 +87,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
@@ -97,7 +97,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/parser/-/parser-7.29.2.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dev": true,
       "license": "MIT",
@@ -113,7 +113,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/types/-/types-7.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "license": "MIT",
@@ -127,7 +127,7 @@
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
       "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
       "dev": true,
       "license": "MIT",
@@ -137,7 +137,7 @@
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
       "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
       "dev": true,
       "license": "MIT",
@@ -150,7 +150,7 @@
     },
     "node_modules/@codemirror/state": {
       "version": "6.5.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@codemirror/state/-/state-6.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
       "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
       "dev": true,
       "license": "MIT",
@@ -161,7 +161,7 @@
     },
     "node_modules/@codemirror/view": {
       "version": "6.38.6",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@codemirror/view/-/view-6.38.6.tgz",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
       "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
       "dev": true,
       "license": "MIT",
@@ -175,7 +175,7 @@
     },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
       "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
       "dev": true,
       "funding": [
@@ -195,7 +195,7 @@
     },
     "node_modules/@csstools/css-calc": {
       "version": "3.1.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
       "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
       "dev": true,
       "funding": [
@@ -219,7 +219,7 @@
     },
     "node_modules/@csstools/css-color-parser": {
       "version": "4.0.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
       "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
       "dev": true,
       "funding": [
@@ -247,7 +247,7 @@
     },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
       "dev": true,
       "funding": [
@@ -270,7 +270,7 @@
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
       "version": "1.1.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
       "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
       "dev": true,
       "funding": [
@@ -295,7 +295,7 @@
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
       "dev": true,
       "funding": [
@@ -315,7 +315,7 @@
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@emnapi/core/-/core-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
       "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
       "dev": true,
       "license": "MIT",
@@ -327,7 +327,7 @@
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.9.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
       "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
       "dev": true,
       "license": "MIT",
@@ -338,7 +338,7 @@
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
       "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
       "dev": true,
       "license": "MIT",
@@ -349,7 +349,7 @@
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
       "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
       "cpu": [
         "ppc64"
@@ -366,7 +366,7 @@
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
       "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
       "cpu": [
         "arm"
@@ -383,7 +383,7 @@
     },
     "node_modules/@esbuild/android-arm64": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
       "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
       "cpu": [
         "arm64"
@@ -400,7 +400,7 @@
     },
     "node_modules/@esbuild/android-x64": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
       "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
       "cpu": [
         "x64"
@@ -417,7 +417,7 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
       "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
       "cpu": [
         "arm64"
@@ -434,7 +434,7 @@
     },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
       "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
       "cpu": [
         "x64"
@@ -451,7 +451,7 @@
     },
     "node_modules/@esbuild/freebsd-arm64": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
       "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
       "cpu": [
         "arm64"
@@ -468,7 +468,7 @@
     },
     "node_modules/@esbuild/freebsd-x64": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
       "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
       "cpu": [
         "x64"
@@ -485,7 +485,7 @@
     },
     "node_modules/@esbuild/linux-arm": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
       "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
       "cpu": [
         "arm"
@@ -502,7 +502,7 @@
     },
     "node_modules/@esbuild/linux-arm64": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
       "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
       "cpu": [
         "arm64"
@@ -519,7 +519,7 @@
     },
     "node_modules/@esbuild/linux-ia32": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
       "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
       "cpu": [
         "ia32"
@@ -536,7 +536,7 @@
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
       "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
       "cpu": [
         "loong64"
@@ -553,7 +553,7 @@
     },
     "node_modules/@esbuild/linux-mips64el": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
       "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
       "cpu": [
         "mips64el"
@@ -570,7 +570,7 @@
     },
     "node_modules/@esbuild/linux-ppc64": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
       "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
       "cpu": [
         "ppc64"
@@ -587,7 +587,7 @@
     },
     "node_modules/@esbuild/linux-riscv64": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
       "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
       "cpu": [
         "riscv64"
@@ -604,7 +604,7 @@
     },
     "node_modules/@esbuild/linux-s390x": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
       "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
       "cpu": [
         "s390x"
@@ -621,7 +621,7 @@
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
       "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
       "cpu": [
         "x64"
@@ -638,7 +638,7 @@
     },
     "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
       "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
       "cpu": [
         "arm64"
@@ -656,7 +656,7 @@
     },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
       "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
       "cpu": [
         "x64"
@@ -673,7 +673,7 @@
     },
     "node_modules/@esbuild/openbsd-arm64": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
       "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
       "cpu": [
         "arm64"
@@ -691,7 +691,7 @@
     },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
       "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
       "cpu": [
         "x64"
@@ -708,7 +708,7 @@
     },
     "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
       "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
       "cpu": [
         "arm64"
@@ -726,7 +726,7 @@
     },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
       "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
       "cpu": [
         "x64"
@@ -743,7 +743,7 @@
     },
     "node_modules/@esbuild/win32-arm64": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
       "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
       "cpu": [
         "arm64"
@@ -760,7 +760,7 @@
     },
     "node_modules/@esbuild/win32-ia32": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
       "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
       "cpu": [
         "ia32"
@@ -777,7 +777,7 @@
     },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
       "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
       "cpu": [
         "x64"
@@ -794,7 +794,7 @@
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
       "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
@@ -813,7 +813,7 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
@@ -823,7 +823,7 @@
     },
     "node_modules/@eslint/config-array": {
       "version": "0.23.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@eslint/config-array/-/config-array-0.23.3.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
       "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -838,7 +838,7 @@
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.5.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
       "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -851,7 +851,7 @@
     },
     "node_modules/@eslint/core": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@eslint/core/-/core-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
       "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -864,7 +864,7 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@eslint/object-schema/-/object-schema-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
       "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -874,7 +874,7 @@
     },
     "node_modules/@eslint/plugin-kit": {
       "version": "0.6.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
       "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -888,7 +888,7 @@
     },
     "node_modules/@exodus/bytes": {
       "version": "1.15.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
       "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
       "dev": true,
       "license": "MIT",
@@ -906,7 +906,7 @@
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@humanfs/core/-/core-0.19.1.tgz",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -916,7 +916,7 @@
     },
     "node_modules/@humanfs/node": {
       "version": "0.16.7",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@humanfs/node/-/node-0.16.7.tgz",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
       "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -930,7 +930,7 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -944,7 +944,7 @@
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -958,7 +958,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
       "license": "MIT",
@@ -968,14 +968,14 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
@@ -986,7 +986,7 @@
     },
     "node_modules/@marijn/find-cluster-break": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "dev": true,
       "license": "MIT",
@@ -994,7 +994,7 @@
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
       "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
       "dev": true,
       "license": "MIT",
@@ -1011,7 +1011,7 @@
     },
     "node_modules/@oxc-project/types": {
       "version": "0.122.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@oxc-project/types/-/types-0.122.0.tgz",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
       "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
       "dev": true,
       "license": "MIT",
@@ -1021,7 +1021,7 @@
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.12",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
       "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
       "cpu": [
         "arm64"
@@ -1038,7 +1038,7 @@
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
       "version": "1.0.0-rc.12",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
       "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
       "cpu": [
         "arm64"
@@ -1055,7 +1055,7 @@
     },
     "node_modules/@rolldown/binding-darwin-x64": {
       "version": "1.0.0-rc.12",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
       "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
       "cpu": [
         "x64"
@@ -1072,7 +1072,7 @@
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
       "version": "1.0.0-rc.12",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
       "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
       "cpu": [
         "x64"
@@ -1089,7 +1089,7 @@
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
       "version": "1.0.0-rc.12",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
       "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
       "cpu": [
         "arm"
@@ -1106,7 +1106,7 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
       "version": "1.0.0-rc.12",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
       "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
       "cpu": [
         "arm64"
@@ -1123,7 +1123,7 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
       "version": "1.0.0-rc.12",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
       "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
       "cpu": [
         "arm64"
@@ -1140,7 +1140,7 @@
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
       "version": "1.0.0-rc.12",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
       "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
       "cpu": [
         "ppc64"
@@ -1157,7 +1157,7 @@
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
       "version": "1.0.0-rc.12",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
       "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
       "cpu": [
         "s390x"
@@ -1174,7 +1174,7 @@
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
       "version": "1.0.0-rc.12",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
       "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
       "cpu": [
         "x64"
@@ -1191,7 +1191,7 @@
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
       "version": "1.0.0-rc.12",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
       "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
       "cpu": [
         "x64"
@@ -1208,7 +1208,7 @@
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
       "version": "1.0.0-rc.12",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
       "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
       "cpu": [
         "arm64"
@@ -1225,7 +1225,7 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
       "version": "1.0.0-rc.12",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
       "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
       "cpu": [
         "wasm32"
@@ -1242,7 +1242,7 @@
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.0-rc.12",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
       "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
       "cpu": [
         "arm64"
@@ -1259,7 +1259,7 @@
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
       "version": "1.0.0-rc.12",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
       "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
       "cpu": [
         "x64"
@@ -1276,21 +1276,21 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.12",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
       "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
       "dev": true,
       "license": "MIT",
@@ -1301,7 +1301,7 @@
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/chai/-/chai-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
@@ -1312,7 +1312,7 @@
     },
     "node_modules/@types/codemirror": {
       "version": "5.60.8",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/codemirror/-/codemirror-5.60.8.tgz",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
       "integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
       "dev": true,
       "license": "MIT",
@@ -1322,35 +1322,35 @@
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
       "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/estree/-/estree-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.19.37",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/node/-/node-20.19.37.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "dev": true,
       "license": "MIT",
@@ -1360,7 +1360,7 @@
     },
     "node_modules/@types/tern": {
       "version": "0.23.9",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/tern/-/tern-0.23.9.tgz",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
       "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
       "dev": true,
       "license": "MIT",
@@ -1370,7 +1370,7 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.2.tgz",
       "integrity": "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==",
       "dev": true,
       "license": "MIT",
@@ -1399,7 +1399,7 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.57.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@typescript-eslint/parser/-/parser-8.57.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.2.tgz",
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
@@ -1424,7 +1424,7 @@
     },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.57.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@typescript-eslint/project-service/-/project-service-8.57.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.2.tgz",
       "integrity": "sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==",
       "dev": true,
       "license": "MIT",
@@ -1446,7 +1446,7 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.57.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@typescript-eslint/scope-manager/-/scope-manager-8.57.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.2.tgz",
       "integrity": "sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==",
       "dev": true,
       "license": "MIT",
@@ -1464,7 +1464,7 @@
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
       "version": "8.57.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.2.tgz",
       "integrity": "sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==",
       "dev": true,
       "license": "MIT",
@@ -1481,7 +1481,7 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "8.57.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@typescript-eslint/type-utils/-/type-utils-8.57.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.2.tgz",
       "integrity": "sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg==",
       "dev": true,
       "license": "MIT",
@@ -1506,7 +1506,7 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "8.57.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@typescript-eslint/types/-/types-8.57.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.2.tgz",
       "integrity": "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==",
       "dev": true,
       "license": "MIT",
@@ -1520,7 +1520,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "8.57.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.2.tgz",
       "integrity": "sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==",
       "dev": true,
       "license": "MIT",
@@ -1548,7 +1548,7 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.57.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@typescript-eslint/utils/-/utils-8.57.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.2.tgz",
       "integrity": "sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg==",
       "dev": true,
       "license": "MIT",
@@ -1572,7 +1572,7 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "8.57.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.2.tgz",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.2.tgz",
       "integrity": "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==",
       "dev": true,
       "license": "MIT",
@@ -1590,7 +1590,7 @@
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1603,7 +1603,7 @@
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
       "integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
       "dev": true,
       "license": "MIT",
@@ -1634,7 +1634,7 @@
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@vitest/expect/-/expect-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
       "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
       "dev": true,
       "license": "MIT",
@@ -1652,7 +1652,7 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "4.1.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
       "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
       "dev": true,
       "license": "MIT",
@@ -1665,7 +1665,7 @@
     },
     "node_modules/@vitest/runner": {
       "version": "4.1.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@vitest/runner/-/runner-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
       "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
       "dev": true,
       "license": "MIT",
@@ -1679,7 +1679,7 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "4.1.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
       "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
       "dev": true,
       "license": "MIT",
@@ -1695,7 +1695,7 @@
     },
     "node_modules/@vitest/spy": {
       "version": "4.1.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@vitest/spy/-/spy-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
       "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
       "dev": true,
       "license": "MIT",
@@ -1705,7 +1705,7 @@
     },
     "node_modules/@vitest/utils": {
       "version": "4.1.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@vitest/utils/-/utils-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
       "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
       "dev": true,
       "license": "MIT",
@@ -1720,7 +1720,7 @@
     },
     "node_modules/@xterm/addon-fit": {
       "version": "0.10.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
       "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -1729,37 +1729,37 @@
     },
     "node_modules/@xterm/addon-search": {
       "version": "0.16.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@xterm/addon-search/-/addon-search-0.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-search/-/addon-search-0.16.0.tgz",
       "integrity": "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==",
       "license": "MIT"
     },
     "node_modules/@xterm/addon-unicode11": {
       "version": "0.9.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@xterm/addon-unicode11/-/addon-unicode11-0.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-unicode11/-/addon-unicode11-0.9.0.tgz",
       "integrity": "sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw==",
       "license": "MIT"
     },
     "node_modules/@xterm/addon-web-links": {
       "version": "0.12.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz",
       "integrity": "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==",
       "license": "MIT"
     },
     "node_modules/@xterm/addon-webgl": {
       "version": "0.19.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@xterm/addon-webgl/-/addon-webgl-0.19.0.tgz",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.19.0.tgz",
       "integrity": "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==",
       "license": "MIT"
     },
     "node_modules/@xterm/xterm": {
       "version": "5.5.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
       "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.16.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/acorn/-/acorn-8.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
@@ -1772,7 +1772,7 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
@@ -1782,7 +1782,7 @@
     },
     "node_modules/ajv": {
       "version": "6.14.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ajv/-/ajv-6.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
@@ -1799,7 +1799,7 @@
     },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
       "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
       "dev": true,
       "license": "MIT",
@@ -1815,7 +1815,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
@@ -1828,7 +1828,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "6.2.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
@@ -1841,7 +1841,7 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/assertion-error/-/assertion-error-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
@@ -1851,7 +1851,7 @@
     },
     "node_modules/ast-v8-to-istanbul": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
       "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
       "dev": true,
       "license": "MIT",
@@ -1863,7 +1863,7 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/balanced-match/-/balanced-match-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
@@ -1873,7 +1873,7 @@
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bidi-js/-/bidi-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
       "dev": true,
       "license": "MIT",
@@ -1883,7 +1883,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
@@ -1896,7 +1896,7 @@
     },
     "node_modules/chai": {
       "version": "6.2.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chai/-/chai-6.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
@@ -1906,7 +1906,7 @@
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
       "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
       "dev": true,
       "license": "MIT",
@@ -1922,7 +1922,7 @@
     },
     "node_modules/cli-truncate": {
       "version": "5.2.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
       "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
       "dev": true,
       "license": "MIT",
@@ -1939,14 +1939,14 @@
     },
     "node_modules/colorette": {
       "version": "2.0.20",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/colorette/-/colorette-2.0.20.tgz",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
       "version": "14.0.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/commander/-/commander-14.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "dev": true,
       "license": "MIT",
@@ -1956,14 +1956,14 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/crelt": {
       "version": "1.0.6",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/crelt/-/crelt-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "dev": true,
       "license": "MIT",
@@ -1971,7 +1971,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
@@ -1986,7 +1986,7 @@
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/css-tree/-/css-tree-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
@@ -2000,7 +2000,7 @@
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/data-urls/-/data-urls-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
       "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
       "dev": true,
       "license": "MIT",
@@ -2014,7 +2014,7 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
@@ -2032,21 +2032,21 @@
     },
     "node_modules/decimal.js": {
       "version": "10.6.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/decimal.js/-/decimal.js-10.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/deep-is/-/deep-is-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/detect-libc/-/detect-libc-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -2056,14 +2056,14 @@
     },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/entities": {
       "version": "6.0.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/entities/-/entities-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2076,7 +2076,7 @@
     },
     "node_modules/environment": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/environment/-/environment-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
       "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
       "dev": true,
       "license": "MIT",
@@ -2089,14 +2089,14 @@
     },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/esbuild/-/esbuild-0.21.5.tgz",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "dev": true,
       "hasInstallScript": true,
@@ -2135,7 +2135,7 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
@@ -2148,7 +2148,7 @@
     },
     "node_modules/eslint": {
       "version": "10.1.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/eslint/-/eslint-10.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
       "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
       "dev": true,
       "license": "MIT",
@@ -2204,7 +2204,7 @@
     },
     "node_modules/eslint-config-prettier": {
       "version": "10.1.8",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
@@ -2220,7 +2220,7 @@
     },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
       "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2239,7 +2239,7 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
@@ -2252,7 +2252,7 @@
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -2265,7 +2265,7 @@
     },
     "node_modules/eslint/node_modules/ignore": {
       "version": "5.3.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ignore/-/ignore-5.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
@@ -2275,7 +2275,7 @@
     },
     "node_modules/espree": {
       "version": "11.2.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/espree/-/espree-11.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
       "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2293,7 +2293,7 @@
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -2306,7 +2306,7 @@
     },
     "node_modules/esquery": {
       "version": "1.7.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/esquery/-/esquery-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2319,7 +2319,7 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/esrecurse/-/esrecurse-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2332,7 +2332,7 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/estraverse/-/estraverse-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2342,7 +2342,7 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/estree-walker/-/estree-walker-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
@@ -2352,7 +2352,7 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/esutils/-/esutils-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2362,14 +2362,14 @@
     },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/expect-type/-/expect-type-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
       "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -2379,28 +2379,28 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fdir/-/fdir-6.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
@@ -2418,7 +2418,7 @@
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
@@ -2431,7 +2431,7 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/find-up/-/find-up-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
@@ -2448,7 +2448,7 @@
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/flat-cache/-/flat-cache-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
@@ -2462,14 +2462,14 @@
     },
     "node_modules/flatted": {
       "version": "3.4.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/flatted/-/flatted-3.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fsevents/-/fsevents-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
@@ -2484,7 +2484,7 @@
     },
     "node_modules/get-east-asian-width": {
       "version": "1.5.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
       "dev": true,
       "license": "MIT",
@@ -2497,7 +2497,7 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/glob-parent/-/glob-parent-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
@@ -2510,7 +2510,7 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
@@ -2520,7 +2520,7 @@
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
       "dev": true,
       "license": "MIT",
@@ -2533,14 +2533,14 @@
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/html-escaper/-/html-escaper-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/husky": {
       "version": "9.1.7",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/husky/-/husky-9.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
       "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
       "license": "MIT",
@@ -2556,7 +2556,7 @@
     },
     "node_modules/ignore": {
       "version": "7.0.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ignore/-/ignore-7.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
@@ -2566,7 +2566,7 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
@@ -2576,7 +2576,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
@@ -2586,7 +2586,7 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "5.1.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
       "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
       "dev": true,
       "license": "MIT",
@@ -2602,7 +2602,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-glob/-/is-glob-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
@@ -2615,21 +2615,21 @@
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2639,7 +2639,7 @@
     },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2654,7 +2654,7 @@
     },
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
       "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2668,14 +2668,14 @@
     },
     "node_modules/js-tokens": {
       "version": "10.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/js-tokens/-/js-tokens-10.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "29.0.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jsdom/-/jsdom-29.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
       "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
       "dev": true,
       "license": "MIT",
@@ -2716,28 +2716,28 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/json-buffer/-/json-buffer-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/keyv/-/keyv-4.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
@@ -2747,7 +2747,7 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/levn/-/levn-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
@@ -2761,7 +2761,7 @@
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lightningcss/-/lightningcss-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
@@ -2791,7 +2791,7 @@
     },
     "node_modules/lightningcss-android-arm64": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
       "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
@@ -2812,7 +2812,7 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
       "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
@@ -2833,7 +2833,7 @@
     },
     "node_modules/lightningcss-darwin-x64": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
       "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
@@ -2854,7 +2854,7 @@
     },
     "node_modules/lightningcss-freebsd-x64": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
       "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
@@ -2875,7 +2875,7 @@
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
       "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
@@ -2896,7 +2896,7 @@
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
       "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
@@ -2917,7 +2917,7 @@
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
@@ -2938,7 +2938,7 @@
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
       "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
@@ -2959,7 +2959,7 @@
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
@@ -2980,7 +2980,7 @@
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
       "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
@@ -3001,7 +3001,7 @@
     },
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
       "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
@@ -3022,7 +3022,7 @@
     },
     "node_modules/lint-staged": {
       "version": "16.4.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lint-staged/-/lint-staged-16.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
       "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
       "dev": true,
       "license": "MIT",
@@ -3046,7 +3046,7 @@
     },
     "node_modules/listr2": {
       "version": "9.0.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/listr2/-/listr2-9.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
@@ -3064,7 +3064,7 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/locate-path/-/locate-path-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
@@ -3080,7 +3080,7 @@
     },
     "node_modules/log-update": {
       "version": "6.1.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/log-update/-/log-update-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
       "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
       "dev": true,
       "license": "MIT",
@@ -3100,7 +3100,7 @@
     },
     "node_modules/log-update/node_modules/slice-ansi": {
       "version": "7.1.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
       "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
       "dev": true,
       "license": "MIT",
@@ -3117,7 +3117,7 @@
     },
     "node_modules/lru-cache": {
       "version": "11.2.7",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lru-cache/-/lru-cache-11.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
       "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -3127,7 +3127,7 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/magic-string/-/magic-string-0.30.21.tgz",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
@@ -3137,7 +3137,7 @@
     },
     "node_modules/magicast": {
       "version": "0.5.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/magicast/-/magicast-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
       "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
       "dev": true,
       "license": "MIT",
@@ -3149,7 +3149,7 @@
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/make-dir/-/make-dir-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
       "license": "MIT",
@@ -3165,14 +3165,14 @@
     },
     "node_modules/mdn-data": {
       "version": "2.27.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/mdn-data/-/mdn-data-2.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/mimic-function": {
       "version": "5.0.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/mimic-function/-/mimic-function-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
       "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
       "dev": true,
       "license": "MIT",
@@ -3185,7 +3185,7 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/minimatch/-/minimatch-10.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
       "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -3201,7 +3201,7 @@
     },
     "node_modules/moment": {
       "version": "2.29.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/moment/-/moment-2.29.4.tgz",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "dev": true,
       "license": "MIT",
@@ -3211,14 +3211,14 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/nanoid/-/nanoid-3.3.11.tgz",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
@@ -3237,14 +3237,14 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/obsidian": {
       "version": "1.12.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/obsidian/-/obsidian-1.12.3.tgz",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
       "integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
       "dev": true,
       "license": "MIT",
@@ -3259,7 +3259,7 @@
     },
     "node_modules/obug": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/obug/-/obug-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
       "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
       "dev": true,
       "funding": [
@@ -3270,7 +3270,7 @@
     },
     "node_modules/onetime": {
       "version": "7.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/onetime/-/onetime-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
       "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
       "dev": true,
       "license": "MIT",
@@ -3286,7 +3286,7 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/optionator/-/optionator-0.9.4.tgz",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
@@ -3304,7 +3304,7 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/p-limit/-/p-limit-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
@@ -3320,7 +3320,7 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/p-locate/-/p-locate-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
@@ -3336,7 +3336,7 @@
     },
     "node_modules/parse5": {
       "version": "8.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/parse5/-/parse5-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
       "dev": true,
       "license": "MIT",
@@ -3349,7 +3349,7 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/path-exists/-/path-exists-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
@@ -3359,7 +3359,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/path-key/-/path-key-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
@@ -3369,21 +3369,21 @@
     },
     "node_modules/pathe": {
       "version": "2.0.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pathe/-/pathe-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/picocolors/-/picocolors-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/picomatch/-/picomatch-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
@@ -3396,7 +3396,7 @@
     },
     "node_modules/postcss": {
       "version": "8.5.8",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss/-/postcss-8.5.8.tgz",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
       "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "dev": true,
       "funding": [
@@ -3425,7 +3425,7 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
@@ -3435,7 +3435,7 @@
     },
     "node_modules/prettier": {
       "version": "3.8.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/prettier/-/prettier-3.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
@@ -3451,7 +3451,7 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/punycode/-/punycode-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
@@ -3461,7 +3461,7 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/require-from-string/-/require-from-string-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
@@ -3471,7 +3471,7 @@
     },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
       "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
       "dev": true,
       "license": "MIT",
@@ -3488,14 +3488,14 @@
     },
     "node_modules/rfdc": {
       "version": "1.4.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/rfdc/-/rfdc-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.12",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/rolldown/-/rolldown-1.0.0-rc.12.tgz",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
       "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
       "dev": true,
       "license": "MIT",
@@ -3529,7 +3529,7 @@
     },
     "node_modules/saxes": {
       "version": "6.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/saxes/-/saxes-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
       "license": "ISC",
@@ -3542,7 +3542,7 @@
     },
     "node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-7.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
@@ -3555,7 +3555,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/shebang-command/-/shebang-command-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
@@ -3568,7 +3568,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
@@ -3578,14 +3578,14 @@
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/siginfo/-/siginfo-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/signal-exit/-/signal-exit-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
@@ -3598,7 +3598,7 @@
     },
     "node_modules/slice-ansi": {
       "version": "8.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
       "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
       "dev": true,
       "license": "MIT",
@@ -3615,7 +3615,7 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map-js/-/source-map-js-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -3625,21 +3625,21 @@
     },
     "node_modules/stackback": {
       "version": "0.0.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/stackback/-/stackback-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/std-env/-/std-env-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/string-argv/-/string-argv-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
       "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
       "dev": true,
       "license": "MIT",
@@ -3649,7 +3649,7 @@
     },
     "node_modules/string-width": {
       "version": "8.2.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/string-width/-/string-width-8.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
       "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
       "dev": true,
       "license": "MIT",
@@ -3666,7 +3666,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "7.2.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
@@ -3682,7 +3682,7 @@
     },
     "node_modules/style-mod": {
       "version": "4.1.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/style-mod/-/style-mod-4.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "dev": true,
       "license": "MIT",
@@ -3690,7 +3690,7 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
@@ -3703,21 +3703,21 @@
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tinybench/-/tinybench-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tinyexec/-/tinyexec-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
       "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
       "dev": true,
       "license": "MIT",
@@ -3727,7 +3727,7 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
@@ -3744,7 +3744,7 @@
     },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
       "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
@@ -3754,7 +3754,7 @@
     },
     "node_modules/tldts": {
       "version": "7.0.27",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tldts/-/tldts-7.0.27.tgz",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
       "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
       "dev": true,
       "license": "MIT",
@@ -3767,14 +3767,14 @@
     },
     "node_modules/tldts-core": {
       "version": "7.0.27",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tldts-core/-/tldts-core-7.0.27.tgz",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
       "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
       "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -3787,7 +3787,7 @@
     },
     "node_modules/tr46": {
       "version": "6.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tr46/-/tr46-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "dev": true,
       "license": "MIT",
@@ -3800,7 +3800,7 @@
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
@@ -3813,7 +3813,7 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tslib/-/tslib-2.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD",
@@ -3821,7 +3821,7 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/type-check/-/type-check-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
@@ -3834,7 +3834,7 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/typescript/-/typescript-5.9.3.tgz",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -3848,7 +3848,7 @@
     },
     "node_modules/typescript-eslint": {
       "version": "8.57.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/typescript-eslint/-/typescript-eslint-8.57.2.tgz",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.2.tgz",
       "integrity": "sha512-VEPQ0iPgWO/sBaZOU1xo4nuNdODVOajPnTIbog2GKYr31nIlZ0fWPoCQgGfF3ETyBl1vn63F/p50Um9Z4J8O8A==",
       "dev": true,
       "license": "MIT",
@@ -3872,7 +3872,7 @@
     },
     "node_modules/undici": {
       "version": "7.24.6",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/undici/-/undici-7.24.6.tgz",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
       "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
       "dev": true,
       "license": "MIT",
@@ -3882,14 +3882,14 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/undici-types/-/undici-types-6.21.0.tgz",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/uri-js/-/uri-js-4.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -3899,7 +3899,7 @@
     },
     "node_modules/vitest": {
       "version": "4.1.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/vitest/-/vitest-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
       "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
       "dev": true,
       "license": "MIT",
@@ -3981,7 +3981,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
       "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
       "cpu": [
         "ppc64"
@@ -3999,7 +3999,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/android-arm": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
       "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
       "cpu": [
         "arm"
@@ -4017,7 +4017,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/android-arm64": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
       "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
       "cpu": [
         "arm64"
@@ -4035,7 +4035,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/android-x64": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
       "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
       "cpu": [
         "x64"
@@ -4053,7 +4053,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
       "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
       "cpu": [
         "arm64"
@@ -4071,7 +4071,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
       "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
       "cpu": [
         "x64"
@@ -4089,7 +4089,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
       "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
       "cpu": [
         "arm64"
@@ -4107,7 +4107,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
       "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
       "cpu": [
         "x64"
@@ -4125,7 +4125,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/linux-arm": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
       "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
       "cpu": [
         "arm"
@@ -4143,7 +4143,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
       "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
       "cpu": [
         "arm64"
@@ -4161,7 +4161,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
       "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
       "cpu": [
         "ia32"
@@ -4179,7 +4179,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
       "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
       "cpu": [
         "loong64"
@@ -4197,7 +4197,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
       "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
       "cpu": [
         "mips64el"
@@ -4215,7 +4215,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
       "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
       "cpu": [
         "ppc64"
@@ -4233,7 +4233,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
       "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
       "cpu": [
         "riscv64"
@@ -4251,7 +4251,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
       "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
       "cpu": [
         "s390x"
@@ -4269,7 +4269,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/linux-x64": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
       "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
       "cpu": [
         "x64"
@@ -4287,7 +4287,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
       "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
       "cpu": [
         "x64"
@@ -4305,7 +4305,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
       "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
       "cpu": [
         "x64"
@@ -4323,7 +4323,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
       "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
       "cpu": [
         "x64"
@@ -4341,7 +4341,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
       "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
       "cpu": [
         "arm64"
@@ -4359,7 +4359,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
       "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
       "cpu": [
         "ia32"
@@ -4377,7 +4377,7 @@
     },
     "node_modules/vitest/node_modules/@esbuild/win32-x64": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
       "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
       "cpu": [
         "x64"
@@ -4395,7 +4395,7 @@
     },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
       "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
       "dev": true,
       "license": "MIT",
@@ -4422,7 +4422,7 @@
     },
     "node_modules/vitest/node_modules/esbuild": {
       "version": "0.27.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/esbuild/-/esbuild-0.27.4.tgz",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
       "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
       "dev": true,
       "hasInstallScript": true,
@@ -4466,7 +4466,7 @@
     },
     "node_modules/vitest/node_modules/vite": {
       "version": "8.0.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/vite/-/vite-8.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
@@ -4544,7 +4544,7 @@
     },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
       "license": "MIT",
@@ -4552,7 +4552,7 @@
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "dev": true,
       "license": "MIT",
@@ -4565,7 +4565,7 @@
     },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -4575,7 +4575,7 @@
     },
     "node_modules/whatwg-mimetype": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
       "dev": true,
       "license": "MIT",
@@ -4585,7 +4585,7 @@
     },
     "node_modules/whatwg-url": {
       "version": "16.0.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
       "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "dev": true,
       "license": "MIT",
@@ -4600,7 +4600,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/which/-/which-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
@@ -4616,7 +4616,7 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
       "license": "MIT",
@@ -4633,7 +4633,7 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/word-wrap/-/word-wrap-1.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
@@ -4643,7 +4643,7 @@
     },
     "node_modules/wrap-ansi": {
       "version": "9.0.2",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
       "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "dev": true,
       "license": "MIT",
@@ -4661,7 +4661,7 @@
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "7.2.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/string-width/-/string-width-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
@@ -4679,7 +4679,7 @@
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
       "license": "Apache-2.0",
@@ -4689,14 +4689,14 @@
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/xmlchars/-/xmlchars-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/yaml": {
       "version": "2.8.3",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/yaml/-/yaml-2.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
@@ -4712,7 +4712,7 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",


### PR DESCRIPTION
## Summary
- add a repo-level .npmrc that pins installs to the public npm registry
- rewrite package-lock.json resolved URLs from the private Artifactory mirror to registry.npmjs.org without changing dependency versions
- validate with npm ci --ignore-scripts, npm run build, and npm test

Fixes #148