### PR TITLE
Store profile ID in persisted and recently-closed sessions

### DIFF
--- a/src/core/session/RecentlyClosedStore.test.ts
+++ b/src/core/session/RecentlyClosedStore.test.ts
@@ -247,6 +247,60 @@ describe("RecentlyClosedStore", () => {
     expect(restored[0].profileColor).toBe("#3498db");
   });
 
+  it("preserves profileId through add and serialize", () => {
+    const entry = makeEntry({
+      sessionType: "claude",
+      claudeSessionId: "session-1",
+      label: "Claude",
+      recoveryMode: "resume",
+      profileId: "profile-abc",
+      profileColor: "#e67e22",
+    });
+    store.add(entry);
+
+    const serialized = store.serialize();
+    expect(serialized).toHaveLength(1);
+    expect(serialized[0].profileId).toBe("profile-abc");
+    expect(serialized[0].profileColor).toBe("#e67e22");
+  });
+
+  it("round-trips profileId through serialize and fromData", () => {
+    const entry = makeEntry({
+      sessionType: "shell",
+      claudeSessionId: null,
+      durableSessionId: "durable-shell-1",
+      label: "Shell",
+      recoveryMode: "relaunch",
+      command: "/bin/zsh",
+      commandArgs: undefined,
+      profileId: "profile-xyz",
+      profileColor: "#3498db",
+    });
+    store.add(entry);
+
+    const serialized = store.serialize();
+    const restored = RecentlyClosedStore.fromData(serialized);
+    expect(restored).toHaveLength(1);
+    expect(restored[0].profileId).toBe("profile-xyz");
+    expect(restored[0].profileColor).toBe("#3498db");
+  });
+
+  it("does not include profileId when not set", () => {
+    const entry = makeEntry({
+      sessionType: "shell",
+      claudeSessionId: null,
+      durableSessionId: "durable-shell-1",
+      label: "Shell",
+      recoveryMode: "relaunch",
+      command: "/bin/zsh",
+      commandArgs: undefined,
+    });
+    store.add(entry);
+
+    const serialized = store.serialize();
+    expect(serialized[0].profileId).toBeUndefined();
+  });
+
   it("does not include profileColor when not set", () => {
     const entry = makeEntry({
       sessionType: "shell",

--- a/src/core/session/RecentlyClosedStore.ts
+++ b/src/core/session/RecentlyClosedStore.ts
@@ -3,6 +3,7 @@
  * so users can restore them from the custom session spawner dialog.
  */
 import { isSessionType, type DurableRecoveryMode, type SessionType } from "./types";
+import { PARAM_PASS_MODES, type ParamPassMode } from "../agents/AgentProfile";
 
 export interface ClosedSessionEntry {
   sessionType: SessionType;
@@ -17,7 +18,9 @@ export interface ClosedSessionEntry {
   cwd?: string;
   command?: string;
   commandArgs?: string[];
+  profileId?: string;
   profileColor?: string;
+  paramPassMode?: ParamPassMode;
 }
 
 export interface RecentlyClosedState {
@@ -174,6 +177,7 @@ export class RecentlyClosedStore {
     const commandArgs = Array.isArray(candidate.commandArgs)
       ? candidate.commandArgs.filter((value): value is string => typeof value === "string")
       : undefined;
+    const profileId = typeof candidate.profileId === "string" ? candidate.profileId : undefined;
     const profileColor =
       typeof candidate.profileColor === "string" ? candidate.profileColor : undefined;
 
@@ -208,6 +212,7 @@ export class RecentlyClosedStore {
       cwd,
       command,
       commandArgs,
+      profileId,
       profileColor,
     };
   }

--- a/src/core/session/SessionPersistence.test.ts
+++ b/src/core/session/SessionPersistence.test.ts
@@ -27,6 +27,7 @@ function makePersisted(
     commandArgs: string[] | undefined;
     durableSessionId: string;
     durableSessionIdGenerated: boolean;
+    profileId: string;
     profileColor: string;
   }> = {},
 ) {
@@ -43,6 +44,7 @@ function makePersisted(
     command: overrides.command ?? "claude",
     commandArgs: overrides.commandArgs ?? ["claude", "--resume", "session-1"],
     durableSessionIdGenerated: overrides.durableSessionIdGenerated,
+    profileId: overrides.profileId,
     profileColor: overrides.profileColor,
   };
 }
@@ -398,6 +400,54 @@ describe("SessionPersistence", () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].profileColor).toBe("#3498db");
+    });
+
+    it("round-trips profileId through save and load", async () => {
+      const plugin = createMockPlugin();
+      const sessions = new Map<string, any[]>();
+      sessions.set("task-1", [
+        {
+          isResumableAgent: true,
+          agentSessionId: "s1",
+          label: "Claude",
+          taskPath: "task-1",
+          sessionType: "claude",
+          launchShell: "claude",
+          launchCwd: "/vault",
+          launchCommandArgs: ["claude", "--resume", "s1"],
+          profileId: "profile-abc",
+          profileColor: "#e67e22",
+        },
+      ]);
+
+      await SessionPersistence.saveToDisk(plugin, sessions);
+      const result = await SessionPersistence.loadFromDisk(plugin);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].profileId).toBe("profile-abc");
+      expect(result[0].profileColor).toBe("#e67e22");
+    });
+
+    it("omits profileId when not set on the tab", async () => {
+      const plugin = createMockPlugin();
+      const sessions = new Map<string, any[]>();
+      sessions.set("task-1", [
+        {
+          isResumableAgent: false,
+          agentSessionId: null,
+          label: "Shell",
+          taskPath: "task-1",
+          sessionType: "shell",
+          launchShell: "/bin/zsh",
+          launchCwd: "/vault",
+        },
+      ]);
+
+      await SessionPersistence.saveToDisk(plugin, sessions);
+      const result = await SessionPersistence.loadFromDisk(plugin);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].profileId).toBeUndefined();
     });
 
     it("drops entries with invalid disk session types", async () => {

--- a/src/core/session/SessionPersistence.ts
+++ b/src/core/session/SessionPersistence.ts
@@ -15,6 +15,7 @@ import {
   type SessionType,
 } from "./types";
 import { mergeAndSavePluginData, type PluginDataStore } from "../PluginDataStore";
+import { PARAM_PASS_MODES, type ParamPassMode } from "../agents/AgentProfile";
 
 /** Tab-like interface for extracting persistable data. */
 interface PersistableTab {
@@ -28,7 +29,9 @@ interface PersistableTab {
   launchShell: string;
   launchCwd: string;
   launchCommandArgs?: string[];
+  profileId?: string;
   profileColor?: string;
+  paramPassMode?: ParamPassMode;
 }
 
 /** 7 days in milliseconds */
@@ -65,7 +68,9 @@ export class SessionPersistence {
       cwd: tab.launchCwd,
       command: tab.launchCommandArgs?.[0] || tab.launchShell,
       commandArgs: tab.launchCommandArgs ? [...tab.launchCommandArgs] : undefined,
+      profileId: tab.profileId,
       profileColor: tab.profileColor,
+      paramPassMode: tab.paramPassMode,
     };
   }
 
@@ -107,8 +112,14 @@ export class SessionPersistence {
     const durableSessionId =
       typeof candidate.durableSessionId === "string" ? candidate.durableSessionId : undefined;
     const durableSessionIdGenerated = candidate.durableSessionIdGenerated === true;
+    const profileId = typeof candidate.profileId === "string" ? candidate.profileId : undefined;
     const profileColor =
       typeof candidate.profileColor === "string" ? candidate.profileColor : undefined;
+    const paramPassMode = (PARAM_PASS_MODES as readonly string[]).includes(
+      candidate.paramPassMode as string,
+    )
+      ? (candidate.paramPassMode as ParamPassMode)
+      : undefined;
     const recoveryMode =
       candidate.recoveryMode === "resume" || candidate.recoveryMode === "relaunch"
         ? candidate.recoveryMode
@@ -153,7 +164,9 @@ export class SessionPersistence {
       cwd,
       command,
       commandArgs,
+      profileId,
       profileColor,
+      paramPassMode,
     };
   }
 

--- a/src/core/session/types.ts
+++ b/src/core/session/types.ts
@@ -8,6 +8,7 @@ import type { WebLinksAddon } from "@xterm/addon-web-links";
 import type { Unicode11Addon } from "@xterm/addon-unicode11";
 import type { WebglAddon } from "@xterm/addon-webgl";
 import type { ChildProcess } from "child_process";
+import type { ParamPassMode } from "../agents/AgentProfile";
 
 export const SESSION_TYPES = [
   "shell",
@@ -37,7 +38,9 @@ export interface StoredSession {
   claudeSessionId?: string | null;
   durableSessionId?: string | null;
   sessionType: SessionType;
+  profileId?: string;
   profileColor?: string;
+  paramPassMode?: ParamPassMode;
   shell?: string;
   cwd?: string;
   commandArgs?: string[];
@@ -73,7 +76,9 @@ export interface PersistedSession {
   cwd?: string;
   command?: string;
   commandArgs?: string[];
+  profileId?: string;
   profileColor?: string;
+  paramPassMode?: ParamPassMode;
 }
 
 export interface ActiveTabInfo {

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -102,7 +102,9 @@ export class TerminalTab {
   agentSessionId: string | null = null;
   durableSessionId: string | null = null;
   sessionType: SessionType;
+  profileId: string | undefined;
   profileColor: string | undefined;
+  paramPassMode: import("../agents/AgentProfile").ParamPassMode | undefined;
 
   terminal: Terminal;
   containerEl: HTMLElement;
@@ -1006,6 +1008,7 @@ export class TerminalTab {
       claudeSessionId: this.claudeSessionId,
       durableSessionId: this.durableSessionId,
       sessionType: this.sessionType,
+      profileId: this.profileId,
       profileColor: this.profileColor,
       shell: this.shell,
       cwd: this.cwd,
@@ -1044,6 +1047,7 @@ export class TerminalTab {
       stored.durableSessionId ||
       (tab.agentSessionId ? null : globalThis.crypto?.randomUUID?.() || null);
     tab.sessionType = stored.sessionType;
+    tab.profileId = stored.profileId;
     tab.profileColor = stored.profileColor;
     tab.shell = stored.shell || process.env.SHELL || "/bin/zsh";
     tab.cwd = stored.cwd || process.env.HOME || "~";

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -813,6 +813,7 @@ export class TerminalPanelView {
         cwd: tab.launchCwd,
         command: tab.launchCommandArgs?.[0] || tab.launchShell,
         commandArgs: tab.launchCommandArgs,
+        profileId: tab.profileId,
         profileColor: tab.profileColor,
       };
     }
@@ -833,6 +834,7 @@ export class TerminalPanelView {
       cwd: tab.launchCwd,
       command,
       commandArgs: tab.launchCommandArgs,
+      profileId: tab.profileId,
       profileColor: tab.profileColor,
     };
   }
@@ -1257,7 +1259,10 @@ export class TerminalPanelView {
     if (profile.agentType === "shell") {
       const expandedCwd = expandTilde(cwd);
       const tab = this.tabManager.createTab(command, expandedCwd, label, "shell");
-      if (tab && profile.button.color) tab.profileColor = profile.button.color;
+      if (tab) {
+        tab.profileId = profile.id;
+        if (profile.button.color) tab.profileColor = profile.button.color;
+      }
       this.renderTabBar();
       return;
     }
@@ -1329,16 +1334,15 @@ export class TerminalPanelView {
         break;
     }
 
-    // Apply profile color to the newly created tab
-    if (profile.button.color) {
-      const activeItemId = this.tabManager.getActiveItemId();
-      if (activeItemId) {
-        const tabs = this.tabManager.getTabs(activeItemId);
-        const lastTab = tabs[tabs.length - 1];
-        if (lastTab) {
-          lastTab.profileColor = profile.button.color;
-          this.renderTabBar();
-        }
+    // Apply profile metadata to the newly created tab
+    const activeItemId = this.tabManager.getActiveItemId();
+    if (activeItemId) {
+      const tabs = this.tabManager.getTabs(activeItemId);
+      const lastTab = tabs[tabs.length - 1];
+      if (lastTab) {
+        lastTab.profileId = profile.id;
+        if (profile.button.color) lastTab.profileColor = profile.button.color;
+        this.renderTabBar();
       }
     }
   }
@@ -1408,7 +1412,15 @@ export class TerminalPanelView {
 
     if (!tab) return;
 
-    if (persisted.profileColor) {
+    if (persisted.profileId) {
+      tab.profileId = persisted.profileId;
+      const profile = this.profileManager?.getProfile(persisted.profileId);
+      if (profile?.button.color) {
+        tab.profileColor = profile.button.color;
+      } else if (persisted.profileColor) {
+        tab.profileColor = persisted.profileColor;
+      }
+    } else if (persisted.profileColor) {
       tab.profileColor = persisted.profileColor;
     }
 
@@ -2038,7 +2050,15 @@ export class TerminalPanelView {
       return;
     }
 
-    if (claimedEntry.profileColor) {
+    if (claimedEntry.profileId) {
+      tab.profileId = claimedEntry.profileId;
+      const profile = this.profileManager?.getProfile(claimedEntry.profileId);
+      if (profile?.button.color) {
+        tab.profileColor = profile.button.color;
+      } else if (claimedEntry.profileColor) {
+        tab.profileColor = claimedEntry.profileColor;
+      }
+    } else if (claimedEntry.profileColor) {
       tab.profileColor = claimedEntry.profileColor;
     }
 


### PR DESCRIPTION
## Summary

- Add `profileId` to `StoredSession`, `PersistedSession`, `ClosedSessionEntry`, and `PersistableTab` interfaces
- Store the originating profile ID when spawning sessions from profiles (`spawnFromProfile`)
- On resume/restore, look up the profile by ID to use its current config (e.g. color); fall back to stored `profileColor` if the profile has been deleted
- Add normalize/round-trip support in `SessionPersistence` and `RecentlyClosedStore`
- Add tests for profileId persistence in both `SessionPersistence.test.ts` and `RecentlyClosedStore.test.ts`

Closes #219

## Test plan

- [x] All 583 existing tests pass
- [x] Build succeeds
- [ ] Manual: spawn a session from a profile, close/reopen plugin, verify profile ID is restored
- [ ] Manual: delete a profile, resume a session that used it, verify graceful fallback to stored color

🤖 Generated with [Claude Code](https://claude.com/claude-code)