### PR TITLE
Revert full-width tab stacking, keep buttons-above-tabs (#235)

### DIFF
--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -543,7 +543,7 @@ export class TerminalPanelView {
       }
 
       // Temporarily remove expanded class so tabs return to natural inline size
-      // for accurate measurement (expanded mode sets max-width: none + column layout)
+      // for accurate measurement (expanded mode changes flex-direction)
       const wasExpanded = this.tabBarEl.classList.contains("wt-tab-bar-expanded");
       if (wasExpanded) {
         this.tabBarEl.removeClass("wt-tab-bar-expanded");

--- a/styles.css
+++ b/styles.css
@@ -508,39 +508,15 @@
   flex-shrink: 0;
 }
 
-/* Expanded layout: buttons above tabs, each tab gets full width */
+/* Expanded layout: move launch buttons above tabs when crowded */
 .wt-tab-bar-expanded {
   flex-direction: column-reverse;
-  align-items: stretch;
 }
 
 .wt-tab-bar-expanded .wt-tab-buttons {
   align-self: flex-start;
   padding: 4px 6px 2px;
   border-bottom: 1px solid var(--background-modifier-border);
-}
-
-.wt-tab-bar-expanded .wt-tabs-container {
-  flex-direction: column;
-  gap: 0;
-}
-
-.wt-tab-bar-expanded .wt-tab {
-  max-width: none;
-  border-radius: 0;
-  border-left: none;
-  border-right: none;
-  border-top: none;
-  border-bottom: 1px solid var(--background-modifier-border);
-}
-
-.wt-tab-bar-expanded .wt-tab:last-child {
-  border-bottom: none;
-}
-
-.wt-tab-bar-expanded .wt-tab-active {
-  border-bottom: 1px solid var(--background-modifier-border);
-  border-left: 2px solid var(--interactive-accent);
 }
 
 .wt-tab {


### PR DESCRIPTION
## Summary

- Removes the CSS that made tabs display as full-width rows (one tab per line) introduced in PR #216
- Keeps the overflow detection that moves launch buttons above tabs when space is tight
- Tabs now remain inline and wrap naturally as they did before #214

## Changes

**styles.css**: Removed `.wt-tab-bar-expanded .wt-tabs-container` (vertical column layout), `.wt-tab-bar-expanded .wt-tab` (full-width styling), `.wt-tab-bar-expanded .wt-tab:last-child`, and `.wt-tab-bar-expanded .wt-tab-active` (stacked active highlight). Kept `.wt-tab-bar-expanded` with `flex-direction: column-reverse` and the `.wt-tab-buttons` row styling.

**TerminalPanelView.ts**: Updated a stale comment in the overflow detection method.

## Test plan

- [x] All 606 tests pass
- [x] Build succeeds
- [ ] Visual check: tabs remain inline when few tabs open
- [ ] Visual check: tabs wrap naturally when many tabs open
- [ ] Visual check: launch buttons move above tabs when crowded

Fixes #235