### PR TITLE
Make Copilot session log directory configurable

### DIFF
--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -180,6 +180,8 @@ export class TerminalTab {
 
   // Deferred session ID detection (Copilot context sessions)
   private _sessionDetector: CopilotSessionDetector | null = null;
+  /** Override the session log directory from agent config (set from user settings). */
+  sessionLogDirOverride?: string;
 
   // Rename detection
   private _renameDecoder = new StringDecoder("utf8");
@@ -1113,16 +1115,13 @@ export class TerminalTab {
   private _initDeferredSessionDetector(): void {
     const { agentType } = sessionTypeToAgentType(this.sessionType);
     const resumeConfig = getResumeConfig(agentType);
-    if (
-      !resumeConfig.deferSessionId ||
-      !resumeConfig.sessionLogDir ||
-      !resumeConfig.sessionLogPattern
-    ) {
+    const sessionLogDir = this.sessionLogDirOverride || resumeConfig.sessionLogDir;
+    if (!resumeConfig.deferSessionId || !sessionLogDir || !resumeConfig.sessionLogPattern) {
       return;
     }
 
     this._sessionDetector = new CopilotSessionDetector({
-      logDir: resumeConfig.sessionLogDir,
+      logDir: sessionLogDir,
       logPattern: resumeConfig.sessionLogPattern,
       spawnTime: this.spawnTime,
     });

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -22,6 +22,7 @@ interface CoreSettings {
   "core.claudeExtraArgs": string;
   "core.copilotCommand": string;
   "core.copilotExtraArgs": string;
+  "core.copilotSessionLogDir": string;
   "core.strandsCommand": string;
   "core.strandsExtraArgs": string;
   "core.additionalAgentContext": string;
@@ -39,6 +40,7 @@ const CORE_DEFAULTS: CoreSettings = {
   "core.claudeExtraArgs": "",
   "core.copilotCommand": "copilot",
   "core.copilotExtraArgs": "",
+  "core.copilotSessionLogDir": "~/.copilot/logs",
   "core.strandsCommand": "strands",
   "core.strandsExtraArgs": "",
   "core.additionalAgentContext": "",
@@ -116,6 +118,12 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
       "core.defaultTerminalCwd",
       "Default terminal CWD",
       "Working directory for new terminals (supports ~)",
+    );
+    this.addCoreSetting(
+      containerEl,
+      "core.copilotSessionLogDir",
+      "Copilot session log directory",
+      "Directory where Copilot CLI writes session logs. Used for deferred session ID detection. Supports ~ expansion.",
     );
     this.addCoreToggle(
       containerEl,

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -1514,6 +1514,12 @@ export class TerminalPanelView {
 
     if (!tab) return;
 
+    // Pass user-configured session log directory override for deferred detection
+    const copilotLogDir = this.getStringSetting(fresh, "core.copilotSessionLogDir", "");
+    if (copilotLogDir) {
+      tab.sessionLogDirOverride = copilotLogDir;
+    }
+
     if (persisted.profileId) {
       tab.profileId = persisted.profileId;
       const profile = this.profileManager?.getProfile(persisted.profileId);
@@ -1717,6 +1723,12 @@ export class TerminalPanelView {
     }
 
     if (!replacement) return;
+
+    // Pass user-configured session log directory override for deferred detection
+    const copilotLogDir = this.getStringSetting(fresh, "core.copilotSessionLogDir", "");
+    if (copilotLogDir) {
+      replacement.sessionLogDirOverride = copilotLogDir;
+    }
 
     // Close the old tab first, then move replacement to the old position
     this.tabManager.closeTabInstance(targetItemId, tab);
@@ -2387,8 +2399,15 @@ export class TerminalPanelView {
       [resolved, ...args],
       sessionId ?? null,
     );
-    if (tab && this.adapter.transformSessionLabel) {
-      tab.transformLabel = (old, detected) => this.adapter.transformSessionLabel!(old, detected);
+    if (tab) {
+      // Pass user-configured session log directory override for deferred detection
+      const copilotLogDir = this.getStringSetting(fresh, "core.copilotSessionLogDir", "");
+      if (copilotLogDir) {
+        tab.sessionLogDirOverride = copilotLogDir;
+      }
+      if (this.adapter.transformSessionLabel) {
+        tab.transformLabel = (old, detected) => this.adapter.transformSessionLabel!(old, detected);
+      }
     }
     this.renderTabBar();
     return tab;


### PR DESCRIPTION
## Summary

- Adds `core.copilotSessionLogDir` setting (default: `~/.copilot/logs`) so users with non-default Copilot installations can override the log directory used for deferred session ID detection
- Setting appears in the Core section of the plugin settings tab with tilde expansion support
- Override is propagated through all tab creation paths: fresh spawn, resume, relaunch, and restart

Fixes #342

## Test plan

- [ ] Verify default behavior unchanged: Copilot context sessions still detect session IDs from `~/.copilot/logs`
- [ ] Change setting to a custom path and verify the detector uses the new path
- [ ] Verify the setting appears in Settings > Core section
- [ ] Run `pnpm exec vitest run` - all 765 tests pass
- [ ] Build succeeds with `pnpm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)