### PR TITLE
Remove duplicate removeOrphanedContainers method

### DIFF
--- a/src/core/terminal/TabManager.ts
+++ b/src/core/terminal/TabManager.ts
@@ -662,32 +662,6 @@ export class TabManager {
     }
   }
 
-  /**
-   * Find and remove any `.wt-terminal-instance` elements in the wrapper that
-   * are not owned by a tracked TerminalTab. These are orphans left over from
-   * a failed dispose or reload race.
-   */
-  private removeOrphanedContainers(): void {
-    if (!this.terminalWrapperEl) return;
-    const tracked = new Set<HTMLElement>();
-    for (const tabs of this.sessions.values()) {
-      for (const tab of tabs) {
-        tracked.add(tab.containerEl);
-      }
-    }
-    const allContainers = this.terminalWrapperEl.querySelectorAll(".wt-terminal-instance");
-    let removed = 0;
-    for (const container of Array.from(allContainers)) {
-      if (!tracked.has(container as HTMLElement)) {
-        (container as HTMLElement).remove();
-        removed++;
-      }
-    }
-    if (removed > 0) {
-      console.warn(`[work-terminal] Removed ${removed} orphaned terminal container(s) from DOM`);
-    }
-  }
-
   private _notifyLabelChange(): void {
     // Bubble up to trigger tab bar re-render
     this.onSessionChange?.();


### PR DESCRIPTION
## Summary

Remove duplicate `removeOrphanedContainers` method in TabManager.ts introduced by the squash merge of #268. The method appeared twice (lines 644 and 670) causing an esbuild warning.

## Test plan

- [x] Build succeeds with no warnings
- [x] 653 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)