### PR TITLE
fix: ignore typed prompt lines in waiting detection

### DIFF
--- a/src/core/agents/AgentStateDetector.test.ts
+++ b/src/core/agents/AgentStateDetector.test.ts
@@ -415,6 +415,42 @@ describe("AgentStateDetector", () => {
       detector.stop();
     });
 
+    it("does not treat user-typed Claude prompt questions as waiting", () => {
+      const terminal = mockTerminal([
+        "  some previous output",
+        "  ❯ Would you like to review the latest change?",
+      ]);
+      const detector = new AgentStateDetector(terminal, () => false);
+      detector.start();
+
+      vi.advanceTimersByTime(2100);
+      expect(detector.state).toBe("idle");
+      detector.stop();
+    });
+
+    it("does not treat user-typed Copilot prompt questions as waiting", () => {
+      const terminal = mockTerminal([
+        "  some previous output",
+        "  ❯ Can you explain this refactor in more detail?",
+      ]);
+      const detector = new AgentStateDetector(terminal, () => false);
+      detector.start();
+
+      vi.advanceTimersByTime(2100);
+      expect(detector.state).toBe("idle");
+      detector.stop();
+    });
+
+    it("does not treat user-typed prompt questions from recent output as waiting", () => {
+      const detector = new AgentStateDetector(mockTerminal([]), () => false);
+      detector.trackOutput("❯ Could you summarize the latest test failure?");
+      detector.start(true);
+
+      vi.advanceTimersByTime(2100);
+      expect(detector.state).toBe("idle");
+      detector.stop();
+    });
+
     it("does not treat ordinary boxed output as waiting", () => {
       const terminal = mockTerminal(["  some previous output"]);
       const detector = new AgentStateDetector(terminal, () => false);

--- a/src/core/agents/AgentStateDetector.ts
+++ b/src/core/agents/AgentStateDetector.ts
@@ -21,6 +21,7 @@ function normalizeWaitingLine(line: string): string {
 const GENERIC_WAITING_QUESTION_WINDOW = 5;
 const HIDDEN_CLAUDE_QUESTION_WINDOW = 10;
 const HIDDEN_CLAUDE_PROMPT_CHROME_SCAN_LINES = 6;
+const USER_PROMPT_LINE_PATTERN = /^❯\s+\S/;
 
 /** Matches lines that are informational and should not be treated as questions. */
 const INFORMATIONAL_PREFIX_PATTERN = /^(?:Tip|Hint|Note|Info|FYI|Did you know|Pro tip)\s*:/i;
@@ -63,6 +64,7 @@ function findLastWaitingLineIndex(lines: string[]): number {
   for (let i = tail.length - 1; i >= Math.max(0, tail.length - 15); i--) {
     const normalizedLine = normalizeWaitingLine(tail[i]);
     if (!normalizedLine) continue;
+    if (USER_PROMPT_LINE_PATTERN.test(normalizedLine)) continue;
 
     if (/Enter to (?:select|confirm)|to navigate/i.test(normalizedLine)) return tailStart + i;
 


### PR DESCRIPTION
## Summary
- ignore filled prompt lines that start with ❯ before applying generic waiting-question heuristics
- keep the change scoped to shared waiting-line detection so screen and recent-output fallback paths both benefit
- add regression tests for Claude and Copilot prompt input ending in ?

## Testing
- pnpm run lint
- pnpm exec vitest run
- pnpm run build

Fixes #313