### PR TITLE
Add graceful Python 3 availability check on first terminal spawn

### DIFF
--- a/src/core/terminal/PythonCheck.test.ts
+++ b/src/core/terminal/PythonCheck.test.ts
@@ -8,6 +8,8 @@ import { resolveCommandInfo } from "../agents/AgentLauncher";
 import {
   checkPython3Available,
   resetPython3Cache,
+  hasPython3BeenNotified,
+  markPython3Notified,
   PYTHON3_MISSING_MESSAGE,
 } from "./PythonCheck";
 
@@ -19,18 +21,18 @@ describe("PythonCheck", () => {
     vi.clearAllMocks();
   });
 
-  it("returns true when python3 is found on PATH", () => {
+  it("returns the resolved path when python3 is found", () => {
     mockResolveCommandInfo.mockReturnValue({
       requested: "python3",
       resolved: "/usr/bin/python3",
       found: true,
     });
 
-    expect(checkPython3Available()).toBe(true);
+    expect(checkPython3Available()).toBe("/usr/bin/python3");
     expect(mockResolveCommandInfo).toHaveBeenCalledWith("python3", undefined, undefined);
   });
 
-  it("returns false when python3 is not found", () => {
+  it("returns null when python3 is not found", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     mockResolveCommandInfo.mockReturnValue({
       requested: "python3",
@@ -38,21 +40,21 @@ describe("PythonCheck", () => {
       found: false,
     });
 
-    expect(checkPython3Available()).toBe(false);
-    expect(warnSpy).toHaveBeenCalledWith("[work-terminal] python3 not found on PATH");
+    expect(checkPython3Available()).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith("[work-terminal] python3 not found on augmented PATH");
     warnSpy.mockRestore();
   });
 
-  it("caches the result and does not re-check on subsequent calls", () => {
+  it("caches a positive result and does not re-check on subsequent calls", () => {
     mockResolveCommandInfo.mockReturnValue({
       requested: "python3",
       resolved: "/usr/bin/python3",
       found: true,
     });
 
-    checkPython3Available();
-    checkPython3Available();
-    checkPython3Available();
+    expect(checkPython3Available()).toBe("/usr/bin/python3");
+    expect(checkPython3Available()).toBe("/usr/bin/python3");
+    expect(checkPython3Available()).toBe("/usr/bin/python3");
 
     expect(mockResolveCommandInfo).toHaveBeenCalledTimes(1);
   });
@@ -65,8 +67,8 @@ describe("PythonCheck", () => {
       found: false,
     });
 
-    expect(checkPython3Available()).toBe(false);
-    expect(checkPython3Available()).toBe(false);
+    expect(checkPython3Available()).toBeNull();
+    expect(checkPython3Available()).toBeNull();
     expect(mockResolveCommandInfo).toHaveBeenCalledTimes(1);
   });
 
@@ -78,7 +80,7 @@ describe("PythonCheck", () => {
     });
     vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    expect(checkPython3Available()).toBe(false);
+    expect(checkPython3Available()).toBeNull();
     resetPython3Cache();
 
     mockResolveCommandInfo.mockReturnValue({
@@ -87,7 +89,7 @@ describe("PythonCheck", () => {
       found: true,
     });
 
-    expect(checkPython3Available()).toBe(true);
+    expect(checkPython3Available()).toBe("/usr/local/bin/python3");
     expect(mockResolveCommandInfo).toHaveBeenCalledTimes(2);
   });
 
@@ -107,5 +109,23 @@ describe("PythonCheck", () => {
     expect(PYTHON3_MISSING_MESSAGE).toContain("Python 3");
     expect(PYTHON3_MISSING_MESSAGE).toContain("python3");
     expect(PYTHON3_MISSING_MESSAGE).toContain("PATH");
+  });
+
+  describe("notification de-duplication", () => {
+    it("starts not-notified", () => {
+      expect(hasPython3BeenNotified()).toBe(false);
+    });
+
+    it("tracks notification state via markPython3Notified()", () => {
+      markPython3Notified();
+      expect(hasPython3BeenNotified()).toBe(true);
+    });
+
+    it("resets notification state along with cache", () => {
+      markPython3Notified();
+      expect(hasPython3BeenNotified()).toBe(true);
+      resetPython3Cache();
+      expect(hasPython3BeenNotified()).toBe(false);
+    });
   });
 });

--- a/src/core/terminal/PythonCheck.ts
+++ b/src/core/terminal/PythonCheck.ts
@@ -9,28 +9,47 @@ import { resolveCommandInfo, type ResolveCommandInfoDeps } from "../agents/Agent
 export const PYTHON3_MISSING_MESSAGE =
   "Python 3 is required for terminal tabs. Install Python 3.7+ and ensure `python3` is on your PATH.";
 
-let cachedResult: boolean | null = null;
+let cachedResult: { resolvedPath: string } | false | null = null;
+let notified = false;
 
 /**
- * Check whether `python3` is available on PATH.
- * Returns true if found, false otherwise. Result is cached for the session.
+ * Check whether `python3` is available on the augmented PATH
+ * (includes common tool directories like /opt/homebrew/bin).
+ *
+ * Returns the resolved absolute path when found, or null if missing.
+ * The result is cached for the session lifetime.
  */
-export function checkPython3Available(deps?: ResolveCommandInfoDeps): boolean {
+export function checkPython3Available(deps?: ResolveCommandInfoDeps): string | null {
   if (cachedResult !== null) {
-    return cachedResult;
+    return cachedResult === false ? null : cachedResult.resolvedPath;
   }
   const result = resolveCommandInfo("python3", undefined, deps);
-  cachedResult = result.found;
-  if (!result.found) {
-    console.warn("[work-terminal] python3 not found on PATH");
+  if (result.found) {
+    cachedResult = { resolvedPath: result.resolved };
+    return result.resolved;
   }
-  return cachedResult;
+  cachedResult = false;
+  console.warn("[work-terminal] python3 not found on augmented PATH");
+  return null;
 }
 
 /**
- * Reset the cached result. Useful for testing or if the user installs Python
- * mid-session and wants to retry.
+ * Returns true if a missing-python Notice has already been shown this session.
+ * Call `markPython3Notified()` after showing the Notice.
+ */
+export function hasPython3BeenNotified(): boolean {
+  return notified;
+}
+
+export function markPython3Notified(): void {
+  notified = true;
+}
+
+/**
+ * Reset the cached result and notification flag. Useful for testing or if the
+ * user installs Python mid-session and wants to retry.
  */
 export function resetPython3Cache(): void {
   cachedResult = null;
+  notified = false;
 }

--- a/src/core/terminal/TerminalTab.test.ts
+++ b/src/core/terminal/TerminalTab.test.ts
@@ -116,7 +116,9 @@ vi.mock("obsidian", () => ({
 }));
 
 vi.mock("./PythonCheck", () => ({
-  checkPython3Available: vi.fn(() => true),
+  checkPython3Available: vi.fn(() => "/usr/bin/python3"),
+  hasPython3BeenNotified: vi.fn(() => false),
+  markPython3Notified: vi.fn(),
   PYTHON3_MISSING_MESSAGE:
     "Python 3 is required for terminal tabs. Install Python 3.7+ and ensure `python3` is on your PATH.",
 }));

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -17,7 +17,12 @@ import { expandTilde, stripAnsi, electronRequire } from "../utils";
 import { injectXtermCss } from "./XtermCss";
 import { attachScrollButton } from "./ScrollButton";
 import { attachBubbleCapture, attachCapturePhase } from "./KeyboardCapture";
-import { checkPython3Available, PYTHON3_MISSING_MESSAGE } from "./PythonCheck";
+import {
+  checkPython3Available,
+  hasPython3BeenNotified,
+  markPython3Notified,
+  PYTHON3_MISSING_MESSAGE,
+} from "./PythonCheck";
 import {
   type AgentRuntimeState,
   type StoredSession,
@@ -265,14 +270,18 @@ export class TerminalTab {
       const cols = this.terminal.cols || 80;
       const rows = this.terminal.rows || 24;
       try {
-        if (!checkPython3Available()) {
+        const python3Path = checkPython3Available();
+        if (!python3Path) {
           console.error("[work-terminal] python3 not found - cannot spawn PTY");
           this.terminal.write(`\r\n[${PYTHON3_MISSING_MESSAGE}]\r\n`);
-          new Notice(PYTHON3_MISSING_MESSAGE, 10_000);
+          if (!hasPython3BeenNotified()) {
+            new Notice(PYTHON3_MISSING_MESSAGE, 10_000);
+            markPython3Notified();
+          }
           return;
         }
         this.spawnTime = Date.now();
-        const proc = this.spawnPty(cols, rows, command);
+        const proc = this.spawnPty(cols, rows, command, python3Path);
         console.log("[work-terminal] Spawned pid:", proc.pid, "cols:", cols, "rows:", rows);
         this.process = proc;
         this.wireProcess(proc);
@@ -619,17 +628,22 @@ export class TerminalTab {
   // PTY spawn
   // ---------------------------------------------------------------------------
 
-  private spawnPty(cols: number, rows: number, command?: string[]): ChildProcess {
+  private spawnPty(
+    cols: number,
+    rows: number,
+    command?: string[],
+    python3Path = "python3",
+  ): ChildProcess {
     const cp = electronRequire("child_process") as typeof import("child_process");
     const wrapperPath = resolvePtyWrapperPath(this.pluginDir);
 
     const cmd = command || [this.shell, "-i"];
     const args = [wrapperPath, String(cols), String(rows), "--", ...cmd];
 
-    console.log("[work-terminal] Spawning via pty-wrapper:", args.join(" "));
+    console.log("[work-terminal] Spawning via pty-wrapper:", python3Path, args.join(" "));
     console.log("[work-terminal] cwd:", this.cwd);
 
-    const proc = cp.spawn("python3", args, {
+    const proc = cp.spawn(python3Path, args, {
       cwd: this.cwd,
       stdio: ["pipe", "pipe", "pipe"],
       env: {


### PR DESCRIPTION
## Summary

- Adds a one-time `python3` PATH check before spawning `pty-wrapper.py`, cached per session
- Shows a clear Obsidian Notice (10s duration) and terminal message when Python 3 is missing, replacing the cryptic ENOENT error
- Reuses existing `resolveCommandInfo` from `AgentLauncher.ts` for PATH-based binary resolution

## Implementation

- New `PythonCheck.ts` module in `src/core/terminal/` with `checkPython3Available()` (cached) and `resetPython3Cache()`
- Check runs in `TerminalTab`'s `spawnWithFit()` before the `spawnPty()` call
- 7 new unit tests for PythonCheck (caching, reset, deps passthrough, message content)
- Updated TerminalTab test mocks for the new `obsidian` and `PythonCheck` dependencies

Fixes #173

## Test plan

- [x] `npx vitest run` - all 481 tests pass
- [x] `npm run build` - clean production build
- [ ] Manual: remove python3 from PATH, open a terminal tab, verify Notice appears with install guidance
- [ ] Manual: with python3 available, verify terminals spawn normally with no extra delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)