### PR TITLE
Fix context launch abort when suppressAdapterPrompt has no template

### DIFF
--- a/src/framework/TerminalPanelView.test.ts
+++ b/src/framework/TerminalPanelView.test.ts
@@ -3902,9 +3902,57 @@ describe("profile launch", () => {
     // Should NOT abort - spawnAgentSession should be called
     expect(spawnAgentSpy).toHaveBeenCalledOnce();
     const callArgs = spawnAgentSpy.mock.calls[0][0];
-    // prompt should be undefined since there's nothing to pass
-    expect(callArgs.prompt).toBeUndefined();
+    // prompt should be empty string (not undefined) so spawnAgentSession
+    // won't auto-build a context prompt from the adapter
+    expect(callArgs.prompt).toBe("");
     expect(promptBuilder.buildPrompt).not.toHaveBeenCalled();
+  });
+
+  it("does not auto-build adapter prompt in spawnAgentSession when suppressAdapterPrompt with no template", async () => {
+    const promptBuilder = {
+      buildPrompt: vi.fn(() => "adapter prompt"),
+    };
+    const { view } = createView({}, {}, promptBuilder);
+    await flushAsync();
+
+    mockState.activeItemId = "task-1";
+    (view as any).allItems = [
+      { id: "task-1", title: "Task", state: "doing", path: "Tasks/task-1.md" },
+    ];
+    (view as any).profileManager = {
+      resolveCommand: () => "claude",
+      resolveCwd: () => "~/projects",
+      resolveArguments: () => "",
+      resolveContextPrompt: () => "",
+    };
+
+    // Add getButtonProfiles so renderTabBar (called at end of spawnAgentSession) works
+    (view as any).profileManager.getButtonProfiles = () => [];
+
+    // Do NOT mock spawnAgentSession - let it run through to createTab
+    const resolveStub = vi
+      .spyOn(AgentLauncher, "resolveCommandInfo")
+      .mockReturnValue({ found: true, resolved: "claude" });
+
+    await (view as any).spawnFromProfile(
+      makeProfile({
+        useContext: true,
+        suppressAdapterPrompt: true,
+        contextPrompt: "",
+      }),
+    );
+
+    // spawnAgentSession should have called createTab
+    expect(mockState.tabManagerCalls).toContain("createTab");
+    // The full command array (6th arg, index 5) should not contain the adapter prompt
+    const cmdArray = mockState.latestCreateTabArgs?.[5] as string[];
+    expect(cmdArray).toBeDefined();
+    const joinedArgs = cmdArray.join(" ");
+    expect(joinedArgs).not.toContain("adapter prompt");
+    // buildPrompt should never have been called
+    expect(promptBuilder.buildPrompt).not.toHaveBeenCalled();
+
+    resolveStub.mockRestore();
   });
 
   it("passes arguments when paramPassMode is launch-only", async () => {

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -1388,8 +1388,10 @@ export class TerminalPanelView {
           new Notice("Could not build a contextual prompt for this item");
           return;
         }
-        // suppressAdapterPrompt is on but no template exists - launch without context
-        prompt = undefined;
+        // suppressAdapterPrompt is on but no template exists - launch without context.
+        // Use empty string (not undefined) so spawnAgentSession knows prompt was
+        // intentionally omitted and won't auto-build one from the adapter.
+        prompt = "";
       }
     }
 
@@ -2267,9 +2269,11 @@ export class TerminalPanelView {
     const resumeConfig = getResumeConfig(options.agentType);
     const { withContext } = sessionTypeToAgentType(options.sessionType);
 
-    // Build context prompt on demand if this is a context session without one
+    // Build context prompt on demand if this is a context session without one.
+    // Check for undefined (not falsy) so callers can pass "" to explicitly skip
+    // auto-building a context prompt (e.g. when suppressAdapterPrompt is set).
     let prompt = options.prompt;
-    if (withContext && !prompt) {
+    if (withContext && prompt === undefined) {
       const item = this.getActiveItem();
       if (!item) {
         new Notice(


### PR DESCRIPTION
## Summary

- When `suppressAdapterPrompt` is true and no context template is configured (neither profile template nor global `additionalAgentContext`), the agent launch now proceeds without a context prompt instead of aborting with a "Could not build a contextual prompt" notice.
- The abort guard in `spawnFromProfile()` now only triggers when `suppressAdapterPrompt` is false, since explicitly suppressing the adapter prompt signals intent to launch without adapter context.
- Adds a test covering this exact edge case.

Fixes #323

## Test plan

- [x] New test: `launches without aborting when suppressAdapterPrompt is true and no template exists`
- [x] All 731 existing tests pass
- [x] Build succeeds