### PR TITLE
Add pi as branded icon for agent profiles

### DIFF
--- a/src/core/agents/AgentProfile.ts
+++ b/src/core/agents/AgentProfile.ts
@@ -34,6 +34,7 @@ export const PROFILE_ICONS = [
   "copilot",
   "aws",
   "skyscanner",
+  "pi",
 ] as const;
 
 export type ProfileIcon = (typeof PROFILE_ICONS)[number];
@@ -47,6 +48,7 @@ export const BRAND_COLORS: Partial<Record<ProfileIcon, string>> = {
   copilot: "#6E40C9",
   aws: "#FF9900",
   skyscanner: "#0770E3",
+  pi: "#00C853",
 };
 
 // ---------------------------------------------------------------------------

--- a/src/ui/ProfileIcons.test.ts
+++ b/src/ui/ProfileIcons.test.ts
@@ -34,7 +34,7 @@ describe("ProfileIcons", () => {
   });
 
   describe("branded icons", () => {
-    const brandedIcons: ProfileIcon[] = ["claude", "copilot", "aws", "skyscanner", "bee"];
+    const brandedIcons: ProfileIcon[] = ["claude", "copilot", "aws", "skyscanner", "bee", "pi"];
 
     for (const icon of brandedIcons) {
       it(`creates ${icon} icon with path elements`, () => {
@@ -63,6 +63,23 @@ describe("ProfileIcons", () => {
     it("skyscanner icon uses padded viewBox for original coordinates", () => {
       const svg = createProfileIcon("skyscanner");
       expect(svg!.getAttribute("viewBox")).toBe("91 57 210 210");
+    });
+
+    it("pi icon uses 800x800 viewBox from official logo", () => {
+      const svg = createProfileIcon("pi");
+      expect(svg!.getAttribute("viewBox")).toBe("0 0 800 800");
+    });
+
+    it("pi icon has 2 path elements (P shape with cutout + i dot)", () => {
+      const svg = createProfileIcon("pi");
+      const paths = svg!.querySelectorAll("path");
+      expect(paths.length).toBe(2);
+    });
+
+    it("pi icon P shape uses evenodd fill-rule for cutout", () => {
+      const svg = createProfileIcon("pi");
+      const firstPath = svg!.querySelector("path");
+      expect(firstPath!.getAttribute("fill-rule")).toBe("evenodd");
     });
 
     it("aws icon has 5 path elements (A, W, S, smile, arrowhead)", () => {

--- a/src/ui/ProfileIcons.ts
+++ b/src/ui/ProfileIcons.ts
@@ -157,6 +157,24 @@ function createSkyscannerIcon(size: number): SVGSVGElement {
   return svg;
 }
 
+function createPiIcon(size: number): SVGSVGElement {
+  // pi (pi-coding-agent) geometric logo from https://pi.dev/logo.svg
+  // Blocky "P" with inner cutout + square "i" dot, viewBox 0 0 800 800
+  const svg = makeSvg(size, "0 0 800 800");
+  // P shape (outer boundary clockwise, inner hole counter-clockwise via fill-rule)
+  const p = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  p.setAttribute("fill", "currentColor");
+  p.setAttribute("fill-rule", "evenodd");
+  p.setAttribute(
+    "d",
+    "M165.29 165.29H517.36V400H400V517.36H282.65V634.72H165.29Z M282.65 282.65V400H400V282.65Z",
+  );
+  svg.appendChild(p);
+  // i dot
+  addPath(svg, "M517.36 400H634.72V634.72H517.36Z");
+  return svg;
+}
+
 function createBeeIcon(size: number): SVGSVGElement {
   // Literal bee illustration
   const svg = makeSvg(size, "0 0 24 24");
@@ -348,6 +366,7 @@ const ICON_FACTORIES: Record<ProfileIcon, (size: number) => SVGSVGElement> = {
   copilot: createCopilotIcon,
   aws: createAwsIcon,
   skyscanner: createSkyscannerIcon,
+  pi: createPiIcon,
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds pi (pi-coding-agent) as a recognised agent with a branded icon in agent profiles (#356).

## Changes

- **AgentProfile.ts**: Added `'pi'` to `PROFILE_ICONS` array, added `pi: '#00C853'` to `BRAND_COLORS`
- **ProfileIcons.ts**: Added `createPiIcon()` using the official geometric logo from [pi.dev/logo.svg](https://pi.dev/logo.svg) - a blocky P shape with evenodd fill-rule cutout + square i-dot, using the original 800x800 viewBox
- **ProfileIcons.test.ts**: 4 new tests covering the branded icon list, viewBox, path element count, and fill-rule

## Result

pi now appears as an icon option when configuring agent profiles, consistent with how Claude, Copilot, AWS, and Skyscanner icons are handled. The icon renders at the standard profile icon sizes (14px default, scalable).

865 tests pass.

Closes #356