### PR TITLE
Fix Claude tab scrolling to top after sending messages

### DIFF
--- a/src/core/terminal/TerminalTab.test.ts
+++ b/src/core/terminal/TerminalTab.test.ts
@@ -1264,3 +1264,151 @@ describe("TerminalTab WebGL recovery", () => {
     expect((tab as unknown as { webglAddon: unknown }).webglAddon).toBe(staleAddon);
   });
 });
+
+describe("TerminalTab auto-scroll on write", () => {
+  beforeEach(() => {
+    mocks.MockWebglAddon.instances.length = 0;
+    vi.restoreAllMocks();
+    mocks.injectXtermCss.mockClear();
+    mocks.attachScrollButton.mockClear();
+    mocks.attachBubbleCapture.mockClear();
+    mocks.attachCapturePhase.mockClear();
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe = vi.fn();
+        disconnect = vi.fn();
+      },
+    );
+    vi.stubGlobal("requestAnimationFrame", ((cb: FrameRequestCallback) => {
+      cb(0);
+      return 1;
+    }) as typeof requestAnimationFrame);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(TerminalTab.prototype as never, "startStateTracking").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  function createTabWithMockTerminal() {
+    const onDataHandlers: Array<(data: string) => void> = [];
+    const onWriteParsedHandlers: Array<() => void> = [];
+    const scrollToBottom = vi.fn();
+    const write = vi.fn(() => {
+      // Simulate xterm calling onWriteParsed after processing a write
+      for (const handler of onWriteParsedHandlers) handler();
+    });
+
+    const bufferActive = { viewportY: 100, baseY: 100 };
+
+    const terminal = {
+      onData: vi.fn((handler: (data: string) => void) => {
+        onDataHandlers.push(handler);
+      }),
+      onWriteParsed: vi.fn((handler: () => void) => {
+        onWriteParsedHandlers.push(handler);
+      }),
+      scrollToBottom,
+      write,
+      buffer: { active: bufferActive },
+    };
+
+    const tab = Object.assign(Object.create(TerminalTab.prototype), {
+      id: "term-1",
+      taskPath: "task.md",
+      label: "Shell",
+      sessionType: "shell",
+      terminal,
+      containerEl: new FakeElement(),
+      process: null,
+      _isDisposed: false,
+      _sessionTracker: null,
+      _renameDecoder: { write: () => "", end: () => "" },
+      _renameLineBuffer: "",
+      _renamePattern: /^\s*[^\w]*Session renamed to:\s*(.+?)\s*$/,
+      _recentCleanLines: [],
+    }) as TerminalTab;
+
+    return { tab, terminal, scrollToBottom, bufferActive };
+  }
+
+  function createMockProcess() {
+    const stdoutHandlers: Record<string, Array<(...args: unknown[]) => void>> = {};
+    const procHandlers: Record<string, Array<(...args: unknown[]) => void>> = {};
+    return {
+      stdout: {
+        on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+          (stdoutHandlers[event] ??= []).push(handler);
+        }),
+      },
+      stderr: { on: vi.fn() },
+      stdin: { write: vi.fn(), destroyed: false },
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        (procHandlers[event] ??= []).push(handler);
+      }),
+      killed: false,
+      exitCode: null,
+      signalCode: null,
+      emitStdout(data: Buffer) {
+        for (const handler of stdoutHandlers["data"] ?? []) handler(data);
+      },
+    };
+  }
+
+  it("auto-scrolls to bottom on stdout data when viewport is at bottom", () => {
+    const { tab, scrollToBottom, bufferActive } = createTabWithMockTerminal();
+    const proc = createMockProcess();
+
+    // viewportY === baseY means at bottom
+    bufferActive.viewportY = 100;
+    bufferActive.baseY = 100;
+
+    (tab as any).wireProcess(proc);
+    scrollToBottom.mockClear(); // clear any setup calls
+
+    proc.emitStdout(Buffer.from("hello"));
+
+    expect(scrollToBottom).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not auto-scroll when user has scrolled up", () => {
+    const { tab, scrollToBottom, bufferActive } = createTabWithMockTerminal();
+    const proc = createMockProcess();
+
+    // viewportY < baseY means user scrolled up
+    bufferActive.viewportY = 50;
+    bufferActive.baseY = 100;
+
+    (tab as any).wireProcess(proc);
+    scrollToBottom.mockClear();
+
+    proc.emitStdout(Buffer.from("hello"));
+
+    expect(scrollToBottom).not.toHaveBeenCalled();
+  });
+
+  it("resumes auto-scroll when user returns to bottom", () => {
+    const { tab, scrollToBottom, bufferActive } = createTabWithMockTerminal();
+    const proc = createMockProcess();
+
+    bufferActive.viewportY = 50;
+    bufferActive.baseY = 100;
+
+    (tab as any).wireProcess(proc);
+    scrollToBottom.mockClear();
+
+    // First write: user is scrolled up - no auto-scroll
+    proc.emitStdout(Buffer.from("hello"));
+    expect(scrollToBottom).not.toHaveBeenCalled();
+
+    // User scrolls back to bottom
+    bufferActive.viewportY = 100;
+
+    // Second write: viewport is at bottom again - should auto-scroll
+    proc.emitStdout(Buffer.from("world"));
+    expect(scrollToBottom).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -437,11 +437,31 @@ export class TerminalTab {
       }
     });
 
+    // Auto-scroll: track whether the viewport was at the bottom before each
+    // write. After xterm finishes parsing the write, scroll back to bottom if
+    // the user hadn't intentionally scrolled up. This is needed because agents
+    // like Claude Code use scroll regions and absolute cursor positioning for
+    // their status bar, which xterm.js doesn't treat as new scrollback content
+    // that should trigger auto-scroll.
+    let wasAtBottom = true;
+
+    const snapshotScrollPosition = () => {
+      const buf = this.terminal.buffer.active;
+      wasAtBottom = buf.viewportY >= buf.baseY;
+    };
+
+    this.terminal.onWriteParsed(() => {
+      if (wasAtBottom) {
+        this.terminal.scrollToBottom();
+      }
+    });
+
     proc.stdout?.on("data", (data: Buffer) => {
       if (this._isDisposed) return;
       this._checkRename(data);
       this._trackOutput(data);
       this.onOutputData?.(data);
+      snapshotScrollPosition();
       this.terminal.write(data);
     });
 
@@ -450,17 +470,20 @@ export class TerminalTab {
       this._checkRename(data);
       this._trackOutput(data);
       this.onOutputData?.(data);
+      snapshotScrollPosition();
       this.terminal.write(data);
     });
 
     proc.on("error", (err) => {
       if (this._isDisposed) return;
       console.error("[work-terminal] Process error:", err);
+      snapshotScrollPosition();
       this.terminal.write(`\r\n[Process error: ${err.message}]\r\n`);
     });
 
     proc.on("exit", (code, signal) => {
       if (this._isDisposed) return;
+      snapshotScrollPosition();
       this.terminal.write(`\r\n[Process exited (code: ${code}, signal: ${signal})]\r\n`);
       this.onProcessExit?.(code, signal);
     });


### PR DESCRIPTION
## Summary

- Fixes the viewport jumping to the top of the scrollback buffer when Claude Code (or other agents using scroll regions) writes output
- Tracks whether the viewport was at the bottom before each terminal write, and auto-scrolls via `onWriteParsed` only when the user hasn't intentionally scrolled up
- Adds 3 unit tests covering: auto-scroll when at bottom, no scroll when user scrolled up, and resuming auto-scroll when user returns to bottom

## How it works

Claude Code uses scroll regions and absolute cursor positioning for its status bar. xterm.js doesn't treat these as "new scrollback content" that should trigger auto-scroll, so `viewportY` stays at 0 while `baseY` grows.

The fix snapshots `viewportY >= baseY` (at bottom?) before each `terminal.write()`, then in the `onWriteParsed` callback scrolls to bottom only if the snapshot showed the user was at the bottom.

## Test plan

- [x] All 605 tests pass (`npx vitest run`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual: open Claude tab, send messages, verify viewport stays at bottom
- [ ] Manual: scroll up in Claude tab, verify new output does NOT force scroll to bottom
- [ ] Manual: scroll back to bottom, verify auto-scroll resumes

Fixes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)