### PR TITLE
Fix drop indicator flicker on card drag

### DIFF
--- a/src/framework/ListPanel.ts
+++ b/src/framework/ListPanel.ts
@@ -558,8 +558,11 @@ export class ListPanel {
       this.positionDropIndicator(cardsEl, e.clientY);
     });
 
-    cardsEl.addEventListener("dragleave", () => {
-      cardsEl.querySelectorAll(".wt-drop-indicator").forEach((el) => el.remove());
+    cardsEl.addEventListener("dragleave", (e: DragEvent) => {
+      const related = e.relatedTarget as Node | null;
+      if (!related || !cardsEl.contains(related)) {
+        cardsEl.querySelectorAll(".wt-drop-indicator").forEach((el) => el.remove());
+      }
     });
 
     cardsEl.addEventListener("drop", async (e: DragEvent) => {
@@ -600,9 +603,6 @@ export class ListPanel {
   }
 
   private positionDropIndicator(cardsEl: HTMLElement, clientY: number): void {
-    // Remove existing indicators
-    cardsEl.querySelectorAll(".wt-drop-indicator").forEach((el) => el.remove());
-
     const cards = Array.from(cardsEl.querySelectorAll(".wt-card-wrapper:not(.wt-card-dragging)"));
     let insertBefore: Element | null = null;
 
@@ -614,13 +614,28 @@ export class ListPanel {
       }
     }
 
-    const indicator = document.createElement("div");
-    indicator.addClass("wt-drop-indicator");
+    // Reuse existing indicator if present, only move when insertion point changes
+    let indicator = cardsEl.querySelector(".wt-drop-indicator") as HTMLElement | null;
+    const currentNext = indicator?.nextElementSibling ?? null;
 
-    if (insertBefore) {
-      cardsEl.insertBefore(indicator, insertBefore);
+    if (indicator) {
+      // Indicator already at correct position - nothing to do
+      if (insertBefore === currentNext) return;
+      // Move existing indicator to new position
+      if (insertBefore) {
+        cardsEl.insertBefore(indicator, insertBefore);
+      } else {
+        cardsEl.appendChild(indicator);
+      }
     } else {
-      cardsEl.appendChild(indicator);
+      // Create new indicator
+      indicator = document.createElement("div");
+      indicator.addClass("wt-drop-indicator");
+      if (insertBefore) {
+        cardsEl.insertBefore(indicator, insertBefore);
+      } else {
+        cardsEl.appendChild(indicator);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Fixed `dragleave` handler in `ListPanel.ts` to check `relatedTarget` before removing drop indicators - prevents flicker caused by `dragleave` firing when cursor moves onto child elements (including the indicator itself)
- Optimized `positionDropIndicator()` to reuse the existing indicator element and only reposition it when the insertion point actually changes, instead of remove-and-recreate on every `dragover` event

Fixes #283

## Test plan

- [ ] Drag a card slowly between two adjacent cards - indicator should remain stable without flickering
- [ ] Drag a card to the top and bottom of a column - indicator appears correctly
- [ ] Drag a card between columns - indicator cleans up when leaving a column and appears in the target column
- [ ] All 658 existing tests pass, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)