### PR TITLE
Fix scroll-to-top: track user-initiated scrolls only

### DIFF
--- a/src/core/terminal/ScrollButton.test.ts
+++ b/src/core/terminal/ScrollButton.test.ts
@@ -40,18 +40,18 @@ describe("attachScrollButton", () => {
     expect(onScroll).toHaveBeenCalledTimes(1);
     expect(onWriteParsed).not.toHaveBeenCalled();
     expect(containerEl.querySelector(".wt-scroll-bottom")).not.toBeNull();
-    expect((containerEl.querySelector(".wt-scroll-bottom") as HTMLButtonElement).style.display).toBe(
-      "flex",
-    );
+    expect(
+      (containerEl.querySelector(".wt-scroll-bottom") as HTMLButtonElement).style.display,
+    ).toBe("flex");
 
     terminal.buffer.active.viewportY = 5;
     const scrollHandler = onScroll.mock.calls[0][0] as () => void;
     scrollHandler();
     rafQueue.shift()?.(0);
 
-    expect((containerEl.querySelector(".wt-scroll-bottom") as HTMLButtonElement).style.display).toBe(
-      "none",
-    );
+    expect(
+      (containerEl.querySelector(".wt-scroll-bottom") as HTMLButtonElement).style.display,
+    ).toBe("none");
   });
 
   it("scrolls to bottom and focuses when clicked", () => {
@@ -82,5 +82,30 @@ describe("attachScrollButton", () => {
 
     expect(terminal.scrollToBottom).toHaveBeenCalledTimes(1);
     expect(terminal.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onScrollToBottom callback when button is clicked", () => {
+    const containerEl = document.createElement("div");
+    const viewport = document.createElement("div");
+    viewport.className = "xterm-viewport";
+    containerEl.appendChild(viewport);
+
+    const onScrollToBottom = vi.fn();
+    const terminal = {
+      buffer: { active: { viewportY: 0, baseY: 5 } },
+      onScroll: vi.fn(),
+      scrollToBottom: vi.fn(),
+      focus: vi.fn(),
+    };
+
+    attachScrollButton(containerEl, terminal as any, onScrollToBottom);
+    rafQueue.shift()?.(0);
+    const button = containerEl.querySelector(".wt-scroll-bottom") as HTMLButtonElement;
+
+    button.click();
+    rafQueue.shift()?.(0);
+
+    expect(onScrollToBottom).toHaveBeenCalledTimes(1);
+    expect(terminal.scrollToBottom).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/core/terminal/ScrollButton.ts
+++ b/src/core/terminal/ScrollButton.ts
@@ -6,7 +6,11 @@
  */
 import type { Terminal } from "@xterm/xterm";
 
-export function attachScrollButton(containerEl: HTMLElement, terminal: Terminal): void {
+export function attachScrollButton(
+  containerEl: HTMLElement,
+  terminal: Terminal,
+  onScrollToBottom?: () => void,
+): void {
   // Remove any existing button (e.g. from a previous reload)
   containerEl.querySelector(".wt-scroll-bottom")?.remove();
 
@@ -46,6 +50,7 @@ export function attachScrollButton(containerEl: HTMLElement, terminal: Terminal)
   scrollBtn.addEventListener("click", (e) => {
     e.stopPropagation();
     terminal.scrollToBottom();
+    onScrollToBottom?.();
     terminal.focus();
     scheduleVisibilityUpdate();
   });

--- a/src/core/terminal/TerminalTab.test.ts
+++ b/src/core/terminal/TerminalTab.test.ts
@@ -128,10 +128,12 @@ import { resolvePtyWrapperPath, TerminalTab } from "./TerminalTab";
 class FakeElement {
   appendChild = vi.fn();
   addEventListener = vi.fn();
+  removeEventListener = vi.fn();
   remove = vi.fn();
   hasClass = vi.fn(() => false);
   addClass = vi.fn();
   removeClass = vi.fn();
+  querySelector = vi.fn(() => null);
   querySelectorAll = vi.fn(() => []);
 }
 
@@ -219,7 +221,9 @@ describe("TerminalTab hot-reload addon handling", () => {
     const addEventListener = vi.fn();
     const containerEl = {
       addEventListener,
+      removeEventListener: vi.fn(),
       hasClass: vi.fn(() => false),
+      querySelector: vi.fn(() => null),
     };
     const parentEl = { appendChild: vi.fn() };
 
@@ -267,7 +271,12 @@ describe("TerminalTab hot-reload addon handling", () => {
         terminal: { focus: vi.fn(), scrollToBottom: vi.fn(), cols: 80 } as any,
         fitAddon: {} as any,
         searchAddon: {} as any,
-        containerEl: { addEventListener: vi.fn(), hasClass: vi.fn(() => false) } as any,
+        containerEl: {
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          hasClass: vi.fn(() => false),
+          querySelector: vi.fn(() => null),
+        } as any,
         process: null,
         webglAddon: null,
         webglContextLossListener: null,
@@ -297,7 +306,12 @@ describe("TerminalTab hot-reload addon handling", () => {
         terminal: terminal as any,
         fitAddon: {} as any,
         searchAddon: {} as any,
-        containerEl: { addEventListener: vi.fn(), hasClass: vi.fn(() => false) } as any,
+        containerEl: {
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          hasClass: vi.fn(() => false),
+          querySelector: vi.fn(() => null),
+        } as any,
         process: null,
         webglAddon: null,
         webglContextLossListener: null,
@@ -336,7 +350,12 @@ describe("TerminalTab hot-reload addon handling", () => {
         terminal: terminal as any,
         fitAddon: {} as any,
         searchAddon: {} as any,
-        containerEl: { addEventListener: vi.fn(), hasClass: vi.fn(() => false) } as any,
+        containerEl: {
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          hasClass: vi.fn(() => false),
+          querySelector: vi.fn(() => null),
+        } as any,
         process: null,
         webglAddon: null,
         webglContextLossListener: null,
@@ -614,7 +633,9 @@ describe("TerminalTab hot-reload addon handling", () => {
     const resizeObserver = { disconnect: vi.fn(), observe: vi.fn() };
     const containerEl = {
       addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
       hasClass: vi.fn(() => false),
+      querySelector: vi.fn(() => null),
       remove: vi.fn(),
     };
     const parentEl = { appendChild: vi.fn() };
@@ -1327,6 +1348,7 @@ describe("TerminalTab auto-scroll on write", () => {
       containerEl: new FakeElement(),
       process: null,
       _isDisposed: false,
+      _userScrolledUp: false,
       _sessionTracker: null,
       _renameDecoder: { write: () => "", end: () => "" },
       _renameLineBuffer: "",
@@ -1367,86 +1389,185 @@ describe("TerminalTab auto-scroll on write", () => {
     };
   }
 
-  it("auto-scrolls to bottom on stdout data when viewport is at bottom", () => {
-    const { tab, scrollToBottom, bufferActive } = createTabWithMockTerminal();
+  it("always auto-scrolls to bottom on stdout data by default", () => {
+    const { tab, scrollToBottom } = createTabWithMockTerminal();
     const proc = createMockProcess();
 
-    // viewportY === baseY means at bottom
-    bufferActive.viewportY = 100;
-    bufferActive.baseY = 100;
-
     (tab as any).wireProcess(proc);
-    scrollToBottom.mockClear(); // clear any setup calls
+    scrollToBottom.mockClear();
 
     proc.emitStdout(Buffer.from("hello"));
 
     expect(scrollToBottom).toHaveBeenCalledTimes(1);
   });
 
-  it("does not auto-scroll when user has scrolled up", () => {
-    const { tab, scrollToBottom, bufferActive } = createTabWithMockTerminal();
+  it("does not auto-scroll when _userScrolledUp flag is set", () => {
+    const { tab, scrollToBottom } = createTabWithMockTerminal();
     const proc = createMockProcess();
-
-    // viewportY < baseY means user scrolled up
-    bufferActive.viewportY = 50;
-    bufferActive.baseY = 100;
 
     (tab as any).wireProcess(proc);
     scrollToBottom.mockClear();
+
+    // Simulate user having scrolled up (set by wheel/touchmove/keydown listeners)
+    tab._userScrolledUp = true;
 
     proc.emitStdout(Buffer.from("hello"));
 
     expect(scrollToBottom).not.toHaveBeenCalled();
   });
 
-  it("resumes auto-scroll when user returns to bottom", () => {
-    const { tab, scrollToBottom, bufferActive } = createTabWithMockTerminal();
+  it("resumes auto-scroll when _userScrolledUp flag is cleared", () => {
+    const { tab, scrollToBottom } = createTabWithMockTerminal();
     const proc = createMockProcess();
-
-    bufferActive.viewportY = 50;
-    bufferActive.baseY = 100;
 
     (tab as any).wireProcess(proc);
     scrollToBottom.mockClear();
 
-    // First write: user is scrolled up - no auto-scroll
+    // User scrolled up
+    tab._userScrolledUp = true;
     proc.emitStdout(Buffer.from("hello"));
     expect(scrollToBottom).not.toHaveBeenCalled();
 
-    // User scrolls back to bottom
-    bufferActive.viewportY = 100;
-
-    // Second write: viewport is at bottom again - should auto-scroll
+    // User scrolls back to bottom (flag cleared by scroll/button handler)
+    tab._userScrolledUp = false;
     proc.emitStdout(Buffer.from("world"));
     expect(scrollToBottom).toHaveBeenCalledTimes(1);
   });
 
-  it("captures per-write scroll snapshot even when callbacks are deferred", () => {
-    // Simulate real xterm async: multiple writes queue before any callback fires
-    const { tab, scrollToBottom, bufferActive, flushCallbacks } = createTabWithMockTerminal({
+  it("auto-scrolls all deferred writes when user has not scrolled up", () => {
+    const { tab, scrollToBottom, flushCallbacks } = createTabWithMockTerminal({
       deferCallbacks: true,
     });
     const proc = createMockProcess();
 
-    bufferActive.viewportY = 100;
-    bufferActive.baseY = 100;
+    (tab as any).wireProcess(proc);
+    scrollToBottom.mockClear();
+
+    // Two writes arrive while user has not scrolled up
+    proc.emitStdout(Buffer.from("chunk-1"));
+    proc.emitStdout(Buffer.from("chunk-2"));
+
+    expect(scrollToBottom).not.toHaveBeenCalled();
+
+    // Flush all deferred callbacks - both should auto-scroll
+    flushCallbacks();
+    expect(scrollToBottom).toHaveBeenCalledTimes(2);
+  });
+
+  it("suppresses all deferred writes when user scrolls up before flush", () => {
+    const { tab, scrollToBottom, flushCallbacks } = createTabWithMockTerminal({
+      deferCallbacks: true,
+    });
+    const proc = createMockProcess();
 
     (tab as any).wireProcess(proc);
     scrollToBottom.mockClear();
 
-    // Write 1: user is at bottom
+    // Writes arrive
     proc.emitStdout(Buffer.from("chunk-1"));
-
-    // Before callback fires, user scrolls up, then write 2 arrives
-    bufferActive.viewportY = 50;
     proc.emitStdout(Buffer.from("chunk-2"));
 
-    // No callbacks have fired yet
-    expect(scrollToBottom).not.toHaveBeenCalled();
+    // User scrolls up before callbacks fire
+    tab._userScrolledUp = true;
 
-    // Now flush: write-1's callback should scroll (was at bottom),
-    // write-2's callback should not (user had scrolled up)
     flushCallbacks();
-    expect(scrollToBottom).toHaveBeenCalledTimes(1);
+    expect(scrollToBottom).not.toHaveBeenCalled();
+  });
+});
+
+describe("TerminalTab user scroll detection", () => {
+  beforeEach(() => {
+    vi.stubGlobal("requestAnimationFrame", ((cb: FrameRequestCallback) => {
+      cb(0);
+      return 1;
+    }) as typeof requestAnimationFrame);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function createTabWithViewport() {
+    const viewportEl = {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    const containerEl = {
+      querySelector: vi.fn((selector: string) =>
+        selector === ".xterm-viewport" ? viewportEl : null,
+      ),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    const bufferActive = { viewportY: 100, baseY: 100 };
+    const terminal = {
+      buffer: { active: bufferActive },
+    };
+
+    const tab = Object.assign(Object.create(TerminalTab.prototype), {
+      terminal,
+      containerEl,
+      _userScrolledUp: false,
+      _isDisposed: false,
+      _documentCleanups: [],
+    }) as TerminalTab;
+
+    return { tab, viewportEl, bufferActive };
+  }
+
+  it("sets _userScrolledUp when wheel event fires and viewport is not at bottom", () => {
+    const { tab, viewportEl, bufferActive } = createTabWithViewport();
+
+    tab._wireUserScrollDetection();
+
+    // Find the wheel listener
+    const wheelCall = viewportEl.addEventListener.mock.calls.find(
+      (c: unknown[]) => c[0] === "wheel",
+    );
+    expect(wheelCall).toBeDefined();
+    const wheelHandler = wheelCall[1] as () => void;
+
+    // Simulate user scrolling up
+    bufferActive.viewportY = 50;
+    wheelHandler();
+
+    expect(tab._userScrolledUp).toBe(true);
+  });
+
+  it("clears _userScrolledUp when user scrolls back to bottom", () => {
+    const { tab, viewportEl, bufferActive } = createTabWithViewport();
+
+    tab._wireUserScrollDetection();
+    tab._userScrolledUp = true;
+
+    const wheelCall = viewportEl.addEventListener.mock.calls.find(
+      (c: unknown[]) => c[0] === "wheel",
+    );
+    const wheelHandler = wheelCall[1] as () => void;
+
+    // User scrolls back to bottom
+    bufferActive.viewportY = 100;
+    wheelHandler();
+
+    expect(tab._userScrolledUp).toBe(false);
+  });
+
+  it("does nothing when no viewport element exists", () => {
+    const containerEl = {
+      querySelector: vi.fn(() => null),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    const tab = Object.assign(Object.create(TerminalTab.prototype), {
+      terminal: { buffer: { active: { viewportY: 100, baseY: 100 } } },
+      containerEl,
+      _userScrolledUp: false,
+      _isDisposed: false,
+      _documentCleanups: [],
+    }) as TerminalTab;
+
+    // Should not throw
+    tab._wireUserScrollDetection();
+    expect(tab._userScrolledUp).toBe(false);
   });
 });

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -154,6 +154,12 @@ export class TerminalTab {
   /** How many consecutive polls the screen content has remained unchanged. */
   private _unchangedPolls = 0;
 
+  // User-initiated scroll tracking: true when the user has explicitly scrolled
+  // up via wheel/touchmove/keyboard. Auto-scroll is suppressed while this flag
+  // is set. Reset when the user scrolls back to the bottom or clicks the
+  // scroll-to-bottom button.
+  _userScrolledUp = false;
+
   // Session tracking (/resume detection)
   private _sessionTracker: AgentSessionTracker | null = null;
 
@@ -253,7 +259,12 @@ export class TerminalTab {
     this.registerFilePathLinks();
 
     // Scroll-to-bottom button
-    attachScrollButton(this.containerEl, this.terminal);
+    attachScrollButton(this.containerEl, this.terminal, () => {
+      this._userScrolledUp = false;
+    });
+
+    // User-initiated scroll detection
+    this._wireUserScrollDetection();
 
     // Keyboard capture - two layers
     attachBubbleCapture(this.containerEl);
@@ -437,16 +448,13 @@ export class TerminalTab {
       }
     });
 
-    // Auto-scroll: snapshot whether the viewport is at the bottom before each
-    // write, then use terminal.write(data, callback) so the callback fires
-    // after that specific write is parsed. This avoids a race condition where
-    // a shared mutable flag could be overwritten by a later write before an
-    // earlier write's callback fires (which happened with onWriteParsed).
+    // Auto-scroll: always scroll to bottom after each write UNLESS the user
+    // has explicitly scrolled up (tracked via wheel/touchmove/keydown events).
+    // This replaces the per-write wasAtBottom snapshot approach which was
+    // defeated by DOM scroll events firing during screen clear/redraw cycles.
     const writeWithAutoScroll = (data: string | Uint8Array) => {
-      const buf = this.terminal.buffer.active;
-      const wasAtBottom = buf.viewportY >= buf.baseY;
       this.terminal.write(data, () => {
-        if (wasAtBottom) {
+        if (!this._userScrolledUp) {
           this.terminal.scrollToBottom();
         }
       });
@@ -478,6 +486,63 @@ export class TerminalTab {
       if (this._isDisposed) return;
       writeWithAutoScroll(`\r\n[Process exited (code: ${code}, signal: ${signal})]\r\n`);
       this.onProcessExit?.(code, signal);
+    });
+  }
+
+  /**
+   * Attach event listeners to detect user-initiated scrolls (wheel, touchmove,
+   * keyboard Page Up/Down/Home/End). Sets `_userScrolledUp = true` when the
+   * user scrolls away from the bottom, and resets it when they return.
+   */
+  _wireUserScrollDetection(): void {
+    const viewport = this.containerEl.querySelector(".xterm-viewport");
+    if (!viewport) return;
+
+    const SCROLL_UP_KEYS = new Set(["PageUp", "PageDown", "Home", "End"]);
+
+    const checkIfAtBottom = () => {
+      const buf = this.terminal.buffer.active;
+      if (buf.viewportY >= buf.baseY) {
+        this._userScrolledUp = false;
+      }
+    };
+
+    const onUserScroll = () => {
+      const buf = this.terminal.buffer.active;
+      if (buf.viewportY < buf.baseY) {
+        this._userScrolledUp = true;
+      } else {
+        this._userScrolledUp = false;
+      }
+    };
+
+    // Use requestAnimationFrame to read scroll position after the browser
+    // has applied the scroll delta from wheel/touch events.
+    const onUserScrollDeferred = () => {
+      requestAnimationFrame(onUserScroll);
+    };
+
+    viewport.addEventListener("wheel", onUserScrollDeferred, { passive: true });
+    viewport.addEventListener("touchmove", onUserScrollDeferred, { passive: true });
+
+    const onKeydown = (e: Event) => {
+      const ke = e as KeyboardEvent;
+      if (SCROLL_UP_KEYS.has(ke.key)) {
+        onUserScrollDeferred();
+      }
+    };
+    viewport.addEventListener("keydown", onKeydown, { passive: true });
+
+    // Also check on native scroll events to catch edge cases (e.g. trackpad
+    // inertia scrolling back to the bottom).
+    viewport.addEventListener("scroll", () => requestAnimationFrame(checkIfAtBottom), {
+      passive: true,
+    });
+
+    this._documentCleanups.push(() => {
+      viewport.removeEventListener("wheel", onUserScrollDeferred);
+      viewport.removeEventListener("touchmove", onUserScrollDeferred);
+      viewport.removeEventListener("keydown", onKeydown);
     });
   }
 
@@ -1164,7 +1229,12 @@ export class TerminalTab {
     });
 
     // Scroll-to-bottom button
-    attachScrollButton(stored.containerEl, stored.terminal);
+    attachScrollButton(stored.containerEl, stored.terminal, () => {
+      tab._userScrolledUp = false;
+    });
+
+    // User-initiated scroll detection
+    tab._wireUserScrollDetection();
 
     // Re-attach resize observer - debounced to avoid fitting during transitions
     stored.resizeObserver.disconnect();


### PR DESCRIPTION
## Summary

- Replaces the per-write `wasAtBottom` viewport snapshot with a `_userScrolledUp` flag tracked via `wheel`/`touchmove`/`keydown` event listeners on the xterm viewport
- Auto-scroll is now always applied after writes unless the user has explicitly scrolled up
- The flag resets when the user scrolls back to the bottom or clicks the scroll-to-bottom button

Fixes #241

## Why

The previous approach snapshotted `buffer.viewportY >= buffer.baseY` before each `terminal.write()`. DOM scroll events fired during Claude Code's screen clear/redraw cycle would move the viewport to a non-bottom position between writes, causing the write callbacks to see `wasAtBottom: false` and skip auto-scroll.

## Test plan

- [x] All 611 tests pass (4 new tests added)
- [x] Build succeeds
- [ ] Manual: run a Claude session, verify output auto-scrolls to bottom
- [ ] Manual: scroll up during output, verify scroll position is preserved
- [ ] Manual: scroll back to bottom, verify auto-scroll resumes
- [ ] Manual: click scroll-to-bottom button, verify auto-scroll resumes