### PR TITLE
Fix event listener leaks in ScrollButton, KeyboardCapture, and TerminalTab

### DIFF
--- a/src/core/terminal/KeyboardCapture.ts
+++ b/src/core/terminal/KeyboardCapture.ts
@@ -16,21 +16,21 @@ import type { ChildProcess } from "child_process";
  * Prevents Obsidian from receiving keydown/keyup events that bubble up
  * from the terminal.
  */
-export function attachBubbleCapture(containerEl: HTMLElement): void {
-  containerEl.addEventListener(
-    "keydown",
-    (e: KeyboardEvent) => {
-      e.stopPropagation();
-    },
-    false,
-  );
-  containerEl.addEventListener(
-    "keyup",
-    (e: KeyboardEvent) => {
-      e.stopPropagation();
-    },
-    false,
-  );
+export function attachBubbleCapture(containerEl: HTMLElement): () => void {
+  const onKeydown = (e: KeyboardEvent) => {
+    e.stopPropagation();
+  };
+  const onKeyup = (e: KeyboardEvent) => {
+    e.stopPropagation();
+  };
+
+  containerEl.addEventListener("keydown", onKeydown, false);
+  containerEl.addEventListener("keyup", onKeyup, false);
+
+  return () => {
+    containerEl.removeEventListener("keydown", onKeydown, false);
+    containerEl.removeEventListener("keyup", onKeyup, false);
+  };
 }
 
 /**

--- a/src/core/terminal/ScrollButton.ts
+++ b/src/core/terminal/ScrollButton.ts
@@ -10,7 +10,7 @@ export function attachScrollButton(
   containerEl: HTMLElement,
   terminal: Terminal,
   onScrollToBottom?: () => void,
-): void {
+): () => void {
   // Remove any existing button (e.g. from a previous reload)
   containerEl.querySelector(".wt-scroll-bottom")?.remove();
 
@@ -38,7 +38,7 @@ export function attachScrollButton(
     visibilityRaf = requestAnimationFrame(updateVisibility);
   };
 
-  terminal.onScroll(scheduleVisibilityUpdate);
+  const scrollDisposable = terminal.onScroll(scheduleVisibilityUpdate);
 
   // Also listen for native scroll on the viewport element, since xterm's
   // onScroll only fires for programmatic scrolls, not user trackpad/wheel.
@@ -56,4 +56,16 @@ export function attachScrollButton(
   });
 
   scheduleVisibilityUpdate();
+
+  return () => {
+    scrollDisposable.dispose();
+    if (viewport) {
+      viewport.removeEventListener("scroll", scheduleVisibilityUpdate);
+    }
+    if (visibilityRaf !== null) {
+      cancelAnimationFrame(visibilityRaf);
+      visibilityRaf = null;
+    }
+    scrollBtn.remove();
+  };
 }

--- a/src/core/terminal/TerminalTab.test.ts
+++ b/src/core/terminal/TerminalTab.test.ts
@@ -34,8 +34,8 @@ const mocks = vi.hoisted(() => {
 
   return {
     injectXtermCss: vi.fn(),
-    attachScrollButton: vi.fn(),
-    attachBubbleCapture: vi.fn(),
+    attachScrollButton: vi.fn(() => vi.fn()),
+    attachBubbleCapture: vi.fn(() => vi.fn()),
     attachCapturePhase: vi.fn(() => vi.fn()),
     electronShell: { openExternal: vi.fn() },
     fsModule: {

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -259,15 +259,17 @@ export class TerminalTab {
     this.registerFilePathLinks();
 
     // Scroll-to-bottom button
-    attachScrollButton(this.containerEl, this.terminal, () => {
+    const scrollCleanup = attachScrollButton(this.containerEl, this.terminal, () => {
       this._userScrolledUp = false;
     });
+    this._documentCleanups.push(scrollCleanup);
 
     // User-initiated scroll detection
     this._wireUserScrollDetection();
 
     // Keyboard capture - two layers
-    attachBubbleCapture(this.containerEl);
+    const bubbleCleanup = attachBubbleCapture(this.containerEl);
+    this._documentCleanups.push(bubbleCleanup);
     const captureCleanup = attachCapturePhase(
       this.containerEl,
       () => this.process,
@@ -276,9 +278,13 @@ export class TerminalTab {
     this._documentCleanups.push(captureCleanup);
 
     // Ensure clicking the terminal area gives xterm focus
-    this.containerEl.addEventListener("click", () => {
+    const clickHandler = () => {
       if (this._isDisposed) return;
       this.terminal.focus();
+    };
+    this.containerEl.addEventListener("click", clickHandler);
+    this._documentCleanups.push(() => {
+      this.containerEl.removeEventListener("click", clickHandler);
     });
 
     // commandArgs takes precedence over preCommand (which is a single string)
@@ -1215,23 +1221,28 @@ export class TerminalTab {
     parentEl.appendChild(stored.containerEl);
 
     // Re-register keyboard interception
-    attachBubbleCapture(stored.containerEl);
+    const bubbleCleanup = attachBubbleCapture(stored.containerEl);
     const captureCleanup = attachCapturePhase(
       stored.containerEl,
       () => tab.process,
       () => tab.toggleSearchBar(),
     );
-    tab._documentCleanups = [captureCleanup];
+    tab._documentCleanups = [bubbleCleanup, captureCleanup];
 
     // Click-to-focus
-    stored.containerEl.addEventListener("click", () => {
+    const clickHandler = () => {
       stored.terminal.focus();
+    };
+    stored.containerEl.addEventListener("click", clickHandler);
+    tab._documentCleanups.push(() => {
+      stored.containerEl.removeEventListener("click", clickHandler);
     });
 
     // Scroll-to-bottom button
-    attachScrollButton(stored.containerEl, stored.terminal, () => {
+    const scrollCleanup = attachScrollButton(stored.containerEl, stored.terminal, () => {
       tab._userScrolledUp = false;
     });
+    tab._documentCleanups.push(scrollCleanup);
 
     // User-initiated scroll detection
     tab._wireUserScrollDetection();


### PR DESCRIPTION
## Summary

- **ScrollButton**: `terminal.onScroll()` returned an `IDisposable` that was discarded. Now captured and disposed via a cleanup function returned from `attachScrollButton()`. Also cleans up the viewport scroll listener and cancels any pending RAF.
- **KeyboardCapture**: `attachBubbleCapture()` added keydown/keyup listeners with no way to remove them. Now returns a cleanup function following the same pattern as `attachCapturePhase()`.
- **TerminalTab**: Container click-to-focus listener was never removed on dispose. Now stored in `_documentCleanups[]`. All three cleanup functions are captured in both the constructor path and the `fromStored()` restore path.

Fixes #247

## Test plan

- [x] All 615 existing tests pass
- [x] Build succeeds
- [ ] Verify no scroll button or keyboard capture regressions after plugin reload
- [ ] Verify dispose cleans up listeners (no leaked handlers in DevTools event listeners panel)