### PR TITLE
Fix tip question mark false positive in state detection

### DIFF
--- a/src/core/agents/AgentStateDetector.test.ts
+++ b/src/core/agents/AgentStateDetector.test.ts
@@ -354,6 +354,67 @@ describe("AgentStateDetector", () => {
       detector.stop();
     });
 
+    it("does not treat Tip lines ending in ? as waiting", () => {
+      const terminal = mockTerminal([
+        "  some previous output",
+        "  Tip: Did you know you can drag and drop image files into your terminal?",
+      ]);
+      const detector = new AgentStateDetector(terminal, () => false);
+      detector.start();
+
+      vi.advanceTimersByTime(2100);
+      expect(detector.state).toBe("idle");
+      detector.stop();
+    });
+
+    it("does not treat other informational prefixes ending in ? as waiting", () => {
+      const prefixes = [
+        "Hint: Have you tried using the keyboard shortcut?",
+        "Note: Did you know this feature supports multiple formats?",
+        "Pro tip: Want to speed things up with parallel execution?",
+        "FYI: Did you know about the new caching feature?",
+      ];
+      for (const line of prefixes) {
+        const terminal = mockTerminal(["  some previous output", `  ${line}`]);
+        const detector = new AgentStateDetector(terminal, () => false);
+        detector.start();
+
+        vi.advanceTimersByTime(2100);
+        expect(detector.state).toBe("idle");
+        detector.stop();
+      }
+    });
+
+    it("does not treat Tip lines in hidden Claude prompt context as waiting", () => {
+      const terminal = mockTerminal([
+        "  Tip: Did you know you can drag and drop image files into your terminal?",
+        "  ────────────────",
+        "  ❯",
+        "  ────────────────",
+        "  ➜  obsidian-work-terminal git:(main) cwd context",
+        "  ⏵⏵ permissions",
+      ]);
+      const detector = new AgentStateDetector(terminal, () => false);
+      detector.start();
+
+      vi.advanceTimersByTime(2100);
+      expect(detector.state).toBe("idle");
+      detector.stop();
+    });
+
+    it("still detects real questions ending in ? as waiting", () => {
+      const terminal = mockTerminal([
+        "  some previous output",
+        "  Would you like me to proceed with this change?",
+      ]);
+      const detector = new AgentStateDetector(terminal, () => false);
+      detector.start();
+
+      vi.advanceTimersByTime(2100);
+      expect(detector.state).toBe("waiting");
+      detector.stop();
+    });
+
     it("does not treat ordinary boxed output as waiting", () => {
       const terminal = mockTerminal(["  some previous output"]);
       const detector = new AgentStateDetector(terminal, () => false);

--- a/src/core/agents/AgentStateDetector.ts
+++ b/src/core/agents/AgentStateDetector.ts
@@ -22,12 +22,16 @@ const GENERIC_WAITING_QUESTION_WINDOW = 5;
 const HIDDEN_CLAUDE_QUESTION_WINDOW = 10;
 const HIDDEN_CLAUDE_PROMPT_CHROME_SCAN_LINES = 6;
 
+/** Matches lines that are informational and should not be treated as questions. */
+const INFORMATIONAL_PREFIX_PATTERN = /^(?:Tip|Hint|Note|Info|FYI|Did you know|Pro tip)\s*:/i;
+
 function looksLikeHiddenClaudePrompt(tail: string[], questionIndex: number): boolean {
   const normalizedQuestion = normalizeWaitingLine(tail[questionIndex]);
   if (
     questionIndex < tail.length - HIDDEN_CLAUDE_QUESTION_WINDOW ||
     !normalizedQuestion.endsWith("?") ||
-    normalizedQuestion.length <= 10
+    normalizedQuestion.length <= 10 ||
+    INFORMATIONAL_PREFIX_PATTERN.test(normalizedQuestion)
   ) {
     return false;
   }
@@ -78,7 +82,8 @@ function findLastWaitingLineIndex(lines: string[]): number {
     if (
       i >= tail.length - GENERIC_WAITING_QUESTION_WINDOW &&
       normalizedLine.endsWith("?") &&
-      normalizedLine.length > 10
+      normalizedLine.length > 10 &&
+      !INFORMATIONAL_PREFIX_PATTERN.test(normalizedLine)
     ) {
       return tailStart + i;
     }


### PR DESCRIPTION
## Summary

- Exclude lines starting with informational prefixes (`Tip:`, `Hint:`, `Note:`, `Pro tip:`, `FYI:`, `Did you know:`) from question detection in `AgentStateDetector`
- Applies the exclusion to both the generic trailing-`?` check and the hidden Claude prompt detection path
- Adds tests for tip lines, other informational prefixes, hidden Claude prompt context with tips, and a sanity check that real questions still trigger waiting

## Test plan

- [x] All 615 tests pass (`pnpm exec vitest run`)
- [x] Build succeeds (`pnpm run build`)
- [ ] Manual: verify Claude Code tip messages like `Tip: Did you know you can drag and drop image files into your terminal?` no longer trigger "waiting for response" state

Fixes #243