### PR TITLE
Fix URL link clicks failing to open in terminals

### DIFF
--- a/src/core/terminal/TerminalTab.test.ts
+++ b/src/core/terminal/TerminalTab.test.ts
@@ -338,6 +338,36 @@ describe("TerminalTab hot-reload addon handling", () => {
     expect(terminal.options.linkHandler).toBe(existingHandler);
   });
 
+  it("backfills linkHandler on show() for live terminals missing the handler", () => {
+    const tab = Object.assign(Object.create(TerminalTab.prototype), {
+      terminal: {
+        options: {} as Record<string, unknown>,
+        refresh: vi.fn(),
+        scrollToBottom: vi.fn(),
+        focus: vi.fn(),
+        rows: 24,
+      },
+      containerEl: {
+        removeClass: vi.fn(),
+        hasClass: vi.fn(() => false),
+        querySelectorAll: vi.fn(() => []),
+      },
+      _isDisposed: false,
+      fitAddon: { fit: vi.fn() },
+    }) as TerminalTab;
+
+    tab.show();
+
+    const handler = (tab as any).terminal.options.linkHandler as {
+      activate: (e: MouseEvent, uri: string) => void;
+    };
+    expect(handler).toBeDefined();
+    expect(typeof handler.activate).toBe("function");
+
+    handler.activate({} as MouseEvent, "https://example.com");
+    expect(mocks.electronShell.openExternal).toHaveBeenCalledWith("https://example.com");
+  });
+
   it("disposes the custom link provider before terminal teardown", () => {
     const order: string[] = [];
     const tab = Object.assign(Object.create(TerminalTab.prototype), {

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -697,6 +697,16 @@ export class TerminalTab {
   }
 
   show(): void {
+    // Backfill linkHandler for already-live terminals that were created before
+    // the Electron openExternal handler was added (pre-#156 fix). Without this,
+    // OSC 8 link clicks fall through to xterm's confirm() + window.open() no-op.
+    if (this.terminal.options && !this.terminal.options.linkHandler) {
+      this.terminal.options.linkHandler = {
+        activate: (_event: MouseEvent, uri: string) => {
+          openUrlViaElectron(uri);
+        },
+      };
+    }
     this.containerEl.removeClass("hidden");
     // Double-rAF: first frame makes the element visible and triggers layout,
     // second frame has correct dimensions for fitAddon to measure.


### PR DESCRIPTION
## Summary

- Terminals restored from hot-reload stash (or upgraded from a prior plugin version before the #156 linkHandler fix) retained a Terminal options object without `linkHandler` set. xterm's `OscLinkProvider` falls back to `confirm()` + `window.open()` when `linkHandler` is null, and `window.open()` is a no-op in Electron - producing the confirm dialog described in #168 but never actually opening the URL.
- Extracted `openUrlViaElectron()` helper with try-catch and promise rejection logging, shared by both the OSC 8 `linkHandler` and the `WebLinksAddon` handler.
- `fromStored()` now backfills `linkHandler` on restored terminals when the option is missing.

## Test plan

- [x] Added test: restored terminal without linkHandler gets one backfilled
- [x] Added test: restored terminal with existing linkHandler is preserved
- [x] All 473 tests pass
- [x] Production build succeeds

Fixes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)