### PR TITLE
Add missing pi label to icon settings dropdown

### DIFF
--- a/src/framework/AgentProfileModal.ts
+++ b/src/framework/AgentProfileModal.ts
@@ -68,6 +68,7 @@ const ICON_LABELS: Record<ProfileIcon, string> = {
   copilot: "Copilot (branded)",
   aws: "AWS (branded)",
   skyscanner: "Skyscanner (branded)",
+  pi: "pi (branded)",
 };
 
 export class AgentProfileEditModal extends Modal {


### PR DESCRIPTION
One-line fix: add `pi: "pi (branded)"` to `ICON_LABELS` in `AgentProfileModal.ts`.

The pi icon was added to the icon registry in #356 but the display label map was missed, causing a blank entry in the Button icon dropdown.

Fixes #362