### PR TITLE
Fix viewport scroll listener leak in _wireUserScrollDetection

### DIFF
--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -541,14 +541,14 @@ export class TerminalTab {
 
     // Also check on native scroll events to catch edge cases (e.g. trackpad
     // inertia scrolling back to the bottom).
-    viewport.addEventListener("scroll", () => requestAnimationFrame(checkIfAtBottom), {
-      passive: true,
-    });
+    const onScroll = () => requestAnimationFrame(checkIfAtBottom);
+    viewport.addEventListener("scroll", onScroll, { passive: true });
 
     this._documentCleanups.push(() => {
       viewport.removeEventListener("wheel", onUserScrollDeferred);
       viewport.removeEventListener("touchmove", onUserScrollDeferred);
       viewport.removeEventListener("keydown", onKeydown);
+      viewport.removeEventListener("scroll", onScroll);
     });
   }
 


### PR DESCRIPTION
## Summary

- Extract anonymous scroll handler into a named `onScroll` const in `_wireUserScrollDetection()` so `removeEventListener` receives the same function reference used by `addEventListener`
- Add `viewport.removeEventListener("scroll", onScroll)` to the existing `_documentCleanups` cleanup block
- Same class of leak as #247

Fixes #249

## Test plan

- [x] All 615 existing tests pass (`pnpm exec vitest run`)
- [x] Production build succeeds (`pnpm run build`)
- [ ] Manual: open multiple terminal tabs, close them, verify no orphaned scroll listeners in DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)