### PR TITLE
Raise terminal scrollback limit to reduce trim jumps

### DIFF
--- a/src/core/terminal/TerminalTab.config.test.ts
+++ b/src/core/terminal/TerminalTab.config.test.ts
@@ -150,6 +150,7 @@ describe("TerminalTab keyboard configuration", () => {
     new TerminalTab(parentEl, "/bin/zsh", "~/repo", "Shell", null, "shell");
 
     expect(mocks.MockTerminal.lastOptions?.macOptionIsMeta).toBe(true);
+    expect(mocks.MockTerminal.lastOptions?.scrollback).toBe(5000);
     expect(mocks.MockTerminal.lastInstance?.options.macOptionIsMeta).toBe(true);
     expect(mocks.MockTerminal.lastInstance?.attachCustomKeyEventHandler).toHaveBeenCalledTimes(1);
   });

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -45,6 +45,7 @@ export type AgentState = AgentRuntimeState;
 export type ClaudeState = AgentState;
 
 let sessionCounter = 0;
+const TERMINAL_SCROLLBACK = 5000;
 
 type TerminalWithAddonManager = Terminal & {
   _addonManager?: {
@@ -219,6 +220,7 @@ export class TerminalTab {
       fontSize: 13,
       fontFamily: "Menlo, Monaco, 'Courier New', monospace",
       macOptionIsMeta: true,
+      scrollback: TERMINAL_SCROLLBACK,
       theme: {
         background: "#1e1e1e",
         foreground: "#d4d4d4",


### PR DESCRIPTION
## Summary
- increase the xterm scrollback limit to 5000 so bulk trim events happen much less often
- keep the change scoped to terminal construction
- add a config test that locks the scrollback option

## Testing
- pnpm exec vitest run src/core/terminal/TerminalTab.config.test.ts
- pnpm exec vitest run
- pnpm run build