### PR TITLE
Enable selecting agent profile for background enrichment

### DIFF
--- a/src/adapters/task-agent/BackgroundEnrich.test.ts
+++ b/src/adapters/task-agent/BackgroundEnrich.test.ts
@@ -565,6 +565,44 @@ describe("BackgroundEnrich", () => {
         120_000,
       );
     });
+
+    it("uses profile override command, args, and cwd when provided", async () => {
+      spawnHeadlessClaudeMock.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+      const app = makeItemCreatedApp({ fileExistsAfterEnrich: false });
+
+      const profileOverride = {
+        command: "/custom/agent",
+        args: "--model gpt-4",
+        cwd: "~/projects",
+      };
+
+      const result = await handleItemCreated(app, "Profile test", defaultSettings, profileOverride);
+      await result.enrichmentDone;
+
+      expect(spawnHeadlessClaudeMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining("projects"), // expanded from ~/projects
+        "/custom/agent",
+        "--model gpt-4",
+        expect.any(Number),
+      );
+    });
+
+    it("falls back to core settings when no profile override is provided", async () => {
+      spawnHeadlessClaudeMock.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+      const app = makeItemCreatedApp({ fileExistsAfterEnrich: false });
+
+      const result = await handleItemCreated(app, "Default test", defaultSettings);
+      await result.enrichmentDone;
+
+      expect(spawnHeadlessClaudeMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        "claude",
+        "",
+        expect.any(Number),
+      );
+    });
   });
 
   describe("findFileByUuid", () => {

--- a/src/adapters/task-agent/BackgroundEnrich.ts
+++ b/src/adapters/task-agent/BackgroundEnrich.ts
@@ -89,15 +89,23 @@ export interface ItemCreatedResult {
   enrichmentDone: Promise<void>;
 }
 
+/** Resolved enrichment profile data passed by the adapter. */
+export interface EnrichmentProfileOverride {
+  command: string;
+  args: string;
+  cwd: string;
+}
+
 export async function handleItemCreated(
   app: App,
   title: string,
   settings: Record<string, any>,
+  profileOverride?: EnrichmentProfileOverride,
 ): Promise<ItemCreatedResult> {
   const columnId = (settings._columnId || "todo") as KanbanColumn;
   const basePath = settings["adapter.taskBasePath"] || "2 - Areas/Tasks";
-  const claudeCommand = settings["core.claudeCommand"] || "claude";
-  const claudeExtraArgs = settings["core.claudeExtraArgs"] || "";
+  const claudeCommand = profileOverride?.command || settings["core.claudeCommand"] || "claude";
+  const claudeExtraArgs = profileOverride?.args ?? (settings["core.claudeExtraArgs"] || "");
 
   const id = crypto.randomUUID();
   const content = generateTaskContent(title, columnId, undefined, id);
@@ -127,9 +135,13 @@ export async function handleItemCreated(
   const enrichPrompt = resolveEnrichmentPrompt(promptTemplate, fullPath);
   const timeoutMs = resolveEnrichmentTimeout(settings);
 
+  const enrichCwd = profileOverride?.cwd
+    ? expandTilde(profileOverride.cwd)
+    : resolveClaudeLaunchCwd(settings);
+
   const enrichmentDone = spawnHeadlessClaude(
     enrichPrompt,
-    resolveClaudeLaunchCwd(settings),
+    enrichCwd,
     claudeCommand,
     claudeExtraArgs,
     timeoutMs,

--- a/src/adapters/task-agent/TaskAgentConfig.ts
+++ b/src/adapters/task-agent/TaskAgentConfig.ts
@@ -52,6 +52,15 @@ export const TASK_AGENT_CONFIG: PluginConfig = {
       default: "",
     },
     {
+      key: "enrichmentProfile",
+      name: "Enrichment agent profile",
+      description:
+        "Agent profile to use for background enrichment. The profile's command, arguments, and working directory will be used. Select 'Default' to use the core Claude command settings.",
+      type: "dropdown",
+      default: "",
+      choices: "profiles",
+    },
+    {
       key: "enrichmentTimeout",
       name: "Enrichment timeout (seconds)",
       description:
@@ -66,6 +75,7 @@ export const TASK_AGENT_CONFIG: PluginConfig = {
     enrichmentEnabled: true,
     enrichmentPrompt: "",
     retryEnrichmentPrompt: "",
+    enrichmentProfile: "",
     enrichmentTimeout: "",
   },
   itemName: "task",

--- a/src/adapters/task-agent/index.ts
+++ b/src/adapters/task-agent/index.ts
@@ -18,6 +18,7 @@ import {
   handleItemCreated,
   handleSplitTaskCreated,
   prepareRetryEnrichment,
+  type EnrichmentProfileOverride,
 } from "./BackgroundEnrich";
 import type { KanbanColumn } from "./types";
 
@@ -77,7 +78,8 @@ export class TaskAgentAdapter extends BaseAdapter {
     if (!this._app) {
       throw new Error("TaskAgentAdapter: app not available (no view opened yet)");
     }
-    return handleItemCreated(this._app, title, settings);
+    const profileOverride = settings._enrichmentProfile as EnrichmentProfileOverride | undefined;
+    return handleItemCreated(this._app, title, settings, profileOverride);
   }
 
   async onSplitItem(

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -50,6 +50,12 @@ export interface SettingField {
   type: "text" | "toggle" | "dropdown";
   /** Default value. */
   default: unknown;
+  /**
+   * Dropdown choices. Either a static map (value -> display label) or the
+   * string `"profiles"` to dynamically populate from agent profiles.
+   * Only used when `type` is `"dropdown"`.
+   */
+  choices?: Record<string, string> | "profiles";
 }
 
 /**

--- a/src/framework/PromptBox.ts
+++ b/src/framework/PromptBox.ts
@@ -121,11 +121,25 @@ export class PromptBox {
       // Adapter handles actual file creation
       let hasCardMapping = false;
       if (this.adapter.onItemCreated) {
-        const result = await this.adapter.onItemCreated(title, {
+        // Resolve enrichment profile if one is configured
+        const enrichmentSettings: Record<string, any> = {
           ...this.settings,
           _columnId: columnId,
           _placeholderPath: placeholderPath,
-        });
+        };
+        const profileId = this.settings["adapter.enrichmentProfile"];
+        if (profileId) {
+          const profileMgr = (this.plugin as any).profileManager;
+          const profile = profileMgr?.getProfile?.(profileId);
+          if (profile) {
+            enrichmentSettings._enrichmentProfile = {
+              command: profile.command,
+              args: profile.arguments,
+              cwd: profile.defaultCwd,
+            };
+          }
+        }
+        const result = await this.adapter.onItemCreated(title, enrichmentSettings);
         if (result && result.id) {
           this.onNewItemCreated(result.id, result.columnId, placeholderPath, result.enrichmentDone);
           hasCardMapping = true;

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -332,6 +332,27 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
           });
         }),
       );
+    } else if (field.type === "dropdown") {
+      let choices: Record<string, string>;
+      if (field.choices === "profiles") {
+        // Dynamically populate from agent profiles
+        choices = { "": "Default (core settings)" };
+        for (const profile of this.profileManager.getProfiles()) {
+          choices[profile.id] = profile.name;
+        }
+      } else {
+        choices = (field.choices as Record<string, string>) || {};
+      }
+      setting.addDropdown((dropdown) => {
+        for (const [val, label] of Object.entries(choices)) {
+          dropdown.addOption(val, label);
+        }
+        dropdown.setValue(String(value || "")).onChange(async (newValue) => {
+          await this.saveSettings((settings) => {
+            settings[key] = newValue;
+          });
+        });
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds a dropdown setting to select which agent profile is used for background enrichment (#357). When a profile is selected, its command, arguments, and working directory override the core Claude settings.

## Changes

- **interfaces.ts**: Added `choices` field to `SettingField` - supports static `Record<string, string>` or the `'profiles'` sentinel for dynamic population from agent profiles
- **SettingsTab.ts**: Implemented dropdown rendering in `addAdapterSetting`, including dynamic profile population
- **TaskAgentConfig.ts**: Added `enrichmentProfile` dropdown setting
- **BackgroundEnrich.ts**: Added `EnrichmentProfileOverride` interface; `handleItemCreated` accepts optional profile override for command/args/cwd
- **PromptBox.ts**: Resolves the selected enrichment profile from the profile manager before calling the adapter
- **index.ts** (adapter): Passes resolved profile override through to `handleItemCreated`

## Design decisions

- The profile is resolved in `PromptBox` (framework layer) rather than in the adapter, because only the framework has access to `AgentProfileManager`
- Profile data is passed as an `_enrichmentProfile` key in the settings dict to avoid changing the adapter interface
- Default behaviour is fully preserved when no profile is selected (empty string = use core settings)

## Testing

867 tests pass. 2 new tests:
- Profile override correctly passes command/args/cwd to `spawnHeadlessClaude`
- Fallback to core settings when no profile override is provided

Closes #357