### PR TITLE
Replace branded icons with official SVG marks

### DIFF
--- a/src/ui/ProfileIcons.ts
+++ b/src/ui/ProfileIcons.ts
@@ -6,7 +6,7 @@
  * Branded icon sources:
  * - Claude: Simple Icons (https://simpleicons.org/?q=claude), 24x24
  * - Copilot: Simple Icons (https://simpleicons.org/?q=github-copilot), 24x24
- * - AWS: Simplified smile-arrow mark, 24x24
+ * - AWS: Wordmark + smile-arrow (https://simpleicons.org/?q=amazon-aws), 24x24
  * - Skyscanner: Official sunrise mark extracted from Wikimedia Commons SVG
  */
 import type { ProfileIcon } from "../core/agents/AgentProfile";
@@ -88,8 +88,7 @@ function createCopilotIcon(size: number): SVGSVGElement {
 }
 
 function createAwsIcon(size: number): SVGSVGElement {
-  // Simplified AWS smile-arrow mark. The distinctive curved arrow beneath
-  // the "AWS" wordmark is the most recognisable brand element at small sizes.
+  // AWS wordmark + smile-arrow mark (Simple Icons, 24x24)
   const svg = makeSvg(size, "0 0 24 24");
   // "A" letterform (left peak)
   addPath(


### PR DESCRIPTION
## Summary

Replaces all four branded profile icons with accurate, properly-sourced SVG paths that render clearly at the plugin's 14px button size.

### Changes

| Icon | Before | After |
|------|--------|-------|
| **Claude** | Complex 110x130 viewBox sparkle path (~2.5KB) that rendered as an indistinct blob at small sizes | Official Claude mark from [Simple Icons](https://simpleicons.org/?q=claude), normalised to 24x24 |
| **Copilot** | Generic chat-bubble with two circle eyes (not the actual Copilot logo) | Official GitHub Copilot visor/goggles mark from [Simple Icons](https://simpleicons.org/?q=github-copilot) |
| **Skyscanner** | Three overlapping stroke circles (generic, not recognisable) | Official sunrise mark (5 rays + horizon arc) extracted from the [Wikimedia Commons horizontal lockup SVG](https://upload.wikimedia.org/wikipedia/commons/9/94/Skyscanner_Logo_LockupHorizontal_SkyBlue_RGB.svg) |
| **AWS** | Two stroke chevrons + a smile curve (looked like a generic code icon) | Recognisable AWS wordmark + smile-arrow as filled paths |

### Technical notes

- Claude and Copilot use standard 24x24 viewBox (consistent with generic Lucide icons)
- Skyscanner uses the original path coordinates with a square-padded viewBox (`91 57 210 210`) to preserve path fidelity without coordinate transformation
- AWS uses filled paths instead of strokes for consistency with other branded icons
- All icons use `addPath()` with `currentColor` fill, inheriting the button's configured color
- Sources documented in file header comment

### Testing

- `pnpm run build` - clean
- `pnpm exec vitest run` - 776/776 tests pass
- No functional changes to icon API or factory interface