### PR TITLE
Hide adapter prompt preview when useContext is off

### DIFF
--- a/src/framework/AgentProfileModal.ts
+++ b/src/framework/AgentProfileModal.ts
@@ -178,8 +178,11 @@ export class AgentProfileEditModal extends Modal {
     argsSetting.settingEl.style.flexWrap = "wrap";
     argsSetting.controlEl.style.width = "100%";
 
-    // Use context
-    new Setting(contentEl)
+    // Container for adapter prompt preview and suppress toggle - gated on useContext
+    const contextDependentEl = contentEl.createDiv();
+
+    // Use context - must be declared after contextDependentEl to avoid temporal dead zone
+    const useContextSetting = new Setting(contentEl)
       .setName("Include context prompt")
       .setDesc("Send the adapter prompt and context template as the initial message")
       .addToggle((toggle) => {
@@ -189,8 +192,8 @@ export class AgentProfileEditModal extends Modal {
         });
       });
 
-    // Container for adapter prompt preview and suppress toggle - gated on useContext
-    const contextDependentEl = contentEl.createDiv();
+    // Reorder DOM: move contextDependentEl after the toggle setting
+    contentEl.insertAfter(contextDependentEl, useContextSetting.settingEl);
     this.renderContextDependentSection(contextDependentEl);
 
     // Context prompt


### PR DESCRIPTION
## Summary

- The adapter prompt preview block and `suppressAdapterPrompt` toggle in `AgentProfileModal` were rendering whenever `adapterPromptDescription` was set, regardless of whether `useContext` was enabled. This was confusing since those controls are irrelevant when context is disabled.
- Extracted the context-dependent UI into a `renderContextDependentSection` method that only renders when `useContext` is true, and re-renders when the toggle changes.

Fixes #322

## Test plan

- [ ] Open an agent profile modal with an adapter that provides `adapterPromptDescription`
- [ ] Verify the adapter prompt preview and suppress toggle appear when `useContext` is on
- [ ] Toggle `useContext` off and verify the preview and suppress toggle disappear
- [ ] Toggle `useContext` back on and verify they reappear
- [ ] Confirm the `suppressAdapterPrompt` value persists correctly across toggle cycles

Generated with [Claude Code](https://claude.com/claude-code)