### PR TITLE
Add Option+Up/Down arrow key support to keyboard capture

### DIFF
--- a/src/core/terminal/KeyboardCapture.test.ts
+++ b/src/core/terminal/KeyboardCapture.test.ts
@@ -199,6 +199,42 @@ describe("KeyboardCapture", () => {
     expect(event.defaultPrevented).toBe(false);
   });
 
+  it("sends Option+Up and Option+Down as CSI sequences with Alt modifier", () => {
+    const write = vi.fn();
+    const cleanup = attachCapturePhase(
+      containerEl,
+      () =>
+        ({
+          stdin: { destroyed: false, write },
+        }) as any,
+    );
+
+    const upEvent = new KeyboardEvent("keydown", {
+      key: "ArrowUp",
+      code: "ArrowUp",
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(upEvent);
+
+    const downEvent = new KeyboardEvent("keydown", {
+      key: "ArrowDown",
+      code: "ArrowDown",
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(downEvent);
+
+    cleanup();
+
+    expect(write).toHaveBeenNthCalledWith(1, "\x1b[1;3A");
+    expect(write).toHaveBeenNthCalledWith(2, "\x1b[1;3B");
+    expect(upEvent.defaultPrevented).toBe(true);
+    expect(downEvent.defaultPrevented).toBe(true);
+  });
+
   it("does not treat Cmd+Shift+F as plain Cmd+F", () => {
     const onSearch = vi.fn();
     const cleanup = attachCapturePhase(containerEl, () => null, onSearch);

--- a/src/core/terminal/KeyboardCapture.ts
+++ b/src/core/terminal/KeyboardCapture.ts
@@ -75,6 +75,12 @@ export function attachCapturePhase(
     } else if (e.altKey && e.key === "ArrowRight") {
       // ESC f - word forward
       seq = "\x1bf";
+    } else if (e.altKey && e.key === "ArrowUp") {
+      // CSI 1;3A - Alt+Up (history search / scroll in many terminal apps)
+      seq = "\x1b[1;3A";
+    } else if (e.altKey && e.key === "ArrowDown") {
+      // CSI 1;3B - Alt+Down (history search / scroll in many terminal apps)
+      seq = "\x1b[1;3B";
     } else if (e.altKey && e.key === "Backspace") {
       // ESC DEL - delete word backward
       seq = "\x1b\x7f";


### PR DESCRIPTION
## Summary

Intercept Alt+ArrowUp and Alt+ArrowDown in the capture-phase keyboard handler and synthesize the standard CSI sequences with Alt modifier (`ESC[1;3A` and `ESC[1;3B`) to PTY stdin.

### Problem

Option+Up and Option+Down key combinations were not usable in the terminal. Obsidian's capture-phase handlers intercepted them before they reached xterm.js.

### Fix

Added two new cases to the capture-phase handler in `KeyboardCapture.ts`, following the same pattern as the existing Option+ArrowLeft/Right handling. The sequences use the standard CSI modifier encoding (parameter 3 = Alt).

### Testing

- Added test: `sends Option+Up and Option+Down as CSI sequences with Alt modifier`
- All 777 tests pass
- Build clean

Fixes #350