### PR TITLE
Reduce task card title padding

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -174,7 +174,7 @@
 /* Card title */
 .wt-card-title {
   font-weight: 500;
-  padding-right: 84px;
+  padding-right: 24px;
   margin-bottom: 4px;
 }
 


### PR DESCRIPTION
## Summary
- Reduced `.wt-card-title` right padding from 84px to 24px
- 24px provides enough space for the single consistently-visible session activity indicator
- Transient indicators can overflow on top of the title text without issue

Fixes #170

## Test plan
- [x] All 474 tests pass
- [x] Build succeeds
- [ ] Visual check: task cards show reduced blank space to the right of titles
- [ ] Verify session activity indicator still displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)