### PR TITLE
Fix double-click rename on non-active tabs

### DIFF
--- a/src/framework/TerminalPanelView.test.ts
+++ b/src/framework/TerminalPanelView.test.ts
@@ -2588,8 +2588,9 @@ describe("TerminalPanelView hook warning", () => {
     const secondTab = panelEl.querySelectorAll(".wt-tab")[1] as HTMLElement;
     const secondLabel = secondTab.querySelector(".wt-tab-label") as HTMLElement;
 
-    // Simulate browser behavior: click fires first, then dblclick
-    secondTab.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
+    // Simulate real browser behavior: click, click, dblclick
+    secondTab.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true, detail: 1 }));
+    secondTab.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true, detail: 2 }));
     secondLabel.dispatchEvent(new dom.window.MouseEvent("dblclick", { bubbles: true }));
 
     // The delayed switch should have been cancelled

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -412,9 +412,14 @@ export class TerminalPanelView {
         const labelEl = tabEl.createSpan({ cls: "wt-tab-label", text: tab.label });
 
         // Click to switch (delayed to allow double-click cancellation)
-        tabEl.addEventListener("click", () => {
+        tabEl.addEventListener("click", (event) => {
           if (this.isRenameActive()) return;
           if (i === activeIdx) return;
+          if ((event as MouseEvent).detail > 1) return;
+          if (this.tabClickTimer !== null) {
+            clearTimeout(this.tabClickTimer);
+            this.tabClickTimer = null;
+          }
           this.tabClickTimer = setTimeout(() => {
             this.tabClickTimer = null;
             this.tabManager.switchToTab(i);
@@ -430,7 +435,12 @@ export class TerminalPanelView {
             this.tabClickTimer = null;
           }
           // Switch to the target tab first without re-rendering
-          if (i !== activeIdx) this.tabManager.switchToTab(i);
+          if (i !== activeIdx) {
+            const currentActive = tabEl.parentElement?.querySelector(".wt-tab-active");
+            if (currentActive) currentActive.removeClass("wt-tab-active");
+            tabEl.addClass("wt-tab-active");
+            this.tabManager.switchToTab(i);
+          }
           this.startTabRename(tabEl, labelEl, tab, i);
         });
 


### PR DESCRIPTION
## Summary
- Delay tab click handler by 250ms so a subsequent double-click can cancel it, preventing the DOM destruction that made rename mode unreachable on non-active tabs
- Double-click handler clears the pending timer, switches to the target tab without re-rendering, then enters rename mode on the original label element
- Clean up pending timer on view disposal

## Test plan
- [x] Existing 501 tests pass (including updated tab-click test that now accounts for the delay)
- [x] New test: single-click on non-active tab switches after 250ms delay
- [x] New test: double-click on non-active tab cancels the delayed switch and enters rename mode (switchToTab called exactly once, rename input present)
- [x] `npm run build` succeeds

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)