### PR TITLE
Improve isolated instance cleanup with CDP close and SIGKILL escalation

### DIFF
--- a/scripts/lib/obsidianAutomation.js
+++ b/scripts/lib/obsidianAutomation.js
@@ -1261,20 +1261,57 @@ async function hideObsidianWindow({ host = DEFAULT_HOST, port, timeoutMs = DEFAU
  * Kill an isolated Obsidian instance identified by its --user-data-dir path.
  * Returns the number of processes killed.
  */
-function killIsolatedInstance({ userDataDir, runningProcesses = listRunningObsidianProcesses() }) {
+async function killIsolatedInstance({ userDataDir, runningProcesses = listRunningObsidianProcesses() }) {
   if (!userDataDir) {
     throw new Error("userDataDir is required to identify the isolated instance");
   }
   const resolvedDir = path.resolve(userDataDir);
   const matches = runningProcesses.filter((p) => p.command.includes(`--user-data-dir=${resolvedDir}`));
+
   for (const proc of matches) {
+    // 1. Try graceful CDP close if the process has a debug port
+    if (proc.port) {
+      try {
+        const client = new CDPClient({ host: DEFAULT_HOST, port: proc.port });
+        await client.send("Browser.close");
+        client.destroy();
+        // Give Electron a moment to shut down gracefully
+        await new Promise((r) => setTimeout(r, 1000));
+        if (!isProcessRunning(proc.pid)) continue;
+      } catch {
+        // CDP may not be reachable - fall through to signal-based kill
+      }
+    }
+
+    // 2. Send SIGTERM
     try {
       process.kill(proc.pid, "SIGTERM");
     } catch {
       // Process may have already exited
+      continue;
+    }
+
+    // 3. Wait briefly for graceful exit, then escalate to SIGKILL
+    await new Promise((r) => setTimeout(r, 2000));
+    if (isProcessRunning(proc.pid)) {
+      try {
+        process.kill(proc.pid, "SIGKILL");
+      } catch {
+        // Already gone
+      }
     }
   }
   return matches.length;
+}
+
+/** Check if a process is still running by sending signal 0. */
+function isProcessRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 const _exports = {

--- a/scripts/obsidian-isolated-instance.js
+++ b/scripts/obsidian-isolated-instance.js
@@ -34,7 +34,7 @@ async function main() {
 
   if (config.command === "stop") {
     const userDataDir = path.join(config.vaultDir, ".user-data");
-    const killed = killIsolatedInstance({ userDataDir });
+    const killed = await killIsolatedInstance({ userDataDir });
     console.log(JSON.stringify({ stopped: killed, userDataDir }));
     return;
   }

--- a/src/devtools/obsidianAutomation.test.ts
+++ b/src/devtools/obsidianAutomation.test.ts
@@ -641,14 +641,20 @@ describe("obsidian automation helpers", () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
-  it("killIsolatedInstance requires userDataDir", () => {
-    expect(() => automation.killIsolatedInstance({})).toThrow("userDataDir is required");
+  it("killIsolatedInstance requires userDataDir", async () => {
+    await expect(automation.killIsolatedInstance({})).rejects.toThrow("userDataDir is required");
   });
 
-  it("killIsolatedInstance matches processes by user-data-dir path", () => {
-    const killed: number[] = [];
-    vi.spyOn(process, "kill").mockImplementation(((pid: number) => {
-      killed.push(pid);
+  it("killIsolatedInstance matches processes by user-data-dir path", async () => {
+    const killed: Array<{ pid: number; signal: string }> = [];
+    vi.spyOn(process, "kill").mockImplementation(((pid: number, signal?: string) => {
+      killed.push({ pid, signal: signal || "SIGTERM" });
+      // Simulate process exiting after SIGTERM (signal 0 check throws)
+      if (signal === 0 || signal === undefined) {
+        const err = new Error("ESRCH") as NodeJS.ErrnoException;
+        err.code = "ESRCH";
+        throw err;
+      }
     }) as typeof process.kill);
 
     const runningProcesses = [
@@ -666,12 +672,14 @@ describe("obsidian automation helpers", () => {
       },
     ];
 
-    const count = automation.killIsolatedInstance({
+    const count = await automation.killIsolatedInstance({
       userDataDir: "/tmp/vault-a/.user-data",
       runningProcesses,
     });
     expect(count).toBe(1);
-    expect(killed).toEqual([100]);
+    // Should have sent SIGTERM then checked if still running (signal 0)
+    expect(killed.some((k) => k.pid === 100 && k.signal === "SIGTERM")).toBe(true);
+    expect(killed.every((k) => k.pid !== 200)).toBe(true);
   });
 
   it("exports OBSIDIAN_BINARY as a lazy getter matching current platform", () => {


### PR DESCRIPTION
## Problem

Isolated test Obsidian instances persist in the macOS Dock/taskbar after `pnpm run obsidian:test:stop` (#361). The stop command was only sending SIGTERM with no follow-up.

## Fix

`killIsolatedInstance` now uses a three-stage shutdown:

1. **CDP Browser.close()** - if the process has a debug port, try graceful Electron shutdown via CDP
2. **SIGTERM** - standard signal, wait 2 seconds for exit
3. **SIGKILL** - forceful kill if still running after SIGTERM

Added `isProcessRunning(pid)` helper that checks via signal 0.

The function is now async. Updated the caller in `obsidian-isolated-instance.js` and the test assertions.

867 tests pass.

Fixes #361