### PR TITLE
Fix tab bar alignment in expanded layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -514,7 +514,7 @@
 }
 
 .wt-tab-bar-expanded .wt-tab-buttons {
-  align-self: flex-start;
+  align-self: flex-end;
   padding: 4px 6px 2px;
   border-bottom: 1px solid var(--background-modifier-border);
 }


### PR DESCRIPTION
## Summary

- Fix launch buttons alignment in the two-row expanded tab bar layout
- Changed `.wt-tab-bar-expanded .wt-tab-buttons` from `align-self: flex-start` to `align-self: flex-end` so session tabs remain left-aligned and launch buttons are right-aligned

Fixes #237

## Test plan

- [ ] Open plugin with enough session tabs to trigger expanded (two-row) tab bar
- [ ] Verify session tabs are left-aligned on the bottom row
- [ ] Verify launch buttons (Shell/Claude/etc) are right-aligned on the top row

🤖 Generated with [Claude Code](https://claude.com/claude-code)