### PR TITLE
Replace hardcoded agent-type resume logic with profile-driven config

### DIFF
--- a/src/core/agents/AgentLauncher.ts
+++ b/src/core/agents/AgentLauncher.ts
@@ -2,6 +2,7 @@
  * CLI launch helpers: PATH augmentation, command resolution, and agent argument builders.
  */
 import { expandTilde, electronRequire } from "../utils";
+import { type AgentType, getResumeConfig } from "./AgentProfile";
 
 const EXTRA_PATH_DIRS = [
   "~/.local/bin",
@@ -10,8 +11,7 @@ const EXTRA_PATH_DIRS = [
   "/opt/homebrew/bin",
 ];
 
-const DEFAULT_WINDOWS_PATHEXT =
-  ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC";
+const DEFAULT_WINDOWS_PATHEXT = ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC";
 
 type FsModule = typeof import("fs");
 type PathModule = typeof import("path");
@@ -193,9 +193,7 @@ export function resolveCommandInfo(
     };
   }
   const delimiter = getPathDelimiter(pathModule, platform);
-  const pathDirs = augmentPath(env, pathModule, platform)
-    .split(delimiter)
-    .filter(Boolean);
+  const pathDirs = augmentPath(env, pathModule, platform).split(delimiter).filter(Boolean);
   for (const dir of pathDirs) {
     const pathVariant = getPathVariant(pathModule, dir, platform);
     const full = pathVariant.join(dir, expanded);
@@ -215,12 +213,10 @@ export function resolveCommand(cmd: string): string {
   return resolveCommandInfo(cmd).resolved;
 }
 
-export function buildMissingCliNotice(agent: "claude" | "copilot", command: string): string {
-  const normalized = command.trim() || (agent === "claude" ? "claude" : "copilot");
-  if (agent === "claude") {
-    return `Claude Code CLI not found for "${normalized}". Install it first, for example with brew install --cask claude-code, then update Work Terminal's Claude command setting if needed.`;
-  }
-  return `GitHub Copilot CLI not found for "${normalized}". Install it first, for example with brew install copilot-cli, then update Work Terminal's Copilot command setting if needed.`;
+export function buildMissingCliNotice(agent: AgentType, command: string): string {
+  const config = getResumeConfig(agent);
+  const normalized = command.trim() || config.defaultCommand || agent;
+  return `${config.cliDisplayName} not found for "${normalized}". ${config.installHint}`;
 }
 
 export function splitConfiguredCommand(command: string): string[] {

--- a/src/core/agents/AgentProfile.test.ts
+++ b/src/core/agents/AgentProfile.test.ts
@@ -10,6 +10,8 @@ import {
   createDefaultClaudeCtxProfile,
   createDefaultCopilotProfile,
   getBuiltInProfiles,
+  getResumeConfig,
+  isResumableAgentType,
 } from "./AgentProfile";
 
 describe("agentTypeToSessionType", () => {
@@ -157,6 +159,52 @@ describe("BRAND_COLORS", () => {
   it("does not define colors for non-branded icons", () => {
     expect(BRAND_COLORS.terminal).toBeUndefined();
     expect(BRAND_COLORS.bee).toBeUndefined();
+  });
+});
+
+describe("getResumeConfig", () => {
+  it("returns resumable config for claude", () => {
+    const config = getResumeConfig("claude");
+    expect(config.resumable).toBe(true);
+    expect(config.sessionTracking).toBe(true);
+    expect(config.resumeFlagFormat).toBe("flag-space");
+    expect(config.resumeFlag).toBe("--resume");
+    expect(config.commandSettingKey).toBe("core.claudeCommand");
+    expect(config.defaultCommand).toBe("claude");
+    expect(config.extraArgsSettingKey).toBe("core.claudeExtraArgs");
+  });
+
+  it("returns resumable config for copilot with equals format", () => {
+    const config = getResumeConfig("copilot");
+    expect(config.resumable).toBe(true);
+    expect(config.sessionTracking).toBe(false);
+    expect(config.resumeFlagFormat).toBe("flag-equals");
+    expect(config.resumeFlag).toBe("--resume");
+    expect(config.commandSettingKey).toBe("core.copilotCommand");
+    expect(config.defaultCommand).toBe("copilot");
+  });
+
+  it("returns non-resumable config for strands", () => {
+    const config = getResumeConfig("strands");
+    expect(config.resumable).toBe(false);
+    expect(config.sessionTracking).toBe(false);
+  });
+
+  it("returns non-resumable config for shell", () => {
+    const config = getResumeConfig("shell");
+    expect(config.resumable).toBe(false);
+  });
+});
+
+describe("isResumableAgentType", () => {
+  it("returns true for claude and copilot", () => {
+    expect(isResumableAgentType("claude")).toBe(true);
+    expect(isResumableAgentType("copilot")).toBe(true);
+  });
+
+  it("returns false for strands and shell", () => {
+    expect(isResumableAgentType("strands")).toBe(false);
+    expect(isResumableAgentType("shell")).toBe(false);
   });
 });
 

--- a/src/core/agents/AgentProfile.ts
+++ b/src/core/agents/AgentProfile.ts
@@ -125,6 +125,94 @@ export const AgentProfileArraySchema = z.array(AgentProfileSchema);
 export { AgentProfileSchema };
 
 // ---------------------------------------------------------------------------
+// Resume configuration per agent type
+// ---------------------------------------------------------------------------
+
+export interface AgentResumeConfig {
+  /** Whether this agent type supports session resume. */
+  resumable: boolean;
+  /** Whether this agent type supports session ID tracking (watching for /resume). */
+  sessionTracking: boolean;
+  /** How the resume flag is formatted: "flag-space" = --resume ID, "flag-equals" = --resume=ID */
+  resumeFlagFormat: "flag-space" | "flag-equals";
+  /** The resume flag name (e.g. "--resume"). */
+  resumeFlag: string;
+  /** Global settings key for the command (e.g. "core.claudeCommand"). */
+  commandSettingKey: string;
+  /** Default command name when no setting is configured. */
+  defaultCommand: string;
+  /** Global settings key for extra args (e.g. "core.claudeExtraArgs"). */
+  extraArgsSettingKey: string;
+  /** Human-readable name for CLI-not-found notices. */
+  cliDisplayName: string;
+  /** Install hint for CLI-not-found notices. */
+  installHint: string;
+}
+
+const AGENT_RESUME_CONFIGS: Record<AgentType, AgentResumeConfig> = {
+  claude: {
+    resumable: true,
+    sessionTracking: true,
+    resumeFlagFormat: "flag-space",
+    resumeFlag: "--resume",
+    commandSettingKey: "core.claudeCommand",
+    defaultCommand: "claude",
+    extraArgsSettingKey: "core.claudeExtraArgs",
+    cliDisplayName: "Claude Code CLI",
+    installHint:
+      "Install it first, for example with brew install --cask claude-code, then update Work Terminal's Claude command setting if needed.",
+  },
+  copilot: {
+    resumable: true,
+    sessionTracking: false,
+    resumeFlagFormat: "flag-equals",
+    resumeFlag: "--resume",
+    commandSettingKey: "core.copilotCommand",
+    defaultCommand: "copilot",
+    extraArgsSettingKey: "core.copilotExtraArgs",
+    cliDisplayName: "GitHub Copilot CLI",
+    installHint:
+      "Install it first, for example with brew install copilot-cli, then update Work Terminal's Copilot command setting if needed.",
+  },
+  strands: {
+    resumable: false,
+    sessionTracking: false,
+    resumeFlagFormat: "flag-space",
+    resumeFlag: "--resume",
+    commandSettingKey: "core.strandsCommand",
+    defaultCommand: "strands",
+    extraArgsSettingKey: "core.strandsExtraArgs",
+    cliDisplayName: "Strands agent",
+    installHint: "Configure the Strands command in Work Terminal settings.",
+  },
+  shell: {
+    resumable: false,
+    sessionTracking: false,
+    resumeFlagFormat: "flag-space",
+    resumeFlag: "",
+    commandSettingKey: "core.defaultShell",
+    defaultCommand: "",
+    extraArgsSettingKey: "",
+    cliDisplayName: "Shell",
+    installHint: "",
+  },
+};
+
+/**
+ * Get resume configuration for an agent type.
+ */
+export function getResumeConfig(agentType: AgentType): AgentResumeConfig {
+  return AGENT_RESUME_CONFIGS[agentType];
+}
+
+/**
+ * Check whether an agent type supports session resume.
+ */
+export function isResumableAgentType(agentType: AgentType): boolean {
+  return AGENT_RESUME_CONFIGS[agentType].resumable;
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 

--- a/src/core/session/types.ts
+++ b/src/core/session/types.ts
@@ -8,7 +8,11 @@ import type { WebLinksAddon } from "@xterm/addon-web-links";
 import type { Unicode11Addon } from "@xterm/addon-unicode11";
 import type { WebglAddon } from "@xterm/addon-webgl";
 import type { ChildProcess } from "child_process";
-import type { ParamPassMode } from "../agents/AgentProfile";
+import {
+  type ParamPassMode,
+  sessionTypeToAgentType,
+  isResumableAgentType,
+} from "../agents/AgentProfile";
 
 export const SESSION_TYPES = [
   "shell",
@@ -161,10 +165,6 @@ export function isSessionType(value: unknown): value is SessionType {
 }
 
 export function isResumableSessionType(sessionType: SessionType): boolean {
-  return (
-    sessionType === "claude" ||
-    sessionType === "claude-with-context" ||
-    sessionType === "copilot" ||
-    sessionType === "copilot-with-context"
-  );
+  const { agentType } = sessionTypeToAgentType(sessionType);
+  return isResumableAgentType(agentType);
 }

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -33,7 +33,11 @@ import {
 } from "../session/types";
 import { AgentSessionTracker } from "../agents/AgentSessionTracker";
 import { hasAgentActiveIndicator, hasAgentWaitingIndicator } from "../agents/AgentStateDetector";
-import type { ParamPassMode } from "../agents/AgentProfile";
+import {
+  type ParamPassMode,
+  sessionTypeToAgentType,
+  getResumeConfig,
+} from "../agents/AgentProfile";
 
 export type AgentState = AgentRuntimeState;
 export type ClaudeState = AgentState;
@@ -881,18 +885,18 @@ export class TerminalTab {
     this._stateTimer = setInterval(() => this._checkState(), 2000);
   }
 
-  /** Initialize session tracker for Claude sessions with a known session ID. */
+  /** Initialize session tracker for agent sessions that support session tracking. */
   private _initSessionTracker(): void {
-    if (
-      (this.sessionType === "claude" || this.sessionType === "claude-with-context") &&
-      this.agentSessionId
-    ) {
-      this._sessionTracker = new AgentSessionTracker(this.cwd, this.agentSessionId);
-      this._sessionTracker.onSessionChange = (newId) => {
-        this.agentSessionId = newId;
-        console.log("[work-terminal] Session ID updated via /resume:", newId);
-      };
-    }
+    if (!this.agentSessionId) return;
+    const { agentType } = sessionTypeToAgentType(this.sessionType);
+    const resumeConfig = getResumeConfig(agentType);
+    if (!resumeConfig.sessionTracking) return;
+
+    this._sessionTracker = new AgentSessionTracker(this.cwd, this.agentSessionId);
+    this._sessionTracker.onSessionChange = (newId) => {
+      this.agentSessionId = newId;
+      console.log("[work-terminal] Session ID updated via /resume:", newId);
+    };
   }
 
   private _detectResumableAgent(): boolean {

--- a/src/framework/TerminalPanelView.test.ts
+++ b/src/framework/TerminalPanelView.test.ts
@@ -2110,7 +2110,7 @@ describe("TerminalPanelView hook warning", () => {
     expect(mockState.notices).toContain("Session diagnostics copied to clipboard");
   });
 
-  it("keeps Copilot tabs out of the Claude-only restart menu action", async () => {
+  it("shows restart menu action for all resumable agent tabs including Copilot", async () => {
     const { view } = createView();
     await flushAsync();
 
@@ -2124,7 +2124,7 @@ describe("TerminalPanelView hook warning", () => {
     );
 
     expect(mockState.menuTitles).toContain("Rename");
-    expect(mockState.menuTitles).not.toContain("Restart");
+    expect(mockState.menuTitles).toContain("Restart");
   });
 
   it("keeps the restart menu action available for Claude tabs", async () => {

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -41,8 +41,12 @@ import { SETTINGS_CHANGED_EVENT } from "./SettingsTab";
 import { getDefaultSessionLabel, isClaudeSession } from "./CustomSessionConfig";
 import type { AgentProfileManager } from "../core/agents/AgentProfileManager";
 import { PROFILES_CHANGED_EVENT } from "../core/agents/AgentProfileManager";
-import type { AgentProfile, ParamPassMode } from "../core/agents/AgentProfile";
-import { agentTypeToSessionType } from "../core/agents/AgentProfile";
+import type { AgentProfile, AgentType, ParamPassMode } from "../core/agents/AgentProfile";
+import {
+  agentTypeToSessionType,
+  sessionTypeToAgentType,
+  getResumeConfig,
+} from "../core/agents/AgentProfile";
 import { createProfileIcon } from "../ui/ProfileIcons";
 
 interface WorkTerminalDebugSnapshot {
@@ -704,10 +708,10 @@ export class TerminalPanelView {
       });
     });
 
-    if (isClaudeSession(tab.sessionType)) {
+    if (isResumableSessionType(tab.sessionType)) {
       menu.addItem((item) => {
         item.setTitle("Restart").onClick(() => {
-          this.launchAction("Claude restart", () => this.restartClaudeTab(tab, index));
+          this.launchAction("Agent restart", () => this.restartAgentTab(tab, index));
         });
       });
     }
@@ -1416,6 +1420,7 @@ export class TerminalPanelView {
               sessionId: this.getPersistedSessionId(persisted) || "",
               freshSettings: fresh,
               paramPassMode: persisted.paramPassMode,
+              profileId: persisted.profileId,
               ...this.getSavedResumeLaunchContext(persisted),
             })
           : null;
@@ -1481,41 +1486,51 @@ export class TerminalPanelView {
     resolvedCommand?: string;
     extraArgs?: string[];
     paramPassMode?: ParamPassMode;
+    profileId?: string;
   }): TerminalTab | null {
-    const isCopilot =
-      options.sessionType === "copilot" || options.sessionType === "copilot-with-context";
-    const agent = isCopilot ? "copilot" : "claude";
+    const { agentType } = sessionTypeToAgentType(options.sessionType);
+    const resumeConfig = getResumeConfig(agentType);
+
+    // Look up originating profile if available
+    const profile = options.profileId
+      ? this.profileManager?.getProfile(options.profileId)
+      : undefined;
+
     const configuredCwd = expandTilde(
       this.getStringSetting(options.freshSettings, "core.defaultTerminalCwd", "~"),
     );
     const cwd = options.cwd || configuredCwd;
-    const configuredCommand = this.getStringSetting(
-      options.freshSettings,
-      isCopilot ? "core.copilotCommand" : "core.claudeCommand",
-      isCopilot ? "copilot" : "claude",
-    );
+    const configuredCommand =
+      profile?.command?.trim() ||
+      this.getStringSetting(
+        options.freshSettings,
+        resumeConfig.commandSettingKey,
+        resumeConfig.defaultCommand,
+      );
     const savedResolution = options.resolvedCommand
       ? resolveCommandInfo(options.resolvedCommand, cwd)
       : null;
     const command = savedResolution?.found
       ? savedResolution.resolved
-      : this.resolveAgentCommandOrNotice(agent, configuredCommand, configuredCwd);
+      : this.resolveAgentCommandOrNotice(agentType, configuredCommand, configuredCwd);
     if (!command) {
       return null;
     }
-    const args = isCopilot ? [`--resume=${options.sessionId}`] : ["--resume", options.sessionId];
+
+    // Build resume flag based on agent type's format
+    const args =
+      resumeConfig.resumeFlagFormat === "flag-equals"
+        ? [`${resumeConfig.resumeFlag}=${options.sessionId}`]
+        : [resumeConfig.resumeFlag, options.sessionId];
+
     // When paramPassMode is "launch-only", skip stored profile args on resume
     // and fall through to global defaults only
     const passParamsOnResume =
       options.paramPassMode === "resume-only" || options.paramPassMode === "both";
-    const extraArgs = passParamsOnResume
-      ? options.extraArgs ||
-        (isCopilot
-          ? this.getStringSetting(options.freshSettings, "core.copilotExtraArgs", "")
-          : this.getStringSetting(options.freshSettings, "core.claudeExtraArgs", ""))
-      : isCopilot
-        ? this.getStringSetting(options.freshSettings, "core.copilotExtraArgs", "")
-        : this.getStringSetting(options.freshSettings, "core.claudeExtraArgs", "");
+    const globalExtraArgs = resumeConfig.extraArgsSettingKey
+      ? this.getStringSetting(options.freshSettings, resumeConfig.extraArgsSettingKey, "")
+      : "";
+    const extraArgs = passParamsOnResume ? options.extraArgs || globalExtraArgs : globalExtraArgs;
     const parsedExtraArgs = Array.isArray(extraArgs) ? extraArgs : parseExtraArgs(extraArgs);
 
     if (parsedExtraArgs.length > 0) {
@@ -1540,7 +1555,7 @@ export class TerminalPanelView {
     return tab;
   }
 
-  private async restartClaudeTab(tab: TerminalTab, _index: number): Promise<void> {
+  private async restartAgentTab(tab: TerminalTab, _index: number): Promise<void> {
     const targetItemId = tab.taskPath ?? this.tabManager.getActiveItemId();
     if (!targetItemId) return;
 
@@ -1550,8 +1565,13 @@ export class TerminalPanelView {
 
     const fresh = await this.loadFreshSettings();
     const fallbackCwd = expandTilde(this.getStringSetting(fresh, "core.defaultTerminalCwd", "~"));
+    const { agentType } = sessionTypeToAgentType(tab.sessionType);
+    const resumeConfig = getResumeConfig(agentType);
     let replacement: TerminalTab | null;
     if (tab.agentSessionId) {
+      const fallbackCommand = tab.profileId
+        ? this.profileManager?.getProfile(tab.profileId)?.command?.trim()
+        : undefined;
       replacement = this.createResumedTab({
         targetItemId,
         sessionType: tab.sessionType,
@@ -1561,9 +1581,17 @@ export class TerminalPanelView {
         cwd: tab.launchCommandArgs?.length ? tab.launchCwd : fallbackCwd,
         resolvedCommand:
           tab.launchCommandArgs?.[0] ||
-          resolveCommand(this.getStringSetting(fresh, "core.claudeCommand", "claude")),
+          resolveCommand(
+            fallbackCommand ||
+              this.getStringSetting(
+                fresh,
+                resumeConfig.commandSettingKey,
+                resumeConfig.defaultCommand,
+              ),
+          ),
         extraArgs: this.extractResumeExtraArgs(tab.sessionType, tab.launchCommandArgs),
         paramPassMode: tab.paramPassMode,
+        profileId: tab.profileId,
       });
     } else if (tab.launchCommandArgs?.length) {
       replacement = this.tabManager.createTabForItem(
@@ -1577,6 +1605,17 @@ export class TerminalPanelView {
         null,
         tab.durableSessionId,
       );
+    } else if (agentType === "copilot") {
+      replacement = null;
+      await this.spawnCopilotSession({
+        sessionType: tab.sessionType as "copilot" | "copilot-with-context",
+        cwd: fallbackCwd,
+        label: tab.label,
+        freshSettings: fresh,
+      });
+      // spawnCopilotSession doesn't return the tab, get it from the tab manager
+      const tabs = this.tabManager.getTabs(targetItemId);
+      replacement = tabs[tabs.length - 1] ?? null;
     } else {
       replacement = await this.spawnClaudeSession({
         sessionType: tab.sessionType === "claude-with-context" ? "claude-with-context" : "claude",
@@ -2062,6 +2101,7 @@ export class TerminalPanelView {
               sessionId,
               freshSettings: fresh,
               paramPassMode: claimedEntry.paramPassMode,
+              profileId: claimedEntry.profileId,
               ...this.getSavedResumeLaunchContext(claimedEntry),
             })
           : null;
@@ -2255,7 +2295,7 @@ export class TerminalPanelView {
   }
 
   private resolveAgentCommandOrNotice(
-    agent: "claude" | "copilot",
+    agent: AgentType,
     command: string,
     cwd?: string,
   ): string | null {


### PR DESCRIPTION
## Summary

- Adds `AgentResumeConfig` data structure to `AgentProfile` with per-agent-type resume settings (flag format, command keys, session tracking, CLI notices)
- Refactors `isResumableSessionType()`, `createResumedTab()`, `_initSessionTracker()`, `buildMissingCliNotice()`, and `resolveAgentCommandOrNotice()` to derive behavior from agent type config instead of hardcoded `isCopilot`/`isClaudeSession` branching
- Renames `restartClaudeTab()` to `restartAgentTab()` and broadens the "Restart" context menu to all resumable session types
- Passes `profileId` through resume paths so `createResumedTab` can look up the originating profile for command resolution
- Backward compatible: sessions without a `profileId` fall through to global settings as before

## Test plan

- [x] All 596 tests pass (6 new tests for `getResumeConfig`, `isResumableAgentType`, updated Copilot restart menu test)
- [x] Build succeeds
- [ ] Manual: resume a Claude session after plugin restart
- [ ] Manual: resume a Copilot session after plugin restart
- [ ] Manual: verify Copilot tabs now show "Restart" in context menu
- [ ] Manual: verify sessions without profileId still resume correctly

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)