### PR TITLE
Add screen-change-based activity detection for Claude sessions

### DIFF
--- a/src/core/agents/AgentStateDetector.test.ts
+++ b/src/core/agents/AgentStateDetector.test.ts
@@ -25,6 +25,33 @@ function mockTerminal(lines: string[]) {
   } as any;
 }
 
+/**
+ * Create a mock terminal whose content can be updated between polls.
+ */
+function mutableMockTerminal(initialLines: string[]) {
+  let currentLines = initialLines;
+  const terminal = {
+    buffer: {
+      active: {
+        get baseY() {
+          return 0;
+        },
+        get cursorY() {
+          return Math.max(0, currentLines.length - 1);
+        },
+        getLine: (i: number) => {
+          const text = currentLines[i];
+          return text != null ? { translateToString: (_trim?: boolean) => text } : null;
+        },
+      },
+    },
+    setLines(lines: string[]) {
+      currentLines = lines;
+    },
+  } as any;
+  return terminal;
+}
+
 describe("AgentStateDetector", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -518,6 +545,89 @@ describe("AgentStateDetector", () => {
       vi.advanceTimersByTime(2100);
       // Should be idle since the active indicator is far from the bottom
       expect(detector.state).toBe("idle");
+      detector.stop();
+    });
+  });
+
+  describe("screen-change-based active detection", () => {
+    it("detects active state when screen content changes between polls (text streaming)", () => {
+      const terminal = mutableMockTerminal(["  plain text line 1"]);
+      const detector = new AgentStateDetector(terminal, () => false);
+      detector.start();
+
+      // First poll at 2000ms: sets the baseline fingerprint, no previous to compare
+      vi.advanceTimersByTime(2100);
+      // First poll after start has no previous fingerprint, falls through to idle
+      expect(detector.state).toBe("idle");
+
+      // Change the screen content (simulates Claude streaming text)
+      terminal.setLines(["  plain text line 1", "  plain text line 2"]);
+      // Second poll at 4000ms: detects screen changed
+      vi.advanceTimersByTime(2000);
+      expect(detector.state).toBe("active");
+      detector.stop();
+    });
+
+    it("returns to idle when screen content stops changing", () => {
+      const terminal = mutableMockTerminal(["  line 1"]);
+      const detector = new AgentStateDetector(terminal, () => false);
+      detector.start();
+
+      // First poll: baseline
+      vi.advanceTimersByTime(2100);
+
+      // Change content
+      terminal.setLines(["  line 1", "  line 2"]);
+      vi.advanceTimersByTime(2000);
+      expect(detector.state).toBe("active");
+
+      // Content stops changing - next poll should go idle
+      vi.advanceTimersByTime(2000);
+      expect(detector.state).toBe("idle");
+      detector.stop();
+    });
+
+    it("does not treat the first poll as a screen change", () => {
+      const terminal = mutableMockTerminal(["  Ready for input"]);
+      const detector = new AgentStateDetector(terminal, () => false);
+      detector.start();
+
+      vi.advanceTimersByTime(2100);
+      // Should be idle, not active - first poll has no previous fingerprint
+      expect(detector.state).toBe("idle");
+      detector.stop();
+    });
+
+    it("screen change detection respects suppression grace period", () => {
+      const terminal = mutableMockTerminal(["  line 1"]);
+      const detector = new AgentStateDetector(terminal, () => false);
+      detector.start(true); // suppressActive
+
+      // First poll: baseline (within suppression)
+      vi.advanceTimersByTime(100);
+      expect(detector.state).toBe("idle");
+
+      // Still within suppression window - change content
+      terminal.setLines(["  line 1", "  line 2"]);
+      vi.advanceTimersByTime(1900); // now at 2000ms total, first interval fires
+      // Suppression ends at ~2000ms, so first check is right at boundary
+      // Either way it should not be active during suppression
+      expect(detector.state).toBe("idle");
+      detector.stop();
+    });
+
+    it("waiting state takes priority over screen changes", () => {
+      const terminal = mutableMockTerminal(["  plain text"]);
+      const detector = new AgentStateDetector(terminal, () => false);
+      detector.start();
+
+      // First poll: baseline
+      vi.advanceTimersByTime(2100);
+
+      // Change screen to show a waiting prompt
+      terminal.setLines(["  Allow this action?", "  allowOnce  denyOnce"]);
+      vi.advanceTimersByTime(2000);
+      expect(detector.state).toBe("waiting");
       detector.stop();
     });
   });

--- a/src/core/agents/AgentStateDetector.ts
+++ b/src/core/agents/AgentStateDetector.ts
@@ -35,20 +35,13 @@ function looksLikeHiddenClaudePrompt(tail: string[], questionIndex: number): boo
   const normalizedAfterQuestion = tail
     .slice(
       questionIndex + 1,
-      Math.min(
-        tail.length,
-        questionIndex + 1 + HIDDEN_CLAUDE_PROMPT_CHROME_SCAN_LINES,
-      ),
+      Math.min(tail.length, questionIndex + 1 + HIDDEN_CLAUDE_PROMPT_CHROME_SCAN_LINES),
     )
     .map((line) => normalizeWaitingLine(line))
     .filter((line) => line.length > 0);
   const promptIndex = normalizedAfterQuestion.findIndex((line) => line === "❯");
   if (promptIndex === -1) return false;
-  if (
-    normalizedAfterQuestion
-      .slice(0, promptIndex)
-      .some((line) => /^❯\s+\S/.test(line))
-  ) {
+  if (normalizedAfterQuestion.slice(0, promptIndex).some((line) => /^❯\s+\S/.test(line))) {
     return false;
   }
 
@@ -114,6 +107,8 @@ export class AgentStateDetector {
   private _timer: ReturnType<typeof setInterval> | null = null;
   private _suppressActiveUntil = 0;
   private _recentCleanLines: string[] = [];
+  private _prevScreenFingerprint = "";
+  private _unchangedPolls = 0;
   onChange?: (state: AgentState) => void;
 
   constructor(
@@ -188,6 +183,8 @@ export class AgentStateDetector {
     // Check for waiting patterns first (highest priority).
     // Suppress waiting if the tab is currently visible - the user can already see it.
     if (this._looksLikeWaiting(screenLines)) {
+      this._prevScreenFingerprint = "";
+      this._unchangedPolls = 0;
       this._setState(this.isVisible() ? "idle" : "waiting");
       return;
     }
@@ -195,9 +192,22 @@ export class AgentStateDetector {
     // Need screen content for idle/active detection
     if (screenLines.length === 0) return;
 
+    // Track buffer content changes: if the visible screen changed since the
+    // last poll, the agent is producing output (text streaming, tool results)
+    // even when no spinner/ellipsis pattern is visible.
+    const fingerprint = screenLines.join("\n");
+    const screenChanged =
+      this._prevScreenFingerprint !== "" && fingerprint !== this._prevScreenFingerprint;
+    this._prevScreenFingerprint = fingerprint;
+    if (screenChanged) {
+      this._unchangedPolls = 0;
+    } else {
+      this._unchangedPolls++;
+    }
+
     const hasActiveIndicator = hasAgentActiveIndicator(screenLines);
 
-    if (hasActiveIndicator) {
+    if (hasActiveIndicator || screenChanged) {
       // During post-reload grace period, treat "active" as "idle"
       if (Date.now() < this._suppressActiveUntil) {
         this._setState("idle");

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -149,6 +149,10 @@ export class TerminalTab {
   /** Suppress "active" detection until this timestamp (ms). Used after reload
    *  to prevent stale xterm buffer content from triggering false active state. */
   _suppressActiveUntil = 0;
+  /** Previous screen content fingerprint for change-based activity detection. */
+  private _prevScreenFingerprint = "";
+  /** How many consecutive polls the screen content has remained unchanged. */
+  private _unchangedPolls = 0;
 
   // Session tracking (/resume detection)
   private _sessionTracker: AgentSessionTracker | null = null;
@@ -947,6 +951,8 @@ export class TerminalTab {
     // Check for waiting patterns first (highest priority).
     // Suppress waiting if the tab is currently visible - the user can already see it.
     if (this._looksLikeWaiting(screenLines)) {
+      this._prevScreenFingerprint = "";
+      this._unchangedPolls = 0;
       this._setAgentState("waiting");
       return;
     }
@@ -954,9 +960,22 @@ export class TerminalTab {
     // Need screen content for idle/active detection
     if (screenLines.length === 0) return;
 
+    // Track buffer content changes: if the visible screen changed since the
+    // last poll, the agent is producing output (text streaming, tool results)
+    // even when no spinner/ellipsis pattern is visible.
+    const fingerprint = screenLines.join("\n");
+    const screenChanged =
+      this._prevScreenFingerprint !== "" && fingerprint !== this._prevScreenFingerprint;
+    this._prevScreenFingerprint = fingerprint;
+    if (screenChanged) {
+      this._unchangedPolls = 0;
+    } else {
+      this._unchangedPolls++;
+    }
+
     const hasActiveIndicator = hasAgentActiveIndicator(screenLines);
 
-    if (hasActiveIndicator) {
+    if (hasActiveIndicator || screenChanged) {
       // During post-reload grace period, treat "active" as "idle"
       if (Date.now() < this._suppressActiveUntil) {
         this._setAgentState("idle");


### PR DESCRIPTION
## Summary

- Fixes #225: Claude session activity indicators are unreliable compared to Copilot
- Adds buffer content fingerprinting to detect activity from screen changes between polls, not just spinner patterns
- Claude only shows spinners during tool execution; text streaming phases were previously invisible to the detector

## Details

The `hasAgentActiveIndicator` function only matched Claude's `✳ <text>…` spinner and `⏿ <text>…` tool output patterns, which are transient. Between tool calls (text streaming, thinking, result display), plain text output has no structural indicator. With 2s polling, the detector frequently sampled during these gaps.

The fix tracks a fingerprint of the visible screen content on each poll. If the content changed since the last poll, the agent is treated as active. This preserves all existing behavior (waiting priority, post-reload suppression, static idle screens).

## Test plan

- [ ] 5 new test cases for screen-change detection (all pass)
- [ ] All 601 existing tests pass
- [ ] Build succeeds with no type errors
- [ ] Manual verification: open a Claude session, confirm card shows activity indicator during text streaming phases (not just tool calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)