### PR TITLE
Prevent task card badges from wrapping text internally

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -181,6 +181,7 @@
 /* Card meta row */
 .wt-card-meta {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 6px;
   font-size: 11px;
@@ -198,6 +199,7 @@
   font-weight: 600;
   text-transform: uppercase;
   color: var(--text-muted);
+  white-space: nowrap;
 }
 
 /* Jira source badge - uses task color if set, otherwise Jira blue */
@@ -1301,6 +1303,7 @@ button.wt-spawn-claude-ctx:hover svg {
   background: linear-gradient(90deg, #7c3aed, #a855f7);
   color: white;
   letter-spacing: 0.03em;
+  white-space: nowrap;
   animation: wt-ingesting-pulse 1.5s ease-in-out infinite;
 }
 


### PR DESCRIPTION
## Summary
- Add `white-space: nowrap` to `.wt-card-source` and `.wt-card-ingesting`/`.wt-card-ingesting-badge` so individual badge text stays on one line
- Add `flex-wrap: wrap` to `.wt-card-meta` so badges wrap as whole units when the card is narrow
- `.wt-card-goal` already had `white-space: nowrap`

Closes #182

## Test plan
- [ ] Resize the kanban columns narrow enough that badges would need to wrap
- [ ] Verify source badges (e.g. Jira keys), ingesting badges, and goal tags each stay on a single line
- [ ] Verify the badge row wraps badges onto a new line as whole units rather than breaking mid-badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)