### PR TITLE
Fix promptBuilder.build crash on context session launch

### DIFF
--- a/src/framework/TerminalPanelView.test.ts
+++ b/src/framework/TerminalPanelView.test.ts
@@ -3476,4 +3476,41 @@ describe("profile launch", () => {
       "No agent profiles configured. Open Settings to create one.",
     );
   });
+
+  it("calls promptBuilder.buildPrompt (not .build) for context profiles", async () => {
+    const promptBuilder = {
+      buildPrompt: vi.fn(() => "adapter prompt"),
+    };
+    const { view } = createView({}, {}, promptBuilder);
+    await flushAsync();
+
+    mockState.activeItemId = "task-1";
+    (view as any).allItems = [
+      { id: "task-1", title: "Task", state: "doing", path: "Tasks/task-1.md" },
+    ];
+    (view as any).profileManager = {
+      resolveCommand: () => "copilot",
+      resolveCwd: () => "~/projects",
+      resolveArguments: () => "",
+      resolveContextPrompt: () => "Context for $title",
+    };
+
+    const spawnCopilotSpy = vi
+      .spyOn(view as any, "spawnCopilotSession")
+      .mockResolvedValue(undefined);
+
+    await (view as any).spawnFromProfile(
+      makeProfile({
+        agentType: "copilot",
+        useContext: true,
+        contextPrompt: "Context for $title",
+      }),
+    );
+
+    expect(promptBuilder.buildPrompt).toHaveBeenCalledOnce();
+    expect(spawnCopilotSpy).toHaveBeenCalledOnce();
+    const callArgs = spawnCopilotSpy.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("adapter prompt");
+    expect(callArgs.prompt).toContain("Context for Task");
+  });
 });

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -1204,7 +1204,10 @@ export class TerminalPanelView {
       const contextTemplate = this.profileManager.resolveContextPrompt(profile, fresh);
       if (contextTemplate) {
         // Build from adapter prompt + profile context template
-        const adapterPrompt = this.promptBuilder.build(item);
+        const adapterPrompt = this.promptBuilder.buildPrompt(
+          item,
+          this.resolveWorkItemPath(item.path),
+        );
         // Defer $sessionId in context template too
         const expandedContext = this.expandProfilePlaceholders(contextTemplate, item, "$sessionId");
         prompt = adapterPrompt ? adapterPrompt + "\n\n" + expandedContext : expandedContext;


### PR DESCRIPTION
## Summary
- `spawnFromProfile` called `this.promptBuilder.build(item)` which doesn't exist on the `WorkItemPromptBuilder` interface - the correct method is `buildPrompt(item, fullPath)`
- This caused "this.promptBuilder.build is not a function" when launching any context session (e.g. Copilot (ctx)) via the profile-based spawn path
- Added regression test verifying `buildPrompt` is called and adapter prompt is included in context session output

Fixes #210