### PR TITLE
Keep sessions alive when tab is closed - stash instead of dispose

### DIFF
--- a/src/framework/MainView.test.ts
+++ b/src/framework/MainView.test.ts
@@ -34,15 +34,19 @@ vi.mock("./PromptBox", () => ({
 
 vi.mock("./SettingsTab", () => ({
   loadAllSettings: vi.fn(),
+  SETTINGS_CHANGED_EVENT: "work-terminal:settings-changed",
 }));
 
 vi.mock("./PluginBase", () => ({
   VIEW_TYPE: "work-terminal-view",
 }));
 
+const { sessionStoreIsReloadMock } = vi.hoisted(() => ({
+  sessionStoreIsReloadMock: vi.fn(() => false),
+}));
 vi.mock("../core/session/SessionStore", () => ({
   SessionStore: {
-    isReload: vi.fn(() => false),
+    isReload: sessionStoreIsReloadMock,
   },
 }));
 
@@ -272,5 +276,156 @@ describe("MainView selection ID backfill", () => {
     await (view as any).refreshList();
 
     expect(listPanel.render).toHaveBeenCalledWith({ todo: [] }, { todo: ["uuid-123"] });
+  });
+});
+
+describe("MainView stash-on-close (keepSessionsAlive)", () => {
+  let dom: JSDOM;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStoreIsReloadMock.mockReturnValue(false);
+    dom = new JSDOM("<!doctype html><html><body></body></html>");
+    vi.stubGlobal("window", dom.window);
+    vi.stubGlobal("document", dom.window.document);
+    vi.stubGlobal("HTMLElement", dom.window.HTMLElement);
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    dom.window.close();
+  });
+
+  function makeView(settings: Record<string, unknown> = {}) {
+    const view = new MainView(
+      {} as any,
+      {} as any,
+      { isReloading: false } as any,
+    );
+    (view as any).settings = { "core.keepSessionsAlive": true, ...settings };
+    return view;
+  }
+
+  function makeTerminalPanel() {
+    return {
+      persistSessions: vi.fn().mockResolvedValue(undefined),
+      stashAll: vi.fn(),
+      disposeAll: vi.fn(),
+      hasAnySessions: vi.fn(() => true),
+    };
+  }
+
+  it("stashes sessions instead of disposing when keepSessionsAlive is enabled", async () => {
+    const view = makeView({ "core.keepSessionsAlive": true });
+    const terminalPanel = makeTerminalPanel();
+    (view as any).terminalPanel = terminalPanel;
+    (view as any).listPanel = { dispose: vi.fn() };
+    (view as any).vaultEventRefs = [];
+    (view as any).pendingRenames = new Map();
+    (view as any).adapter = {};
+
+    await view.onClose();
+
+    expect(terminalPanel.persistSessions).toHaveBeenCalled();
+    expect(terminalPanel.stashAll).toHaveBeenCalled();
+    expect(terminalPanel.disposeAll).not.toHaveBeenCalled();
+  });
+
+  it("disposes sessions when keepSessionsAlive is disabled", async () => {
+    const view = makeView({ "core.keepSessionsAlive": false });
+    const terminalPanel = makeTerminalPanel();
+    (view as any).terminalPanel = terminalPanel;
+    (view as any).listPanel = { dispose: vi.fn() };
+    (view as any).vaultEventRefs = [];
+    (view as any).pendingRenames = new Map();
+    (view as any).adapter = {};
+
+    await view.onClose();
+
+    expect(terminalPanel.persistSessions).toHaveBeenCalled();
+    expect(terminalPanel.disposeAll).toHaveBeenCalled();
+    expect(terminalPanel.stashAll).not.toHaveBeenCalled();
+  });
+
+  it("defaults to stashing when keepSessionsAlive setting is absent", async () => {
+    const view = makeView({});
+    // Remove the setting entirely to test the default
+    delete (view as any).settings["core.keepSessionsAlive"];
+    const terminalPanel = makeTerminalPanel();
+    (view as any).terminalPanel = terminalPanel;
+    (view as any).listPanel = { dispose: vi.fn() };
+    (view as any).vaultEventRefs = [];
+    (view as any).pendingRenames = new Map();
+    (view as any).adapter = {};
+
+    await view.onClose();
+
+    expect(terminalPanel.stashAll).toHaveBeenCalled();
+    expect(terminalPanel.disposeAll).not.toHaveBeenCalled();
+  });
+
+  it("does not double-stash if SessionStore already has stashed data", async () => {
+    sessionStoreIsReloadMock.mockReturnValue(true);
+    const view = makeView({ "core.keepSessionsAlive": true });
+    const terminalPanel = makeTerminalPanel();
+    (view as any).terminalPanel = terminalPanel;
+    (view as any).listPanel = { dispose: vi.fn() };
+    (view as any).vaultEventRefs = [];
+    (view as any).pendingRenames = new Map();
+    (view as any).adapter = {};
+
+    await view.onClose();
+
+    expect(terminalPanel.stashAll).not.toHaveBeenCalled();
+    expect(terminalPanel.persistSessions).toHaveBeenCalled();
+  });
+
+  it("skips close guard confirmation when keepSessionsAlive is enabled", () => {
+    const view = makeView({ "core.keepSessionsAlive": true });
+    const terminalPanel = makeTerminalPanel();
+    (view as any).terminalPanel = terminalPanel;
+
+    const origDetach = vi.fn();
+    const leaf = { detach: origDetach };
+    (view as any).leaf = leaf;
+    (view as any)._origLeafDetach = origDetach;
+
+    // Install the close guard
+    (view as any).installCloseGuard();
+
+    // Spy on confirm - should NOT be called
+    const confirmSpy = vi.spyOn(dom.window, "confirm" as any).mockReturnValue(false);
+    vi.stubGlobal("confirm", confirmSpy);
+
+    // Trigger detach
+    leaf.detach();
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(origDetach).toHaveBeenCalled();
+  });
+
+  it("shows close guard confirmation when keepSessionsAlive is disabled", () => {
+    const view = makeView({ "core.keepSessionsAlive": false });
+    const terminalPanel = makeTerminalPanel();
+    (view as any).terminalPanel = terminalPanel;
+
+    const origDetach = vi.fn();
+    const leaf = { detach: origDetach };
+    (view as any).leaf = leaf;
+    (view as any)._origLeafDetach = origDetach;
+
+    // Install the close guard
+    (view as any).installCloseGuard();
+
+    const confirmSpy = vi.fn().mockReturnValue(true);
+    vi.stubGlobal("confirm", confirmSpy);
+
+    // Trigger detach
+    leaf.detach();
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(origDetach).toHaveBeenCalled();
   });
 });

--- a/src/framework/MainView.ts
+++ b/src/framework/MainView.ts
@@ -17,7 +17,7 @@ import { VIEW_TYPE } from "./PluginBase";
 import { ListPanel } from "./ListPanel";
 import { TerminalPanelView } from "./TerminalPanelView";
 import { PromptBox } from "./PromptBox";
-import { loadAllSettings } from "./SettingsTab";
+import { loadAllSettings, SETTINGS_CHANGED_EVENT } from "./SettingsTab";
 import { SessionStore } from "../core/session/SessionStore";
 import { mergeAndSavePluginData } from "../core/PluginDataStore";
 import { extractYamlFrontmatterString } from "../core/frontmatter";
@@ -67,6 +67,11 @@ export class MainView extends ItemView {
   private _beforeUnloadHandler: ((e: BeforeUnloadEvent) => void) | null = null;
   private _origLeafDetach: (() => void) | null = null;
 
+  // Settings change handler - keeps this.settings in sync
+  private readonly _handleSettingsChanged = (event: Event) => {
+    this.settings = { ...(event as CustomEvent<Record<string, any>>).detail };
+  };
+
   constructor(
     leaf: WorkspaceLeaf,
     adapter: AdapterBundle,
@@ -106,6 +111,9 @@ export class MainView extends ItemView {
 
     // Intercept tab close to confirm when active sessions exist
     this.installCloseGuard();
+
+    // Listen for settings changes to keep cached settings current
+    window.addEventListener(SETTINGS_CHANGED_EVENT, this._handleSettingsChanged as EventListener);
 
     // Warn on app quit with active sessions
     this._beforeUnloadHandler = (e: BeforeUnloadEvent) => {
@@ -180,12 +188,16 @@ export class MainView extends ItemView {
         return;
       }
 
-      // Check for active sessions
+      // Check for active sessions - skip confirmation when stash-on-close
+      // is enabled since sessions will be preserved in memory
       if (this.terminalPanel?.hasAnySessions()) {
-        const confirmed = confirm(
-          "This tab has active terminal sessions. Closing will end them.\n\nClose anyway?",
-        );
-        if (!confirmed) return;
+        const keepAlive = this.settings["core.keepSessionsAlive"] ?? true;
+        if (!keepAlive) {
+          const confirmed = confirm(
+            "This tab has active terminal sessions. Closing will end them.\n\nClose anyway?",
+          );
+          if (!confirmed) return;
+        }
       }
 
       this._origLeafDetach?.();
@@ -588,7 +600,13 @@ export class MainView extends ItemView {
     // subsequent cleanup (detaching detail view, unregistering events)
     // can trigger selection changes that reset activeItemId to null.
     // Skip stash if already stashed by hotReload() (sessions would be empty).
-    if (this.pluginRef.isReloading) {
+    const keepAlive = this.settings["core.keepSessionsAlive"] ?? true;
+    if (this.pluginRef.isReloading || keepAlive) {
+      // Stash sessions to window-global store so PTY processes survive
+      // and can be restored when the view is reopened.
+      // Always persist to disk as a fallback (e.g. if Obsidian quits
+      // before the tab is reopened, the window-global stash is lost).
+      await this.terminalPanel?.persistSessions();
       // Only stash if not already stashed (hotReload pre-stashes explicitly)
       if (!SessionStore.isReload()) {
         this.terminalPanel?.stashAll();
@@ -600,6 +618,9 @@ export class MainView extends ItemView {
     }
 
     this.listPanel?.dispose();
+
+    // Stop listening for settings changes
+    window.removeEventListener(SETTINGS_CHANGED_EVENT, this._handleSettingsChanged as EventListener);
 
     // Detach adapter's detail leaf
     this.adapter.detachDetailView?.();

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -32,6 +32,7 @@ interface CoreSettings {
   "core.defaultShell": string;
   "core.defaultTerminalCwd": string;
   "core.exposeDebugApi": boolean;
+  "core.keepSessionsAlive": boolean;
   "core.acceptNoResumeHooks": boolean;
 }
 
@@ -59,6 +60,7 @@ const CORE_DEFAULTS: CoreSettings = {
   "core.defaultShell": process.env.SHELL || "/bin/zsh",
   "core.defaultTerminalCwd": "~",
   "core.exposeDebugApi": false,
+  "core.keepSessionsAlive": true,
   "core.acceptNoResumeHooks": false,
 };
 
@@ -140,6 +142,12 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
       "core.defaultTerminalCwd",
       "Default terminal CWD",
       "Working directory for new terminals (supports ~)",
+    );
+    this.addCoreToggle(
+      containerEl,
+      "core.keepSessionsAlive",
+      "Keep sessions alive when tab is closed",
+      "Stash terminal sessions to memory instead of killing them when the Work Terminal tab is closed. Reopening the tab restores sessions with full PTY state. Sessions are also persisted to disk as a fallback.",
     );
     this.addCoreToggle(
       containerEl,


### PR DESCRIPTION
## Summary

- Adds `core.keepSessionsAlive` setting (default: enabled) that stashes terminal sessions to the window-global store when the Work Terminal tab is closed, preserving live PTY processes for seamless restoration on reopen
- Disk persistence still runs alongside the stash as a fallback for cases where Obsidian quits before the tab is reopened
- Close guard confirmation dialog is skipped when stash-on-close is enabled since sessions are not lost
- When the setting is disabled, existing behavior is preserved (persist to disk, dispose, confirm on close)

## Test plan

- [x] 6 new unit tests covering stash-on-close behavior (stash vs dispose, default, double-stash prevention, close guard skip/show)
- [x] All 471 existing tests pass
- [x] Build succeeds
- [ ] Manual: enable setting (default), close Work Terminal tab, reopen - sessions should restore with full PTY state
- [ ] Manual: disable setting, close tab - should show confirmation dialog and kill sessions on confirm
- [ ] Manual: enable setting, close tab, quit Obsidian, reopen - disk fallback should allow resume/relaunch

Fixes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)