### PR TITLE
Fix activity detection false positive on tab/task switch

### DIFF
--- a/src/core/agents/AgentStateDetector.test.ts
+++ b/src/core/agents/AgentStateDetector.test.ts
@@ -630,6 +630,27 @@ describe("AgentStateDetector", () => {
       expect(detector.state).toBe("waiting");
       detector.stop();
     });
+
+    it("resetScreenFingerprint prevents false active after tab/item switch", () => {
+      const terminal = mutableMockTerminal(["  line 1"]);
+      const detector = new AgentStateDetector(terminal, () => false);
+      detector.start();
+
+      // First poll: baseline
+      vi.advanceTimersByTime(2100);
+      expect(detector.state).toBe("idle");
+
+      // Simulate a tab switch: content changes completely (different terminal)
+      terminal.setLines(["  completely different content from another tab"]);
+
+      // Reset fingerprint before the next poll (as TabManager would do)
+      detector.resetScreenFingerprint();
+
+      // Next poll: should treat this as a new baseline, not a change
+      vi.advanceTimersByTime(2000);
+      expect(detector.state).toBe("idle");
+      detector.stop();
+    });
   });
 
   describe("active suppression during grace period", () => {

--- a/src/core/agents/AgentStateDetector.ts
+++ b/src/core/agents/AgentStateDetector.ts
@@ -230,6 +230,16 @@ export class AgentStateDetector {
     return hasAgentWaitingIndicator(screenLines || [], this._recentCleanLines || []);
   }
 
+  /**
+   * Reset the screen fingerprint baseline. Call when the viewed terminal
+   * changes (tab/item switch) so the first poll compares against the new
+   * content rather than the previous terminal's content.
+   */
+  resetScreenFingerprint(): void {
+    this._prevScreenFingerprint = "";
+    this._unchangedPolls = 0;
+  }
+
   /** Clear the waiting state (e.g. when the user activates this tab). */
   clearWaiting(): void {
     if (this._state === "waiting") {

--- a/src/core/terminal/TabManager.ts
+++ b/src/core/terminal/TabManager.ts
@@ -122,6 +122,7 @@ export class TabManager {
           targetIdx = remembered;
         }
       }
+      tabs[targetIdx].resetScreenFingerprint();
       tabs[targetIdx].show();
       tabs[targetIdx].clearWaiting();
       this.activeTabIndex = targetIdx;
@@ -237,6 +238,7 @@ export class TabManager {
     if (index < 0 || index >= tabs.length) return;
 
     this.hideAllTerminals();
+    tabs[index].resetScreenFingerprint();
     tabs[index].show();
     tabs[index].clearWaiting();
     this.activeTabIndex = index;

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -997,6 +997,16 @@ export class TerminalTab {
     return hasAgentWaitingIndicator(screenLines || [], this._recentCleanLines || []);
   }
 
+  /**
+   * Reset the screen fingerprint baseline. Call when the viewed terminal
+   * changes (tab/item switch) so the first poll compares against the new
+   * content rather than the previous terminal's content.
+   */
+  resetScreenFingerprint(): void {
+    this._prevScreenFingerprint = "";
+    this._unchangedPolls = 0;
+  }
+
   /** Clear the waiting state (e.g. when the user activates this tab to respond). */
   clearWaiting(): void {
     if (this._agentState === "waiting") {


### PR DESCRIPTION
## Summary

- Fixes false "active" state triggered when switching task cards or tabs - the entire buffer content changes on switch, which the fingerprint-based activity detection (from #226) misinterpreted as agent output
- Adds `resetScreenFingerprint()` to `AgentStateDetector` and `TerminalTab`, called from `TabManager.setActiveItem()` and `switchToTab()` so the first poll after a switch uses the new terminal's content as baseline
- Adds a test verifying that fingerprint reset prevents false active detection

## Test plan

- [x] All 602 tests pass (601 existing + 1 new)
- [x] Build succeeds
- [ ] Manual: switch between task cards with running agents - state indicator should not flash "active"
- [ ] Manual: switch between tabs within a task - same behaviour

Fixes #227