### PR TITLE
Fix hidden Claude waiting false positives

### DIFF
--- a/src/core/agents/AgentStateDetector.test.ts
+++ b/src/core/agents/AgentStateDetector.test.ts
@@ -176,6 +176,72 @@ describe("AgentStateDetector", () => {
       detector.stop();
     });
 
+    it("does not treat answered hidden Claude questions on screen as waiting", () => {
+      const terminal = mockTerminal([
+        "Want me to request a review from someone specific?",
+        "❯ no",
+        "⏺ OK. What do you need done on this PR?",
+        "❯ nothing for now",
+        "⏺ Got it. Standing by.",
+        "──────────────────────────────────────────────",
+        "❯",
+        "──────────────────────────────────────────────",
+        "➜  obsidian-work-terminal git:(main) Opus 4.6",
+        "⏵⏵ bypass permissions on (shift+tab to cycle)",
+      ]);
+      const detector = new AgentStateDetector(terminal, () => false);
+      detector.start(true);
+
+      vi.advanceTimersByTime(2100);
+      expect(detector.state).toBe("idle");
+      detector.stop();
+    });
+
+    it("does not treat answered hidden Claude questions in recent output as waiting", () => {
+      const detector = new AgentStateDetector(mockTerminal([]), () => false);
+      detector.trackOutput(
+        [
+          "Want me to request a review from someone specific?",
+          "❯ no",
+          "⏺ OK. What do you need done on this PR?",
+          "❯ nothing for now",
+          "⏺ Got it. Standing by.",
+          "──────────────────────────────────────────────",
+          "❯",
+          "──────────────────────────────────────────────",
+          "➜  obsidian-work-terminal git:(main) Opus 4.6",
+          "⏵⏵ bypass permissions on (shift+tab to cycle)",
+        ].join("\n"),
+      );
+      detector.start(true);
+
+      vi.advanceTimersByTime(2100);
+      expect(detector.state).toBe("idle");
+      detector.stop();
+    });
+
+    it("still treats a newer unanswered hidden Claude question as waiting", () => {
+      const terminal = mockTerminal([
+        "Want me to request a review from someone specific?",
+        "❯ no",
+        "⏺ OK. What do you need done on this PR?",
+        "❯ nothing for now",
+        "⏺ Got it. Standing by.",
+        "⏺ Need anything else before I stop here?",
+        "──────────────────────────────────────────────",
+        "❯",
+        "──────────────────────────────────────────────",
+        "➜  obsidian-work-terminal git:(main) Opus 4.6",
+        "⏵⏵ bypass permissions on (shift+tab to cycle)",
+      ]);
+      const detector = new AgentStateDetector(terminal, () => false);
+      detector.start();
+
+      vi.advanceTimersByTime(2100);
+      expect(detector.state).toBe("waiting");
+      detector.stop();
+    });
+
     it("keeps a visible asking-user prompt in range even with a full recent-output tail", () => {
       const terminal = mockTerminal([
         "  ○ Asking user What kind of question would you like me to ask?",

--- a/src/core/agents/AgentStateDetector.ts
+++ b/src/core/agents/AgentStateDetector.ts
@@ -44,6 +44,13 @@ function looksLikeHiddenClaudePrompt(tail: string[], questionIndex: number): boo
     .filter((line) => line.length > 0);
   const promptIndex = normalizedAfterQuestion.findIndex((line) => line === "❯");
   if (promptIndex === -1) return false;
+  if (
+    normalizedAfterQuestion
+      .slice(0, promptIndex)
+      .some((line) => /^❯\s+\S/.test(line))
+  ) {
+    return false;
+  }
 
   return normalizedAfterQuestion
     .slice(promptIndex + 1)


### PR DESCRIPTION
## Summary
- ignore hidden-Claude question matches once an answered `❯ ...` line appears before the later bare prompt
- add regression coverage for screen-buffer and recent-output detection
- keep detecting newer unanswered hidden Claude questions as waiting

## Testing
- npm test
- npm run build

Fixes #153