### PR TITLE
Stop input/composition events propagating from terminal container

### DIFF
--- a/src/core/terminal/KeyboardCapture.test.ts
+++ b/src/core/terminal/KeyboardCapture.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { attachCapturePhase } from "./KeyboardCapture";
+import { attachBubbleCapture, attachCapturePhase, attachInputCapture } from "./KeyboardCapture";
 
 describe("KeyboardCapture", () => {
   let containerEl: HTMLDivElement;
@@ -253,5 +253,114 @@ describe("KeyboardCapture", () => {
 
     expect(onSearch).not.toHaveBeenCalled();
     expect(event.defaultPrevented).toBe(false);
+  });
+});
+
+describe("attachBubbleCapture", () => {
+  it("stops keydown and keyup propagation on the container", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const parentSpy = vi.fn();
+    document.body.addEventListener("keydown", parentSpy);
+    document.body.addEventListener("keyup", parentSpy);
+
+    const cleanup = attachBubbleCapture(container);
+
+    container.dispatchEvent(new KeyboardEvent("keydown", { key: "#", bubbles: true }));
+    container.dispatchEvent(new KeyboardEvent("keyup", { key: "#", bubbles: true }));
+
+    expect(parentSpy).not.toHaveBeenCalled();
+
+    cleanup();
+    document.body.removeEventListener("keydown", parentSpy);
+    document.body.removeEventListener("keyup", parentSpy);
+  });
+});
+
+describe("attachInputCapture", () => {
+  it("stops input events from propagating outside the container", () => {
+    const container = document.createElement("div");
+    const textarea = document.createElement("textarea");
+    container.appendChild(textarea);
+    document.body.appendChild(container);
+
+    const parentSpy = vi.fn();
+    document.body.addEventListener("input", parentSpy);
+
+    const cleanup = attachInputCapture(container);
+
+    // Simulate an input event originating from the textarea
+    const inputEvent = new Event("input", { bubbles: true });
+    textarea.dispatchEvent(inputEvent);
+
+    expect(parentSpy).not.toHaveBeenCalled();
+
+    cleanup();
+    document.body.removeEventListener("input", parentSpy);
+  });
+
+  it("stops beforeinput events from propagating outside the container", () => {
+    const container = document.createElement("div");
+    const textarea = document.createElement("textarea");
+    container.appendChild(textarea);
+    document.body.appendChild(container);
+
+    const parentSpy = vi.fn();
+    document.body.addEventListener("beforeinput", parentSpy);
+
+    const cleanup = attachInputCapture(container);
+
+    const beforeInputEvent = new Event("beforeinput", { bubbles: true });
+    textarea.dispatchEvent(beforeInputEvent);
+
+    expect(parentSpy).not.toHaveBeenCalled();
+
+    cleanup();
+    document.body.removeEventListener("beforeinput", parentSpy);
+  });
+
+  it("stops composition events from propagating outside the container", () => {
+    const container = document.createElement("div");
+    const textarea = document.createElement("textarea");
+    container.appendChild(textarea);
+    document.body.appendChild(container);
+
+    const parentSpy = vi.fn();
+    const events = ["compositionstart", "compositionupdate", "compositionend"];
+    for (const evt of events) {
+      document.body.addEventListener(evt, parentSpy);
+    }
+
+    const cleanup = attachInputCapture(container);
+
+    for (const evt of events) {
+      textarea.dispatchEvent(new Event(evt, { bubbles: true }));
+    }
+
+    expect(parentSpy).not.toHaveBeenCalled();
+
+    cleanup();
+    for (const evt of events) {
+      document.body.removeEventListener(evt, parentSpy);
+    }
+  });
+
+  it("removes listeners on cleanup", () => {
+    const container = document.createElement("div");
+    const textarea = document.createElement("textarea");
+    container.appendChild(textarea);
+    document.body.appendChild(container);
+
+    const parentSpy = vi.fn();
+    document.body.addEventListener("input", parentSpy);
+
+    const cleanup = attachInputCapture(container);
+    cleanup();
+
+    // After cleanup, events should propagate normally
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(parentSpy).toHaveBeenCalledTimes(1);
+
+    document.body.removeEventListener("input", parentSpy);
   });
 });

--- a/src/core/terminal/KeyboardCapture.ts
+++ b/src/core/terminal/KeyboardCapture.ts
@@ -34,6 +34,41 @@ export function attachBubbleCapture(containerEl: HTMLElement): () => void {
 }
 
 /**
+ * Attach bubble-phase interception for input, beforeinput, and composition
+ * events on a container element.
+ *
+ * Obsidian has document-level handlers that react to input events (e.g.
+ * markdown heading detection when `#` is typed).  When xterm's hidden
+ * textarea emits these events they can bubble up and trigger Obsidian's
+ * processing, corrupting the terminal's rendered output.  Stopping
+ * propagation at the container keeps them inside the terminal tree where
+ * xterm has already handled them.
+ */
+export function attachInputCapture(containerEl: HTMLElement): () => void {
+  const stop = (e: Event) => {
+    e.stopPropagation();
+  };
+
+  const events = [
+    "input",
+    "beforeinput",
+    "compositionstart",
+    "compositionupdate",
+    "compositionend",
+  ] as const;
+
+  for (const evt of events) {
+    containerEl.addEventListener(evt, stop, false);
+  }
+
+  return () => {
+    for (const evt of events) {
+      containerEl.removeEventListener(evt, stop, false);
+    }
+  };
+}
+
+/**
  * Attach capture-phase keyboard interception on document for modifier combos
  * that Obsidian steals in its own capture-phase handlers.
  *

--- a/src/core/terminal/TerminalTab.config.test.ts
+++ b/src/core/terminal/TerminalTab.config.test.ts
@@ -44,6 +44,7 @@ const mocks = vi.hoisted(() => {
     attachScrollButton: vi.fn(),
     attachBubbleCapture: vi.fn(),
     attachCapturePhase: vi.fn(() => vi.fn()),
+    attachInputCapture: vi.fn(() => vi.fn()),
     electronShell: { openExternal: vi.fn() },
   };
 });
@@ -59,6 +60,7 @@ vi.mock("./ScrollButton", () => ({
 vi.mock("./KeyboardCapture", () => ({
   attachBubbleCapture: mocks.attachBubbleCapture,
   attachCapturePhase: mocks.attachCapturePhase,
+  attachInputCapture: mocks.attachInputCapture,
 }));
 
 vi.mock("../utils", () => ({

--- a/src/core/terminal/TerminalTab.test.ts
+++ b/src/core/terminal/TerminalTab.test.ts
@@ -54,6 +54,7 @@ const mocks = vi.hoisted(() => {
     attachScrollButton: vi.fn(() => vi.fn()),
     attachBubbleCapture: vi.fn(() => vi.fn()),
     attachCapturePhase: vi.fn(() => vi.fn()),
+    attachInputCapture: vi.fn(() => vi.fn()),
     electronShell: { openExternal: vi.fn() },
     fsModule: {
       existsSync: vi.fn(() => false),
@@ -82,6 +83,7 @@ vi.mock("./ScrollButton", () => ({
 vi.mock("./KeyboardCapture", () => ({
   attachBubbleCapture: mocks.attachBubbleCapture,
   attachCapturePhase: mocks.attachCapturePhase,
+  attachInputCapture: mocks.attachInputCapture,
 }));
 
 vi.mock("../utils", () => ({
@@ -181,6 +183,7 @@ describe("TerminalTab hot-reload addon handling", () => {
     mocks.attachScrollButton.mockClear();
     mocks.attachBubbleCapture.mockClear();
     mocks.attachCapturePhase.mockClear();
+    mocks.attachInputCapture.mockClear();
     mocks.electronShell.openExternal.mockClear();
     vi.stubGlobal("ResizeObserver", MockResizeObserver as unknown as typeof ResizeObserver);
     vi.stubGlobal("requestAnimationFrame", ((callback: FrameRequestCallback) => {
@@ -1324,6 +1327,7 @@ describe("TerminalTab auto-scroll on write", () => {
     mocks.attachScrollButton.mockClear();
     mocks.attachBubbleCapture.mockClear();
     mocks.attachCapturePhase.mockClear();
+    mocks.attachInputCapture.mockClear();
     vi.stubGlobal(
       "ResizeObserver",
       class {

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -16,7 +16,7 @@ import { Notice } from "obsidian";
 import { expandTilde, stripAnsi, electronRequire } from "../utils";
 import { injectXtermCss } from "./XtermCss";
 import { attachScrollButton } from "./ScrollButton";
-import { attachBubbleCapture, attachCapturePhase } from "./KeyboardCapture";
+import { attachBubbleCapture, attachCapturePhase, attachInputCapture } from "./KeyboardCapture";
 import {
   checkPython3Available,
   hasPython3BeenNotified,
@@ -297,6 +297,11 @@ export class TerminalTab {
       () => this.toggleSearchBar(),
     );
     this._documentCleanups.push(captureCleanup);
+
+    // Input event isolation - prevent Obsidian from processing input/
+    // composition events from xterm's textarea (fixes #354: # corruption)
+    const inputCleanup = attachInputCapture(this.containerEl);
+    this._documentCleanups.push(inputCleanup);
 
     // Ensure clicking the terminal area gives xterm focus
     const clickHandler = () => {
@@ -1412,7 +1417,8 @@ export class TerminalTab {
       () => tab.process,
       () => tab.toggleSearchBar(),
     );
-    tab._documentCleanups = [bubbleCleanup, captureCleanup];
+    const inputCleanup = attachInputCapture(stored.containerEl);
+    tab._documentCleanups = [bubbleCleanup, captureCleanup, inputCleanup];
 
     // Click-to-focus
     const clickHandler = () => {


### PR DESCRIPTION
## Problem

Typing or displaying the `#` character in the terminal causes widespread rendering corruption across the visible terminal buffer (#354).

## Root cause

The plugin stops `keydown`/`keyup` propagation from the terminal container to prevent Obsidian from intercepting keyboard events (via `attachBubbleCapture`). However, `input`, `beforeinput`, and composition events were **not** stopped, allowing Obsidian's document-level handlers to react to characters typed into xterm's hidden textarea - specifically `#`, which Obsidian may interpret as a markdown heading trigger.

## Fix

Added `attachInputCapture()` to `KeyboardCapture.ts` that stops propagation of:
- `input`
- `beforeinput`
- `compositionstart`
- `compositionupdate`
- `compositionend`

Applied to both new tab creation and session recovery (`fromStored`) paths.

## Verification

- Unable to fully replicate the corruption via CDP automation (synthetic events don't trigger Obsidian's internal handlers the same way physical keyboard events do)
- Verified in isolated Obsidian instance that terminal output containing `#` renders correctly and typing `#` reaches the shell without corruption
- 851 tests pass (5 new tests for `attachInputCapture`, 1 new test for `attachBubbleCapture`)

Fixes #354