### PR TITLE
Fix scroll lock race during rapid output

### DIFF
--- a/src/core/terminal/TerminalTab.test.ts
+++ b/src/core/terminal/TerminalTab.test.ts
@@ -1574,6 +1574,48 @@ describe("TerminalTab auto-scroll on write", () => {
     expect(tab._userScrolledUp).toBe(true);
   });
 
+  it("keeps rapid writes locked after an upward PageUp key before RAF settles", () => {
+    const rafCallbacks: FrameRequestCallback[] = [];
+    vi.stubGlobal("requestAnimationFrame", ((cb: FrameRequestCallback) => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    }) as typeof requestAnimationFrame);
+
+    const { tab, scrollToBottom, flushCallbacks, bufferActive, viewportEl } =
+      createTabWithMockTerminal({
+        deferCallbacks: true,
+        withViewport: true,
+      });
+    const proc = createMockProcess();
+
+    (tab as any).wireProcess(proc);
+    tab._wireUserScrollDetection();
+    scrollToBottom.mockClear();
+
+    proc.emitStdout(Buffer.from("chunk-1"));
+
+    const keydownCall = viewportEl?.addEventListener.mock.calls.find(
+      (c: unknown[]) => c[0] === "keydown",
+    );
+    expect(keydownCall).toBeDefined();
+    const keydownHandler = keydownCall?.[1] as (event: Event) => void;
+    keydownHandler({ key: "PageUp" } as KeyboardEvent);
+
+    expect(tab._userScrolledUp).toBe(true);
+
+    proc.emitStdout(Buffer.from("chunk-2"));
+    flushCallbacks();
+
+    expect(scrollToBottom).not.toHaveBeenCalled();
+
+    bufferActive.viewportY = 50;
+    const runUserScrollCheck = rafCallbacks.shift();
+    expect(runUserScrollCheck).toBeDefined();
+    runUserScrollCheck?.(0);
+
+    expect(tab._userScrolledUp).toBe(true);
+  });
+
   it("keeps the native scroll guard active until the write frame settles", () => {
     const rafCallbacks: FrameRequestCallback[] = [];
     vi.stubGlobal("requestAnimationFrame", ((cb: FrameRequestCallback) => {
@@ -1703,6 +1745,23 @@ describe("TerminalTab user scroll detection", () => {
     // Simulate user scrolling up
     bufferActive.viewportY = 50;
     wheelHandler({ deltaY: -120 } as WheelEvent);
+
+    expect(tab._userScrolledUp).toBe(true);
+  });
+
+  it("sets _userScrolledUp immediately for PageUp", () => {
+    const { tab, viewportEl, bufferActive } = createTabWithViewport();
+
+    tab._wireUserScrollDetection();
+
+    const keydownCall = viewportEl.addEventListener.mock.calls.find(
+      (c: unknown[]) => c[0] === "keydown",
+    );
+    expect(keydownCall).toBeDefined();
+    const keydownHandler = keydownCall[1] as (event: Event) => void;
+
+    bufferActive.viewportY = 50;
+    keydownHandler({ key: "PageUp" } as KeyboardEvent);
 
     expect(tab._userScrolledUp).toBe(true);
   });

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -586,6 +586,7 @@ export class TerminalTab {
     if (!viewport) return;
 
     const SCROLL_KEYS = new Set(["PageUp", "PageDown", "Home", "End"]);
+    const IMMEDIATE_SCROLL_UP_KEYS = new Set(["PageUp", "Home"]);
 
     const checkIfAtBottom = () => {
       if (this._programmaticScrollGuards > 0) {
@@ -626,6 +627,9 @@ export class TerminalTab {
 
     const onKeydown = (e: Event) => {
       const ke = e as KeyboardEvent;
+      if (IMMEDIATE_SCROLL_UP_KEYS.has(ke.key)) {
+        this._userScrolledUp = true;
+      }
       if (SCROLL_KEYS.has(ke.key)) {
         onUserScrollDeferred();
       }


### PR DESCRIPTION
## Summary
- set user scroll-up intent immediately for upward wheel and PageUp/Home interactions
- preserve the existing programmatic scroll guard while queueing a bottom re-check after guarded native scroll events
- add focused regressions for rapid writes and guarded return-to-bottom recovery

## Testing
- pnpm exec vitest run src/core/terminal/TerminalTab.test.ts
- pnpm exec vitest run
- pnpm run build