### PR TITLE
Remove orphan cleanup from hideAllTerminals to fix blank terminal on tab creation

### DIFF
--- a/src/core/terminal/TabManager.ts
+++ b/src/core/terminal/TabManager.ts
@@ -629,11 +629,11 @@ export class TabManager {
         tab.suspendWebGl();
       }
     }
-    // Safety net: remove any orphaned terminal containers in the DOM that are
-    // not tracked in the sessions Map (e.g. left over from a failed dispose
-    // or reload race). This prevents ghost terminal content from remaining
-    // visible when switching to a task with no sessions.
-    this.removeOrphanedContainers();
+    // NOTE: orphan cleanup is NOT called here because hideAllTerminals() runs
+    // during createTabForItem() before the new tab is added to the sessions map.
+    // Cleaning orphans at this point would remove the freshly-created container.
+    // Instead, removeOrphanedContainers() is called from setActiveItem() and the
+    // constructor where the sessions map is stable.
   }
 
   /**


### PR DESCRIPTION
## Summary

Remove `removeOrphanedContainers()` from `hideAllTerminals()`. The squash merge of #268 added the call to `setActiveItem()` but did not remove it from `hideAllTerminals()`, leaving the original race condition intact.

## Reproduction

1. Select any task in the kanban board
2. Click "Claude (ctx)" (or any agent button)
3. **Observed**: Tab appears but terminal area is blank. Console: `Removed 1 orphaned terminal container(s) from DOM`
4. **Expected**: Terminal content visible

Verified via CDP on live Obsidian instance:
- Before fix: `containerEl.parentElement === null` (detached), `domContainers: 0`
- After fix: `containerEl.parentElement !== null` (in DOM), `domContainers` matches tracked tabs

## Root cause

`hideAllTerminals()` at line 636 still called `removeOrphanedContainers()`. This method runs during `createTabForItem()` (line 228) BEFORE the new tab is added to the sessions map (line 231), so the new container was removed as an "orphan". The identical call already exists in `setActiveItem()` (line 114) where the sessions map is stable.

## Test plan

- [x] 653 tests pass
- [x] Build succeeds (no warnings)
- [x] Live Obsidian: Claude (ctx) tab now shows terminal content after click
- [x] Live Obsidian: no orphan removal warnings during tab creation

Fixes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)