### PR TITLE
Fix Copilot and Strands not injecting context prompt

### DIFF
--- a/src/framework/TerminalPanelView.test.ts
+++ b/src/framework/TerminalPanelView.test.ts
@@ -2943,6 +2943,97 @@ describe("TerminalPanelView hook warning", () => {
     ]);
   });
 
+  it("injects context prompt into Copilot-with-context sessions", async () => {
+    mockState.activeItemId = "task-1";
+    const promptBuilder = {
+      buildPrompt: vi.fn(() => "Built prompt"),
+    };
+    const { view } = createView(
+      {
+        "core.additionalAgentContext": "Template for $title in $state",
+        "core.copilotCommand": "/bin/echo",
+        "core.defaultTerminalCwd": "~/ctx",
+      },
+      {},
+      promptBuilder,
+    );
+    view.setItems([
+      {
+        id: "task-1",
+        title: "Task One",
+        state: "doing",
+        path: "Tasks/task-1.md",
+      } as any,
+    ]);
+    await flushAsync();
+
+    await (view as any).spawnCopilotSession({ sessionType: "copilot-with-context" });
+
+    expect(mockState.latestCreateTabArgs?.[5]).toEqual([
+      "/bin/echo",
+      expect.stringMatching(/^--resume=/),
+      "-i",
+      "Built prompt\n\nTemplate for Task One in doing",
+    ]);
+  });
+
+  it("does not inject context prompt into plain Copilot sessions", async () => {
+    mockState.activeItemId = "task-1";
+    const { view } = createView({
+      "core.additionalAgentContext": "Template path: $filePath",
+      "core.copilotCommand": "/bin/echo",
+      "core.defaultTerminalCwd": "~/ctx",
+    });
+    view.setItems([
+      {
+        id: "task-1",
+        title: "Task One",
+        state: "doing",
+        path: "Tasks/task-1.md",
+      } as any,
+    ]);
+    await flushAsync();
+
+    await (view as any).spawnCopilotSession({ sessionType: "copilot" });
+
+    expect(mockState.latestCreateTabArgs?.[5]).toEqual([
+      "/bin/echo",
+      expect.stringMatching(/^--resume=/),
+    ]);
+  });
+
+  it("injects context prompt into Strands-with-context sessions", async () => {
+    mockState.activeItemId = "task-1";
+    const promptBuilder = {
+      buildPrompt: vi.fn(() => "Built prompt"),
+    };
+    const { view } = createView(
+      {
+        "core.additionalAgentContext": "Template for $title in $state",
+        "core.strandsCommand": "/bin/echo",
+        "core.defaultTerminalCwd": "~/ctx",
+      },
+      {},
+      promptBuilder,
+    );
+    view.setItems([
+      {
+        id: "task-1",
+        title: "Task One",
+        state: "doing",
+        path: "Tasks/task-1.md",
+      } as any,
+    ]);
+    await flushAsync();
+
+    await (view as any).spawnStrandsSession({ sessionType: "strands-with-context" });
+
+    expect(mockState.latestCreateTabArgs?.[5]).toEqual([
+      "/bin/echo",
+      "Built prompt\n\nTemplate for Task One in doing",
+    ]);
+  });
+
   it("merges multiline continuation args from settings and custom launches", async () => {
     const { view } = createView({
       "core.claudeCommand": "/bin/echo",

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -2217,6 +2217,22 @@ export class TerminalPanelView {
     prompt?: string;
     freshSettings?: Record<string, unknown>;
   }): Promise<void> {
+    let prompt = options.prompt;
+    if (options.sessionType === "copilot-with-context" && !prompt) {
+      const item = this.getActiveItem();
+      if (!item) {
+        new Notice(`Select a ${this.adapter.config.itemName} first to launch Copilot with context`);
+        return;
+      }
+      const fresh = options.freshSettings ?? (await this.loadFreshSettings());
+      prompt = await this.getAgentContextPrompt(item, fresh);
+      if (!prompt) {
+        new Notice("Could not build a contextual prompt for this item");
+        return;
+      }
+      options.freshSettings = fresh;
+    }
+
     const fresh = options.freshSettings ?? (await this.loadFreshSettings());
     const copilotCmd =
       options.command || this.getStringSetting(fresh, "core.copilotCommand", "copilot");
@@ -2237,7 +2253,7 @@ export class TerminalPanelView {
     const mergedExtraArgs = rawExtraArgs.replace(/\$sessionId/g, sessionId);
     const args = [
       `--resume=${sessionId}`,
-      ...buildCopilotArgs({ copilotExtraArgs: mergedExtraArgs }, options.prompt),
+      ...buildCopilotArgs({ copilotExtraArgs: mergedExtraArgs }, prompt),
     ];
     const label = options.label || getDefaultSessionLabel(options.sessionType);
     this.tabManager.createTab(
@@ -2262,6 +2278,22 @@ export class TerminalPanelView {
     prompt?: string;
     freshSettings?: Record<string, unknown>;
   }): Promise<void> {
+    let prompt = options.prompt;
+    if (options.sessionType === "strands-with-context" && !prompt) {
+      const item = this.getActiveItem();
+      if (!item) {
+        new Notice(`Select a ${this.adapter.config.itemName} first to launch Strands with context`);
+        return;
+      }
+      const fresh = options.freshSettings ?? (await this.loadFreshSettings());
+      prompt = await this.getAgentContextPrompt(item, fresh);
+      if (!prompt) {
+        new Notice("Could not build a contextual prompt for this item");
+        return;
+      }
+      options.freshSettings = fresh;
+    }
+
     const fresh = options.freshSettings ?? (await this.loadFreshSettings());
     const strandsCmd = expandTilde(
       options.command || this.getStringSetting(fresh, "core.strandsCommand", "strands"),
@@ -2282,7 +2314,7 @@ export class TerminalPanelView {
         );
     // Strands has no session ID - strip any deferred $sessionId placeholders
     const mergedExtraArgs = rawExtraArgs.replace(/\$sessionId/g, "");
-    const args = buildStrandsArgs({ strandsExtraArgs: mergedExtraArgs }, options.prompt);
+    const args = buildStrandsArgs({ strandsExtraArgs: mergedExtraArgs }, prompt);
     const cwd = expandTilde(
       options.cwd || this.getStringSetting(fresh, "core.defaultTerminalCwd", "~"),
     );


### PR DESCRIPTION
## Summary
- Copilot and Strands sessions launched with `-with-context` session types were not building the context prompt from the active work item
- Added the same `getAgentContextPrompt` resolution that Claude sessions already use to both `spawnCopilotSession` and `spawnStrandsSession`
- 3 new tests added, all 629 tests pass

Fixes #255

## Test plan
- [ ] Launch a Copilot-with-context session from a work item and verify the context prompt is injected
- [ ] Launch a plain Copilot session and verify no prompt is injected
- [ ] Launch a Strands-with-context session and verify the context prompt is injected
- [ ] `pnpm exec vitest run` passes