### PR TITLE
Fix wasAtBottom race condition in auto-scroll

### DIFF
--- a/src/core/terminal/TerminalTab.test.ts
+++ b/src/core/terminal/TerminalTab.test.ts
@@ -1293,13 +1293,18 @@ describe("TerminalTab auto-scroll on write", () => {
     vi.unstubAllGlobals();
   });
 
-  function createTabWithMockTerminal() {
+  function createTabWithMockTerminal({ deferCallbacks = false } = {}) {
     const onDataHandlers: Array<(data: string) => void> = [];
-    const onWriteParsedHandlers: Array<() => void> = [];
     const scrollToBottom = vi.fn();
-    const write = vi.fn(() => {
-      // Simulate xterm calling onWriteParsed after processing a write
-      for (const handler of onWriteParsedHandlers) handler();
+    const pendingCallbacks: Array<() => void> = [];
+    const write = vi.fn((data: unknown, callback?: () => void) => {
+      if (callback) {
+        if (deferCallbacks) {
+          pendingCallbacks.push(callback);
+        } else {
+          callback();
+        }
+      }
     });
 
     const bufferActive = { viewportY: 100, baseY: 100 };
@@ -1307,9 +1312,6 @@ describe("TerminalTab auto-scroll on write", () => {
     const terminal = {
       onData: vi.fn((handler: (data: string) => void) => {
         onDataHandlers.push(handler);
-      }),
-      onWriteParsed: vi.fn((handler: () => void) => {
-        onWriteParsedHandlers.push(handler);
       }),
       scrollToBottom,
       write,
@@ -1332,7 +1334,14 @@ describe("TerminalTab auto-scroll on write", () => {
       _recentCleanLines: [],
     }) as TerminalTab;
 
-    return { tab, terminal, scrollToBottom, bufferActive };
+    /** Flush all deferred write callbacks in order */
+    const flushCallbacks = () => {
+      while (pendingCallbacks.length > 0) {
+        pendingCallbacks.shift()!();
+      }
+    };
+
+    return { tab, terminal, scrollToBottom, bufferActive, pendingCallbacks, flushCallbacks };
   }
 
   function createMockProcess() {
@@ -1409,6 +1418,35 @@ describe("TerminalTab auto-scroll on write", () => {
 
     // Second write: viewport is at bottom again - should auto-scroll
     proc.emitStdout(Buffer.from("world"));
+    expect(scrollToBottom).toHaveBeenCalledTimes(1);
+  });
+
+  it("captures per-write scroll snapshot even when callbacks are deferred", () => {
+    // Simulate real xterm async: multiple writes queue before any callback fires
+    const { tab, scrollToBottom, bufferActive, flushCallbacks } = createTabWithMockTerminal({
+      deferCallbacks: true,
+    });
+    const proc = createMockProcess();
+
+    bufferActive.viewportY = 100;
+    bufferActive.baseY = 100;
+
+    (tab as any).wireProcess(proc);
+    scrollToBottom.mockClear();
+
+    // Write 1: user is at bottom
+    proc.emitStdout(Buffer.from("chunk-1"));
+
+    // Before callback fires, user scrolls up, then write 2 arrives
+    bufferActive.viewportY = 50;
+    proc.emitStdout(Buffer.from("chunk-2"));
+
+    // No callbacks have fired yet
+    expect(scrollToBottom).not.toHaveBeenCalled();
+
+    // Now flush: write-1's callback should scroll (was at bottom),
+    // write-2's callback should not (user had scrolled up)
+    flushCallbacks();
     expect(scrollToBottom).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -437,32 +437,27 @@ export class TerminalTab {
       }
     });
 
-    // Auto-scroll: track whether the viewport was at the bottom before each
-    // write. After xterm finishes parsing the write, scroll back to bottom if
-    // the user hadn't intentionally scrolled up. This is needed because agents
-    // like Claude Code use scroll regions and absolute cursor positioning for
-    // their status bar, which xterm.js doesn't treat as new scrollback content
-    // that should trigger auto-scroll.
-    let wasAtBottom = true;
-
-    const snapshotScrollPosition = () => {
+    // Auto-scroll: snapshot whether the viewport is at the bottom before each
+    // write, then use terminal.write(data, callback) so the callback fires
+    // after that specific write is parsed. This avoids a race condition where
+    // a shared mutable flag could be overwritten by a later write before an
+    // earlier write's callback fires (which happened with onWriteParsed).
+    const writeWithAutoScroll = (data: string | Uint8Array) => {
       const buf = this.terminal.buffer.active;
-      wasAtBottom = buf.viewportY >= buf.baseY;
+      const wasAtBottom = buf.viewportY >= buf.baseY;
+      this.terminal.write(data, () => {
+        if (wasAtBottom) {
+          this.terminal.scrollToBottom();
+        }
+      });
     };
-
-    this.terminal.onWriteParsed(() => {
-      if (wasAtBottom) {
-        this.terminal.scrollToBottom();
-      }
-    });
 
     proc.stdout?.on("data", (data: Buffer) => {
       if (this._isDisposed) return;
       this._checkRename(data);
       this._trackOutput(data);
       this.onOutputData?.(data);
-      snapshotScrollPosition();
-      this.terminal.write(data);
+      writeWithAutoScroll(data);
     });
 
     proc.stderr?.on("data", (data: Buffer) => {
@@ -470,21 +465,18 @@ export class TerminalTab {
       this._checkRename(data);
       this._trackOutput(data);
       this.onOutputData?.(data);
-      snapshotScrollPosition();
-      this.terminal.write(data);
+      writeWithAutoScroll(data);
     });
 
     proc.on("error", (err) => {
       if (this._isDisposed) return;
       console.error("[work-terminal] Process error:", err);
-      snapshotScrollPosition();
-      this.terminal.write(`\r\n[Process error: ${err.message}]\r\n`);
+      writeWithAutoScroll(`\r\n[Process error: ${err.message}]\r\n`);
     });
 
     proc.on("exit", (code, signal) => {
       if (this._isDisposed) return;
-      snapshotScrollPosition();
-      this.terminal.write(`\r\n[Process exited (code: ${code}, signal: ${signal})]\r\n`);
+      writeWithAutoScroll(`\r\n[Process exited (code: ${code}, signal: ${signal})]\r\n`);
       this.onProcessExit?.(code, signal);
     });
   }


### PR DESCRIPTION
## Summary

- Replace shared mutable `wasAtBottom` flag + `onWriteParsed` listener with `terminal.write(data, callback)` pattern where each write captures its own at-bottom snapshot in a closure
- Eliminates race condition where a later `terminal.write()` could overwrite the scroll snapshot before an earlier write's `onWriteParsed` callback fires
- Add deferred-callback test that verifies per-write snapshots survive async batching (multiple writes queued before any callback fires)

Fixes #231

## Test plan

- [x] All 606 existing tests pass
- [x] New async batching test covers the race condition scenario
- [x] Production build succeeds