### PR TITLE
Add 'Reset guided tour' button to plugin settings

### DIFF
--- a/src/framework/GuidedTour.test.ts
+++ b/src/framework/GuidedTour.test.ts
@@ -6,6 +6,7 @@ import {
   GuidedTourController,
   GUIDED_TOUR_VERSION,
   resetGuidedTourSingletonForTests,
+  resetGuidedTourStatus,
   saveGuidedTourStatus,
   shouldAutoStartGuidedTour,
 } from "./GuidedTour";
@@ -348,6 +349,25 @@ describe("GuidedTour", () => {
         updatedAt: expect.any(String),
       },
     });
+  });
+
+  it("resets guided tour status and re-enables auto-start", async () => {
+    const plugin = createMockPlugin({ settings: { "core.defaultShell": "/bin/zsh" } });
+    await saveGuidedTourStatus(plugin as never, "completed");
+    await expect(shouldAutoStartGuidedTour(plugin as never)).resolves.toBe(false);
+
+    await resetGuidedTourStatus(plugin as never);
+    const data = plugin.getData() as Record<string, unknown>;
+    expect(data).not.toHaveProperty("guidedTour");
+    expect(data).toHaveProperty("guidedTourEligibility", {
+      eligible: true,
+      updatedAt: expect.any(String),
+    });
+    expect(data).toHaveProperty("settings");
+
+    await expect(
+      shouldAutoStartGuidedTour(plugin as never, { hasExistingItems: false }),
+    ).resolves.toBe(true);
   });
 
   it("navigates between board and settings targets in both directions", async () => {

--- a/src/framework/GuidedTour.ts
+++ b/src/framework/GuidedTour.ts
@@ -233,6 +233,16 @@ export async function saveGuidedTourStatus(
   });
 }
 
+export async function resetGuidedTourStatus(plugin: Plugin): Promise<void> {
+  await mergeAndSavePluginData(plugin, async (data: GuidedTourDataShape) => {
+    delete data.guidedTour;
+    data.guidedTourEligibility = {
+      eligible: true,
+      updatedAt: new Date().toISOString(),
+    };
+  });
+}
+
 export class GuidedTourController {
   private static readonly BOARD_FOCUS_RESTORE_SELECTORS = [
     '[data-wt-tour="prompt-box"] .wt-prompt-toggle',

--- a/src/framework/SettingsTab.test.ts
+++ b/src/framework/SettingsTab.test.ts
@@ -7,6 +7,8 @@ const {
   resolveCommandInfoMock,
   splitConfiguredCommandMock,
   checkHookStatusMock,
+  resetGuidedTourStatusMock,
+  NoticeMock,
 } = vi.hoisted(() => ({
   isAbsoluteCommandPathMock: vi.fn(),
   isPathLikeCommandMock: vi.fn(),
@@ -16,6 +18,8 @@ const {
     scriptExists: false,
     hooksConfigured: false,
   })),
+  resetGuidedTourStatusMock: vi.fn(async () => {}),
+  NoticeMock: vi.fn(),
 }));
 
 vi.mock("obsidian", () => {
@@ -160,8 +164,12 @@ vi.mock("obsidian", () => {
     }
   }
 
-  return { App, PluginSettingTab, Setting };
+  return { App, Notice: NoticeMock, PluginSettingTab, Setting };
 });
+
+vi.mock("./GuidedTour", () => ({
+  resetGuidedTourStatus: resetGuidedTourStatusMock,
+}));
 
 vi.mock("../core/claude/ClaudeHookManager", () => ({
   checkHookStatus: checkHookStatusMock,
@@ -502,5 +510,30 @@ describe("WorkTerminalSettingsTab", () => {
       "Using configured path: \\\\server\\share\\copilot.cmd",
     );
     expect(tab.containerEl.textContent).toContain("Resolved from C:\\vault: C:\\vault\\agent.cmd");
+  });
+
+  it("renders a reset guided tour button that calls resetGuidedTourStatus and shows a Notice", async () => {
+    const plugin = makePlugin({});
+    const tab = new WorkTerminalSettingsTab({} as any, plugin as any, adapter);
+
+    tab.display();
+    await flushAsyncWork();
+
+    const allButtons = Array.from(tab.containerEl.querySelectorAll("button"));
+    const resetButton = allButtons.find((btn) => btn.textContent === "Reset");
+    expect(resetButton).toBeDefined();
+
+    expect(tab.containerEl.textContent).toContain("Reset guided tour");
+
+    resetGuidedTourStatusMock.mockClear();
+    NoticeMock.mockClear();
+
+    resetButton!.click();
+    await flushAsyncWork();
+
+    expect(resetGuidedTourStatusMock).toHaveBeenCalledWith(plugin);
+    expect(NoticeMock).toHaveBeenCalledWith(
+      "Guided tour will start next time you open Work Terminal",
+    );
   });
 });

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -7,7 +7,7 @@
  *                core.defaultShell, core.defaultTerminalCwd
  * Adapter settings: adapter.* (from adapter.config.settingsSchema)
  */
-import { App, PluginSettingTab, Setting } from "obsidian";
+import { App, Notice, PluginSettingTab, Setting } from "obsidian";
 import type { Plugin } from "obsidian";
 import type { AdapterBundle, SettingField } from "../core/interfaces";
 import {
@@ -18,6 +18,7 @@ import {
 } from "../core/agents/AgentLauncher";
 import { checkHookStatus, installHooks, removeHooks } from "../core/claude/ClaudeHookManager";
 import { mergeAndSavePluginData } from "../core/PluginDataStore";
+import { resetGuidedTourStatus } from "./GuidedTour";
 import { expandTilde } from "../core/utils";
 
 interface CoreSettings {
@@ -146,6 +147,20 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
       "Expose debug API",
       "Publishes window.__workTerminalDebug for CDP inspection. Disabled by default because it exposes active session metadata to other renderer plugins.",
     );
+
+    new Setting(containerEl)
+      .setName("Reset guided tour")
+      .setDesc(
+        "Clear guided tour completion status so it starts again next time you open Work Terminal.",
+      )
+      .addButton((btn) =>
+        btn.setButtonText("Reset").onClick(async () => {
+          await resetGuidedTourStatus(this.plugin);
+          new Notice(
+            "Guided tour will start next time you open Work Terminal",
+          );
+        }),
+      );
 
     // Session Resume Tracking section
     containerEl.createEl("h2", { text: "Claude /resume hooks" });


### PR DESCRIPTION
## Summary
- Adds a `resetGuidedTourStatus(plugin)` helper to `GuidedTour.ts` that clears the tour completion record and sets eligibility to true, enabling the tour to auto-start on next view open
- Adds a "Reset guided tour" button in the Core settings section of `SettingsTab.ts` that calls the helper and shows a confirmation Notice
- Includes test coverage for both the reset helper and the settings button

## Test plan
- [x] `npx vitest run` - all 465 tests pass
- [x] `npm run build` - clean build
- [ ] Manual: open settings, click "Reset", verify Notice appears, reopen Work Terminal view and confirm tour starts

Fixes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)