### PR TITLE
Fix tab alignment: left-align session tabs in expanded tab bar

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -513,6 +513,10 @@
   flex-direction: column-reverse;
 }
 
+.wt-tab-bar-expanded .wt-tabs-container {
+  align-self: flex-start;
+}
+
 .wt-tab-bar-expanded .wt-tab-buttons {
   align-self: flex-end;
   padding: 4px 6px 2px;


### PR DESCRIPTION
## Summary

- Adds `align-self: flex-start` to `.wt-tab-bar-expanded .wt-tabs-container` so session tabs are left-aligned in the expanded two-row tab bar
- Launch buttons remain right-aligned via their existing `align-self: flex-end`
- Root cause: the parent `.wt-tab-bar` has `align-items: flex-end`, which was inherited by both rows when switching to `column-reverse`

Fixes #239

## Test plan

- [ ] Open Work Terminal with enough sessions to trigger the expanded two-row tab bar
- [ ] Verify session tabs (bottom row) are left-aligned
- [ ] Verify launch buttons (top row) are right-aligned
- [ ] Verify single-row tab bar still looks correct when few tabs are open