### PR TITLE
Fix #213: Remove quoted paths from split task prompt

### DIFF
--- a/src/framework/ListPanel.ts
+++ b/src/framework/ListPanel.ts
@@ -439,13 +439,15 @@ export class ListPanel {
       const sourceFullPath = `${vaultBase}/${sourceItem.path}`;
       const newFullPath = `${vaultBase}/${result.path}`;
 
-      // Build the split-scoping prompt
+      // Build the split-scoping prompt.
+      // Paths are NOT quoted to avoid Claude including literal quote characters
+      // in tool parameters (causes "Invalid tool parameters" errors).
       const prompt =
-        `Read the task file at "${sourceFullPath}". ` +
-        `A new split task has been created at "${newFullPath}" as a sub-scope of the original. ` +
+        `Read the original task file at ${sourceFullPath} and the new split task file at ${newFullPath}. ` +
+        `The new file was created as a sub-scope of the original. ` +
         `Ask the user what the scope of this new split task should be. ` +
-        `Once the user answers, immediately update the new task file: ` +
-        `set the title, write a brief description with relevant context and references from the original task, ` +
+        `Once the user answers, update the new task file in place: ` +
+        `set the title, write a brief description with relevant context from the original task, ` +
         `and log the scope in the activity log. ` +
         `Then rename the file to match the convention TASK-YYYYMMDD-HHMM-slugified-title.md ` +
         `(use the existing date prefix, replace the "pending-XXXXXXXX" segment with a slug of the final title).`;


### PR DESCRIPTION
## Summary

- Removed double-quote wrapping around file paths in the split task prompt, which could cause Claude to include literal quote characters in tool parameters (e.g. `file_path: '"/path/to/file"'` instead of `/path/to/file`), leading to "Invalid tool parameters" errors
- Clarified prompt to read both source and new task files upfront for better context

## Root cause

The split-scoping prompt embedded file paths like `"${sourceFullPath}"` with surrounding double quotes. When Claude parsed this prompt text, it could include the literal `"` characters in the `file_path` parameter of Read/Edit tool calls. Since paths starting with `"` are not valid absolute paths, Claude Code rejected them with "Invalid tool parameters".

The enrichment prompt in `BackgroundEnrich.ts` already used bare paths (no quotes) and did not have this issue.

## Test plan

- [x] All 578 tests pass
- [x] Build succeeds
- [ ] Manual: split a task and verify Claude reads both files without tool parameter errors