### PR TITLE
Move excluded states from hardcoded set to adapter config

### DIFF
--- a/src/adapters/task-agent/TaskAgentConfig.ts
+++ b/src/adapters/task-agent/TaskAgentConfig.ts
@@ -33,4 +33,5 @@ export const TASK_AGENT_CONFIG: PluginConfig = {
     jiraBaseUrl: "",
   },
   itemName: "task",
+  terminalStates: ["done", "abandoned"],
 };

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -67,6 +67,8 @@ export interface PluginConfig {
   defaultSettings: Record<string, unknown>;
   /** Singular noun for items (e.g. "task", "ticket"). Used in UI labels. */
   itemName: string;
+  /** Column/state IDs considered terminal (completed/archived). Items in these states are excluded from "Move to Item" menus and similar UI elements. */
+  terminalStates?: string[];
 }
 
 /**

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -792,7 +792,7 @@ export class TerminalPanelView {
     if (this.allItems.length > 0) {
       menu.addSeparator();
       const activeItemId = this.tabManager.getActiveItemId();
-      const excludedStates = new Set(["done", "abandoned", "archive"]);
+      const excludedStates = new Set(this.adapter.config.terminalStates ?? []);
       const available = this.allItems.filter(
         (wi) => wi.id !== activeItemId && !excludedStates.has(wi.state),
       );


### PR DESCRIPTION
## Summary

- Adds optional `terminalStates` property to `PluginConfig` interface so adapters can declare which states are terminal (completed/archived)
- Task-agent adapter now provides `["done", "abandoned"]` as its terminal states
- `TerminalPanelView` reads from adapter config instead of hardcoding `["done", "abandoned", "archive"]`

Fixes #340

## Test plan

- [ ] All 765 existing tests pass
- [ ] Build succeeds with no type errors
- [ ] "Move to Item" context menu excludes done/abandoned items (same behavior as before for task-agent)
- [ ] A hypothetical adapter with different terminal states would filter correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)