### PR TITLE
Fix tab color indicator misaligned when agent is active

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -675,7 +675,7 @@
   pointer-events: none;
 }
 
-.wt-tab-agent-active > * {
+.wt-tab-agent-active > *:not(.wt-tab-color-indicator) {
   position: relative;
   z-index: 1;
 }


### PR DESCRIPTION
## Summary

- Fixes CSS specificity bug where `.wt-tab-agent-active > *` overrode `position: absolute` on `.wt-tab-color-indicator`, pulling it out of its pinned top-left position into normal flow
- Uses `:not(.wt-tab-color-indicator)` exclusion so the indicator keeps its absolute positioning while other children still get `position: relative; z-index: 1`

Fixes #221

## Test plan

- [ ] Open a work item with an active agent session
- [ ] Verify the tab color indicator triangle is pinned to the top-left corner
- [ ] Verify the animated agent-active border still renders correctly around the tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)