### PR TITLE
fix: detect and mark background enrichment failures on exit code 0

### DIFF
--- a/src/adapters/task-agent/BackgroundEnrich.test.ts
+++ b/src/adapters/task-agent/BackgroundEnrich.test.ts
@@ -322,6 +322,36 @@ describe("BackgroundEnrich", () => {
       expect(finalContent).toContain("background-ingestion: failed");
     });
 
+    it("pending path + exit 0 + no silent failure + old path gone: succeeds without stale flag", async () => {
+      // Regression: cleanup used to look up the old pending path (which no longer exists after
+      // Claude renames the file), get null back, and silently no-op - leaving the renamed file
+      // with background-ingestion: retrying and the warning callout.
+      const content =
+        `---\nid: abc\nbackground-ingestion: failed\nstate: todo\n---\n# Task\n\n` +
+        `> [!warning] Background ingestion incomplete\n` +
+        `> Automatic enrichment was attempted but did not complete successfully.\n`;
+
+      spawnHeadlessClaudeMock.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+      const app = makeApp(content);
+      // Old pending path no longer exists - Claude renamed it
+      app.vault.adapter.exists.mockResolvedValue(false);
+
+      await retryEnrichment(app, "tasks/TASK-20260403-0126-pending-bf7a0012.md", defaultSettings);
+
+      // No failure marking - enrichment succeeded
+      const allWrittenContents = app.vault.modify.mock.calls.map((c: any[]) => c[1] as string);
+      for (const written of allWrittenContents) {
+        expect(written).not.toContain("background-ingestion: failed");
+      }
+      // The "retrying" transient flag must not be written for pending files, because we cannot
+      // clean it up from the renamed file afterwards.
+      for (const written of allWrittenContents) {
+        expect(written).not.toContain("background-ingestion: retrying");
+      }
+      // Sanity: Claude was still invoked
+      expect(spawnHeadlessClaudeMock).toHaveBeenCalledOnce();
+    });
+
     it("does not apply pending-file check for non-pending retry paths", async () => {
       const content = `---\nid: abc\nbackground-ingestion: failed\nstate: todo\n---\n# Task\n`;
       spawnHeadlessClaudeMock.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });

--- a/src/adapters/task-agent/BackgroundEnrich.ts
+++ b/src/adapters/task-agent/BackgroundEnrich.ts
@@ -243,7 +243,12 @@ export async function retryEnrichment(
   const claudeCommand = settings["core.claudeCommand"] || "claude";
   const claudeExtraArgs = settings["core.claudeExtraArgs"] || "";
 
-  await clearIngestionFailedFlag(app, filePath);
+  // For pending files, skip writing "retrying" - the file will be renamed by Claude on success
+  // and we cannot look up the new path to clean up afterwards. For non-pending files, marking
+  // "retrying" gives the user a visible signal that a retry is in progress.
+  if (!filePath.includes("pending-")) {
+    await clearIngestionFailedFlag(app, filePath);
+  }
 
   const fullPath = resolveFullPath(app, filePath);
   const enrichPrompt =
@@ -282,6 +287,11 @@ export async function retryEnrichment(
         await markIngestionFailed(app, filePath);
         return;
       }
+      // File was renamed by Claude - no cleanup needed at the old path.
+      // We intentionally did not write "retrying" before the run, so the renamed file
+      // will not have a stale background-ingestion flag from us.
+      console.log(`[work-terminal] Retry enrich completed (file renamed): ${filePath}`);
+      return;
     }
     console.log(`[work-terminal] Retry enrich completed: ${filePath}`);
     // Remove the failed flag entirely on success


### PR DESCRIPTION
## Summary

Fixes two related bugs where background enrichment silently failed while reporting success because Claude exited 0 without changing the task file.

## Fix 1: Remove skill invocation from enrichment prompts (Fixes #309)

The `/tc-tasks:task-agent` slash-command is a Copilot CLI plugin construct that Claude CLI does not load in headless `-p` mode. Running the enrichment prompt with this prefix produces `Unknown skill: tc-tasks:task-agent` on stdout and exits 0, leaving the task file completely unchanged.

**Change**: Removed the `/tc-tasks:task-agent --fast` prefix from both the `handleItemCreated` and `retryEnrichment` prompts so Claude receives the enrichment instruction as a plain natural-language prompt it can execute directly.

## Fix 2: Validate observable enrichment outcome (Fixes #308)

Even with the prompt fixed, exit code 0 alone is not sufficient proof that enrichment succeeded. Added two checks before declaring success:

1. **`detectSilentFailure(stdout)`** - scans stdout for `Unknown skill:` patterns (and similar) that indicate Claude printed an error but still exited 0.
2. **Pending-file existence check** - after exit 0, verifies the `pending-XXXXXXXX` file was actually renamed away. If it still exists, enrichment was a no-op and the task is marked `background-ingestion: failed` with the warning callout, matching the behavior of other failure modes.

For `retryEnrichment`, the file-existence check is only applied when the file path contains `pending-` (since retried files may already have a proper name).

## Tests

Added 8 new tests:
- Prompt does not start with `/tc-tasks:` or `/task-agent` (both `handleItemCreated` and `retryEnrichment`)
- Exit 0 + `Unknown skill:` in stdout → marks ingestion failed
- Exit 0 + pending file still exists → marks ingestion failed  
- Exit 0 + pending file gone (renamed) → success, no failure marking
- Retry: exit 0 + `Unknown skill:` → marks ingestion failed
- Retry: exit 0 + pending file still exists → marks ingestion failed
- Retry: exit 0 + non-pending path + file exists → success (pending check skipped)

All 714 tests pass. Build clean.