### PR TITLE
Clear persisted session from data.json on resume

### DIFF
--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -1443,14 +1443,20 @@ export class TerminalPanelView {
       tab.paramPassMode = persisted.paramPassMode;
     }
 
-    // Remove the persisted session immediately now that the tab has been
-    // created.  Previously this was deferred to process exit via
-    // trackRecoverySuccess, which meant the entry lingered in data.json
-    // until the resumed process eventually exited (or the next periodic
-    // persist happened to run).  Clearing it eagerly ensures data.json
-    // reflects the true state: the session is now live, not pending resume.
+    // Remove eagerly so data.json reflects the live session, not a pending
+    // resume.  If the process dies within 5s, re-add so the user can retry.
     this.removePersistedSession(persisted);
     this.persistSessions().catch(() => {});
+
+    this.trackRecoverySuccess(
+      tab,
+      () => {}, // success - already removed, nothing to do
+      () => {
+        // Process died within 5s - restore so the user can retry
+        this.persistedSessions.push(persisted);
+        this.persistSessions().catch(() => {});
+      },
+    );
 
     this.renderTabBar();
   }


### PR DESCRIPTION
## Summary

- Removes the persisted session entry from `data.json` immediately when a session is resumed via the resume badge, rather than deferring removal to process exit via `trackRecoverySuccess`
- Previously the entry lingered until the resumed process exited (or the next 30s periodic persist cycle deduplicated it), so `data.json` did not reflect the true state

## Test plan

- [ ] Persist sessions by closing plugin with active resumable agent sessions
- [ ] Reopen plugin, verify resume badges appear
- [ ] Click resume badge to resume a session
- [ ] Inspect `data.json` - the old persisted entry should be removed immediately (a fresh entry from the live tab will appear on the next periodic persist, which is expected)
- [ ] Verify `pnpm exec vitest run` passes (653 tests)
- [ ] Verify `pnpm run build` succeeds

Fixes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)