### PR TITLE
Handle task moves during background enrichment

### DIFF
--- a/src/adapters/task-agent/BackgroundEnrich.test.ts
+++ b/src/adapters/task-agent/BackgroundEnrich.test.ts
@@ -277,6 +277,65 @@ describe("BackgroundEnrich", () => {
       expect(finalContent).toContain("background-ingestion: failed");
     });
 
+    it("succeeds when Claude renames the pending file during enrichment (UUID resolves to new name in same folder)", async () => {
+      spawnHeadlessClaudeMock.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+      // Simulate: Claude renames the pending file to a proper slug name in the same folder.
+      // The original path is gone, but UUID lookup finds the renamed file.
+      const renamedPath = "2 - Areas/Tasks/todo/TASK-20260406-1200-fix-the-widget.md";
+      let createdUuid = "";
+      let originalPath = "";
+      let storedContent = "";
+
+      const app = {
+        vault: {
+          adapter: {
+            basePath: "/vault",
+            // Original pending path no longer exists
+            exists: vi.fn().mockResolvedValue(false),
+          },
+          getAbstractFileByPath(path: string) {
+            // Original path is gone (Claude renamed it)
+            if (path === originalPath) return null;
+            if (path === renamedPath) return { path: renamedPath };
+            if (path === "2 - Areas/Tasks/todo") return { path };
+            return null;
+          },
+          getMarkdownFiles() {
+            return [{ path: renamedPath }];
+          },
+          async createFolder(path: string) {
+            return { path };
+          },
+          async create(path: string, content: string) {
+            originalPath = path;
+            storedContent = content;
+            const idMatch = content.match(/^id:\s*(.+)$/m);
+            if (idMatch) createdUuid = idMatch[1].trim();
+            return { path, content };
+          },
+          read: vi.fn(async () => storedContent),
+          modify: vi.fn(async (_file: any, content: string) => {
+            storedContent = content;
+          }),
+        },
+        metadataCache: {
+          getFileCache(file: any) {
+            if (file.path === renamedPath) {
+              return { frontmatter: { id: createdUuid } };
+            }
+            return null;
+          },
+        },
+      } as any;
+
+      const result = await handleItemCreated(app, "Fix the widget", defaultSettings);
+      await result.enrichmentDone;
+
+      // modify should NOT have been called - this is a successful enrichment
+      expect(app.vault.modify).not.toHaveBeenCalled();
+    });
+
     it("does not mark ingestion failed when pending file was renamed away on exit 0", async () => {
       spawnHeadlessClaudeMock.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
       // fileExistsAfterEnrich: false simulates Claude successfully renaming the file
@@ -351,6 +410,7 @@ describe("BackgroundEnrich", () => {
 
       // Should have called modify to mark ingestion as failed on the moved file
       expect(app.vault.modify).toHaveBeenCalled();
+      expect(app.vault.modify.mock.calls.at(-1)![0].path).toBe(movedPath);
       const finalContent = app.vault.modify.mock.calls.at(-1)![1] as string;
       expect(finalContent).toContain("background-ingestion: failed");
     });
@@ -436,6 +496,21 @@ describe("BackgroundEnrich", () => {
       } as any;
 
       const result = findFileByUuid(app, "test-uuid-123", "2 - Areas/Tasks");
+      expect(result).toBeNull();
+    });
+
+    it("does not match sibling paths with a shared prefix", () => {
+      const archiveFile = { path: "2 - Areas/Tasks Archive/old-task.md" };
+      const app = {
+        vault: {
+          getMarkdownFiles: () => [archiveFile],
+        },
+        metadataCache: {
+          getFileCache: () => ({ frontmatter: { id: "target-uuid" } }),
+        },
+      } as any;
+
+      const result = findFileByUuid(app, "target-uuid", "2 - Areas/Tasks");
       expect(result).toBeNull();
     });
 

--- a/src/adapters/task-agent/BackgroundEnrich.ts
+++ b/src/adapters/task-agent/BackgroundEnrich.ts
@@ -10,9 +10,10 @@ import { STATE_FOLDER_MAP, type KanbanColumn } from "./types";
  * the task base path. Returns null if no file with a matching `id` field is found.
  */
 function findFileByUuid(app: App, uuid: string, basePath: string): TFile | null {
+  const normalizedBase = basePath.endsWith("/") ? basePath : basePath + "/";
   const allFiles = app.vault.getMarkdownFiles();
   for (const file of allFiles) {
-    if (!file.path.startsWith(basePath)) continue;
+    if (!file.path.startsWith(normalizedBase)) continue;
     const cache = app.metadataCache.getFileCache(file);
     if (cache?.frontmatter?.id === uuid) {
       return file;
@@ -127,13 +128,26 @@ export async function handleItemCreated(
         // If the file was moved during enrichment, the headless Claude
         // process was working on a stale path. Mark as failed so the user
         // can retry from the correct location.
+        // However, Claude itself renames the pending file as part of
+        // successful enrichment (removing the "-pending-" segment). Only
+        // treat it as a user-initiated move if the UUID-resolved file is
+        // still pending-style OR is in a different folder.
         if (currentPath !== filePath) {
-          console.warn(
-            `[work-terminal] Task moved during enrichment: ${filePath} -> ${currentPath}. Marking for retry.`,
-          );
-          new Notice("Task was moved during enrichment. Right-click the card to retry.", 8000);
-          await markIngestionFailed(app, currentPath);
-          return;
+          const originalFolder = filePath.substring(0, filePath.lastIndexOf("/"));
+          const currentFolder = currentPath.substring(0, currentPath.lastIndexOf("/"));
+          const currentFilename = currentPath.substring(currentPath.lastIndexOf("/") + 1);
+          const isPendingFilename = /pending-[0-9a-f]+/i.test(currentFilename);
+
+          if (currentFolder !== originalFolder || isPendingFilename) {
+            console.warn(
+              `[work-terminal] Task moved during enrichment: ${filePath} -> ${currentPath}. Marking for retry.`,
+            );
+            new Notice("Task was moved during enrichment. Right-click the card to retry.", 8000);
+            await markIngestionFailed(app, currentPath);
+            return;
+          }
+          // Same folder, no longer pending - normal enrichment rename. Let
+          // the success path proceed.
         }
 
         // Success requires an observable outcome: the pending file must have been


### PR DESCRIPTION
## Summary

- When a task is moved (e.g. via kanban drag-drop) while background enrichment is still running, the enrichment process now detects the move by resolving the file via UUID instead of the stale original path
- Moved tasks are marked with `background-ingestion: failed` at their new location so users can retry via right-click
- All error/timeout paths also use UUID-based resolution so failure marking always targets the correct file

## Details

The root cause was that `handleItemCreated` captured the file path at creation time and used it throughout the enrichment lifecycle. If `TaskMover.move()` relocated the file to a different state folder before enrichment completed, the headless Claude process was working on a non-existent path and the completion handler could not find the file to mark it.

The fix adds `findFileByUuid()` which scans vault markdown files by frontmatter `id` field, and `resolveFileByPathOrUuid()` which tries the original path first then falls back to UUID lookup. The enrichment completion handler now uses this to locate the file regardless of where it has been moved.

Fixes #332

## Test plan

- [x] New test: task moved during enrichment is detected and marked failed at new path
- [x] New test: enrichment error with moved file marks failure at moved path
- [x] New tests: `findFileByUuid` unit tests (match, no match, base path filtering)
- [x] All 763 existing tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)