### PR TITLE
Add configurable enrichment timeout setting

### DIFF
--- a/src/adapters/task-agent/BackgroundEnrich.test.ts
+++ b/src/adapters/task-agent/BackgroundEnrich.test.ts
@@ -6,6 +6,7 @@ const { spawnHeadlessClaudeMock } = vi.hoisted(() => ({
 
 vi.mock("../../core/claude/HeadlessClaude", () => ({
   spawnHeadlessClaude: spawnHeadlessClaudeMock,
+  DEFAULT_TIMEOUT_MS: 300_000,
 }));
 
 import {
@@ -13,6 +14,7 @@ import {
   insertIngestionFailedFlag,
   prepareRetryEnrichment,
   findFileByUuid,
+  resolveEnrichmentTimeout,
 } from "./BackgroundEnrich";
 
 describe("BackgroundEnrich", () => {
@@ -239,6 +241,7 @@ describe("BackgroundEnrich", () => {
         "/Users/tester/launch-root",
         "./bin/claude-wrapper",
         "--allowedTools Edit",
+        300_000,
       );
     });
 
@@ -542,6 +545,26 @@ describe("BackgroundEnrich", () => {
       const modifyCall = app.vault.modify.mock.calls.at(-1)!;
       expect(modifyCall[0].path).toBe(movedPath);
     });
+
+    it("passes custom enrichment timeout to spawnHeadlessClaude", async () => {
+      spawnHeadlessClaudeMock.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+      const app = makeItemCreatedApp({ fileExistsAfterEnrich: false });
+      const settings = {
+        ...defaultSettings,
+        "adapter.enrichmentTimeout": "120",
+      };
+
+      const result = await handleItemCreated(app, "Timeout test", settings);
+      await result.enrichmentDone;
+
+      expect(spawnHeadlessClaudeMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.any(String),
+        expect.any(String),
+        120_000,
+      );
+    });
   });
 
   describe("findFileByUuid", () => {
@@ -608,6 +631,44 @@ describe("BackgroundEnrich", () => {
 
       const result = findFileByUuid(app, "target-uuid", "2 - Areas/Tasks");
       expect(result).toBe(taskFile);
+    });
+  });
+
+  describe("resolveEnrichmentTimeout", () => {
+    it("returns DEFAULT_TIMEOUT_MS when setting is empty string", () => {
+      expect(resolveEnrichmentTimeout({ "adapter.enrichmentTimeout": "" })).toBe(300_000);
+    });
+
+    it("returns DEFAULT_TIMEOUT_MS when setting is undefined", () => {
+      expect(resolveEnrichmentTimeout({})).toBe(300_000);
+    });
+
+    it("returns DEFAULT_TIMEOUT_MS when setting is null", () => {
+      expect(resolveEnrichmentTimeout({ "adapter.enrichmentTimeout": null })).toBe(300_000);
+    });
+
+    it("converts seconds to milliseconds", () => {
+      expect(resolveEnrichmentTimeout({ "adapter.enrichmentTimeout": "120" })).toBe(120_000);
+    });
+
+    it("handles string numbers correctly", () => {
+      expect(resolveEnrichmentTimeout({ "adapter.enrichmentTimeout": "600" })).toBe(600_000);
+    });
+
+    it("returns DEFAULT_TIMEOUT_MS for non-numeric strings", () => {
+      expect(resolveEnrichmentTimeout({ "adapter.enrichmentTimeout": "abc" })).toBe(300_000);
+    });
+
+    it("returns DEFAULT_TIMEOUT_MS for zero", () => {
+      expect(resolveEnrichmentTimeout({ "adapter.enrichmentTimeout": "0" })).toBe(300_000);
+    });
+
+    it("returns DEFAULT_TIMEOUT_MS for negative values", () => {
+      expect(resolveEnrichmentTimeout({ "adapter.enrichmentTimeout": "-10" })).toBe(300_000);
+    });
+
+    it("rounds fractional seconds to whole milliseconds", () => {
+      expect(resolveEnrichmentTimeout({ "adapter.enrichmentTimeout": "1.5" })).toBe(1500);
     });
   });
 });

--- a/src/adapters/task-agent/BackgroundEnrich.ts
+++ b/src/adapters/task-agent/BackgroundEnrich.ts
@@ -1,5 +1,5 @@
 import { Notice, type App, type TFile } from "obsidian";
-import { spawnHeadlessClaude } from "../../core/claude/HeadlessClaude";
+import { spawnHeadlessClaude, DEFAULT_TIMEOUT_MS } from "../../core/claude/HeadlessClaude";
 import { generateTaskContent, generatePendingFilename } from "./TaskFileTemplate";
 import type { SplitSource } from "./TaskFileTemplate";
 import { expandTilde } from "../../core/utils";
@@ -62,6 +62,19 @@ function resolveClaudeLaunchCwd(settings: Record<string, any>): string {
 }
 
 /**
+ * Resolve the enrichment timeout from settings. The setting is stored as a
+ * string representing seconds. Returns the timeout in milliseconds, falling
+ * back to DEFAULT_TIMEOUT_MS if the value is empty or invalid.
+ */
+export function resolveEnrichmentTimeout(settings: Record<string, any>): number {
+  const raw = settings["adapter.enrichmentTimeout"];
+  if (raw == null || raw === "") return DEFAULT_TIMEOUT_MS;
+  const seconds = Number(raw);
+  if (!Number.isFinite(seconds) || seconds <= 0) return DEFAULT_TIMEOUT_MS;
+  return Math.round(seconds * 1000);
+}
+
+/**
  * Detect known patterns in Claude stdout that indicate silent failure despite exit code 0.
  * Returns a short description of the failure, or null if none detected.
  */
@@ -112,12 +125,14 @@ export async function handleItemCreated(
   const promptTemplate =
     (settings["adapter.enrichmentPrompt"] as string) || DEFAULT_ENRICHMENT_PROMPT;
   const enrichPrompt = resolveEnrichmentPrompt(promptTemplate, fullPath);
+  const timeoutMs = resolveEnrichmentTimeout(settings);
 
   const enrichmentDone = spawnHeadlessClaude(
     enrichPrompt,
     resolveClaudeLaunchCwd(settings),
     claudeCommand,
     claudeExtraArgs,
+    timeoutMs,
   ).then(
     async (result) => {
       // Resolve current file location: original path may have changed if

--- a/src/adapters/task-agent/TaskAgentConfig.ts
+++ b/src/adapters/task-agent/TaskAgentConfig.ts
@@ -51,6 +51,14 @@ export const TASK_AGENT_CONFIG: PluginConfig = {
       type: "text",
       default: "",
     },
+    {
+      key: "enrichmentTimeout",
+      name: "Enrichment timeout (seconds)",
+      description:
+        "Maximum time in seconds for background enrichment before it is killed. Leave empty for default (300s / 5 min).",
+      type: "text",
+      default: "",
+    },
   ],
   defaultSettings: {
     taskBasePath: "2 - Areas/Tasks",
@@ -58,6 +66,7 @@ export const TASK_AGENT_CONFIG: PluginConfig = {
     enrichmentEnabled: true,
     enrichmentPrompt: "",
     retryEnrichmentPrompt: "",
+    enrichmentTimeout: "",
   },
   itemName: "task",
   terminalStates: ["done", "abandoned"],

--- a/src/core/claude/HeadlessClaude.ts
+++ b/src/core/claude/HeadlessClaude.ts
@@ -15,7 +15,7 @@ import { expandTilde, electronRequire } from "../utils";
 /** Default timeout: 5 minutes. Enrichment involves skill loading, duplicate
  *  checks, goal alignment, related-task detection, and file rename - 2 min
  *  was consistently too short (see #327). */
-const DEFAULT_TIMEOUT_MS = 300_000;
+export const DEFAULT_TIMEOUT_MS = 300_000;
 
 /** Grace period after SIGTERM before sending SIGKILL. */
 const SIGKILL_GRACE_MS = 5_000;


### PR DESCRIPTION
## Summary

Adds a user-configurable timeout for background enrichment operations (#355).

## Changes

- **TaskAgentConfig.ts**: New `enrichmentTimeout` setting (text field, accepts seconds, empty = default 300s)
- **HeadlessClaude.ts**: Exported `DEFAULT_TIMEOUT_MS` constant for reuse
- **BackgroundEnrich.ts**: Added `resolveEnrichmentTimeout()` helper that parses the setting value (with validation for non-numeric, zero, negative) and passes it to `spawnHeadlessClaude`
- **BackgroundEnrich.test.ts**: 10 new tests - 9 for edge cases of `resolveEnrichmentTimeout`, 1 integration test verifying the timeout flows through

## Testing

861 tests pass. The setting appears in the plugin settings UI under the enrichment section. Default behavior is unchanged when the field is left empty.

Closes #355