### PR TITLE
Support non-Claude agents for background enrichment

### DIFF
--- a/src/adapters/task-agent/BackgroundEnrich.test.ts
+++ b/src/adapters/task-agent/BackgroundEnrich.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { spawnHeadlessClaudeMock } = vi.hoisted(() => ({
+const { spawnHeadlessClaudeMock, spawnHeadlessAgentMock } = vi.hoisted(() => ({
   spawnHeadlessClaudeMock: vi.fn(),
+  spawnHeadlessAgentMock: vi.fn(),
 }));
 
 vi.mock("../../core/claude/HeadlessClaude", () => ({
   spawnHeadlessClaude: spawnHeadlessClaudeMock,
+  spawnHeadlessAgent: spawnHeadlessAgentMock,
   DEFAULT_TIMEOUT_MS: 300_000,
 }));
 
@@ -22,6 +24,11 @@ describe("BackgroundEnrich", () => {
     vi.clearAllMocks();
     process.env.HOME = "/Users/tester";
     spawnHeadlessClaudeMock.mockResolvedValue({
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+    });
+    spawnHeadlessAgentMock.mockResolvedValue({
       exitCode: 0,
       stdout: "",
       stderr: "",
@@ -586,6 +593,77 @@ describe("BackgroundEnrich", () => {
         "--model gpt-4",
         expect.any(Number),
       );
+    });
+
+    it("uses spawnHeadlessAgent with flag mode for non-Claude profiles", async () => {
+      const app = makeItemCreatedApp({ fileExistsAfterEnrich: false });
+
+      const profileOverride = {
+        command: "/usr/local/bin/my-agent",
+        args: "--verbose",
+        cwd: "~/work",
+        agentName: "MyAgent",
+        promptMode: "flag" as const,
+        promptFlag: "-i",
+      };
+
+      const result = await handleItemCreated(app, "Flag mode test", defaultSettings, profileOverride);
+      await result.enrichmentDone;
+
+      // Should use spawnHeadlessAgent, not spawnHeadlessClaude
+      expect(spawnHeadlessClaudeMock).not.toHaveBeenCalled();
+      expect(spawnHeadlessAgentMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          command: "/usr/local/bin/my-agent",
+          extraArgs: "--verbose",
+          promptMode: "flag",
+          promptFlag: "-i",
+          agentName: "MyAgent",
+        }),
+      );
+    });
+
+    it("uses spawnHeadlessAgent with positional mode for positional profiles", async () => {
+      const app = makeItemCreatedApp({ fileExistsAfterEnrich: false });
+
+      const profileOverride = {
+        command: "custom-cli",
+        args: "",
+        cwd: "~/work",
+        promptMode: "positional" as const,
+      };
+
+      const result = await handleItemCreated(app, "Positional test", defaultSettings, profileOverride);
+      await result.enrichmentDone;
+
+      expect(spawnHeadlessClaudeMock).not.toHaveBeenCalled();
+      expect(spawnHeadlessAgentMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          command: "custom-cli",
+          promptMode: "positional",
+        }),
+      );
+    });
+
+    it("uses spawnHeadlessClaude for profiles with claude promptMode", async () => {
+      spawnHeadlessClaudeMock.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+      const app = makeItemCreatedApp({ fileExistsAfterEnrich: false });
+
+      const profileOverride = {
+        command: "pi",
+        args: "--model sonnet",
+        cwd: "~/work",
+        promptMode: "claude" as const,
+      };
+
+      const result = await handleItemCreated(app, "Claude mode profile", defaultSettings, profileOverride);
+      await result.enrichmentDone;
+
+      // Should use spawnHeadlessClaude (Claude-compatible agent)
+      expect(spawnHeadlessClaudeMock).toHaveBeenCalled();
+      expect(spawnHeadlessAgentMock).not.toHaveBeenCalled();
     });
 
     it("falls back to core settings when no profile override is provided", async () => {

--- a/src/adapters/task-agent/BackgroundEnrich.ts
+++ b/src/adapters/task-agent/BackgroundEnrich.ts
@@ -1,5 +1,10 @@
 import { Notice, type App, type TFile } from "obsidian";
-import { spawnHeadlessClaude, DEFAULT_TIMEOUT_MS } from "../../core/claude/HeadlessClaude";
+import {
+  spawnHeadlessClaude,
+  spawnHeadlessAgent,
+  DEFAULT_TIMEOUT_MS,
+  type HeadlessAgentConfig,
+} from "../../core/claude/HeadlessClaude";
 import { generateTaskContent, generatePendingFilename } from "./TaskFileTemplate";
 import type { SplitSource } from "./TaskFileTemplate";
 import { expandTilde } from "../../core/utils";
@@ -94,6 +99,12 @@ export interface EnrichmentProfileOverride {
   command: string;
   args: string;
   cwd: string;
+  /** Agent name for error messages. */
+  agentName?: string;
+  /** How to inject the prompt - "claude" (default), "flag", or "positional". */
+  promptMode?: "claude" | "flag" | "positional";
+  /** Flag name when promptMode is "flag" (e.g. "-i"). */
+  promptFlag?: string;
 }
 
 export async function handleItemCreated(
@@ -139,13 +150,21 @@ export async function handleItemCreated(
     ? expandTilde(profileOverride.cwd)
     : resolveClaudeLaunchCwd(settings);
 
-  const enrichmentDone = spawnHeadlessClaude(
-    enrichPrompt,
-    enrichCwd,
-    claudeCommand,
-    claudeExtraArgs,
-    timeoutMs,
-  ).then(
+  // Use the generic headless agent when a profile override specifies non-Claude
+  // prompt injection, otherwise fall back to the Claude-specific path.
+  const spawnPromise = profileOverride?.promptMode && profileOverride.promptMode !== "claude"
+    ? spawnHeadlessAgent(enrichPrompt, {
+        command: claudeCommand,
+        extraArgs: claudeExtraArgs,
+        cwd: enrichCwd,
+        promptMode: profileOverride.promptMode,
+        promptFlag: profileOverride.promptFlag,
+        timeoutMs,
+        agentName: profileOverride.agentName,
+      })
+    : spawnHeadlessClaude(enrichPrompt, enrichCwd, claudeCommand, claudeExtraArgs, timeoutMs);
+
+  const enrichmentDone = spawnPromise.then(
     async (result) => {
       // Resolve current file location: original path may have changed if
       // the task was moved (e.g. via drag-drop) while enrichment was running.

--- a/src/core/claude/HeadlessClaude.ts
+++ b/src/core/claude/HeadlessClaude.ts
@@ -134,3 +134,145 @@ export function spawnHeadlessClaude(
     proc.stdin?.end();
   });
 }
+
+// ---------------------------------------------------------------------------
+// Generic headless agent spawn
+// ---------------------------------------------------------------------------
+
+/** Configuration for headless agent prompt injection. */
+export interface HeadlessAgentConfig {
+  /** CLI command to run (e.g. "claude", "pi", "/usr/local/bin/copilot"). */
+  command: string;
+  /** Extra arguments string (parsed into array). */
+  extraArgs?: string;
+  /** Working directory. */
+  cwd: string;
+  /** How to inject the prompt. Defaults to "claude" (uses -p <prompt> --output-format text). */
+  promptMode?: "claude" | "flag" | "positional";
+  /** Flag name when promptMode is "flag" (e.g. "-i", "--prompt"). */
+  promptFlag?: string;
+  /** Timeout in milliseconds. */
+  timeoutMs?: number;
+  /** Human-readable agent name for error messages. */
+  agentName?: string;
+}
+
+/**
+ * Generic headless agent spawn. Supports multiple prompt injection modes:
+ * - "claude": -p <prompt> --output-format text (default, backwards-compatible)
+ * - "flag": <promptFlag> <prompt>
+ * - "positional": <prompt> as trailing argument
+ */
+export function spawnHeadlessAgent(
+  prompt: string,
+  config: HeadlessAgentConfig,
+): Promise<HeadlessClaudeResult> {
+  const {
+    command,
+    extraArgs = "",
+    cwd,
+    promptMode = "claude",
+    promptFlag,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    agentName,
+  } = config;
+
+  return new Promise((resolve) => {
+    const cp = electronRequire("child_process") as typeof import("child_process");
+    const resolution = resolveCommandInfo(command, cwd);
+    if (!resolution.found) {
+      resolve({
+        exitCode: -1,
+        stdout: "",
+        stderr: buildMissingCliNotice(agentName || command, command),
+        missingCli: true,
+      });
+      return;
+    }
+    const resolvedCmd = resolution.resolved;
+    const resolvedCwd = expandTilde(cwd);
+
+    const args: string[] = [];
+    if (extraArgs) {
+      args.push(...parseExtraArgs(extraArgs));
+    }
+
+    // Inject prompt based on mode
+    if (promptMode === "flag" && promptFlag) {
+      args.push(promptFlag, prompt);
+    } else if (promptMode === "positional") {
+      args.push(prompt);
+    } else {
+      // "claude" mode (default)
+      args.push("-p", prompt, "--output-format", "text");
+    }
+
+    const proc = cp.spawn(resolvedCmd, args, {
+      cwd: resolvedCwd,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        PATH: getFullPath(),
+        TERM: "dumb",
+      },
+    });
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let settled = false;
+
+    proc.stdout?.on("data", (data: Buffer) => {
+      stdoutChunks.push(data);
+    });
+    proc.stderr?.on("data", (data: Buffer) => {
+      stderrChunks.push(data);
+    });
+
+    const label = agentName || command;
+    const timeoutSec = Math.ceil(timeoutMs / 1000);
+    const timeout = setTimeout(() => {
+      if (!settled && !proc.killed) {
+        settled = true;
+        proc.kill("SIGTERM");
+        setTimeout(() => {
+          try {
+            if (proc.exitCode === null) proc.kill("SIGKILL");
+          } catch {
+            /* already gone */
+          }
+        }, SIGKILL_GRACE_MS);
+        resolve({
+          exitCode: -1,
+          stdout: Buffer.concat(stdoutChunks).toString("utf8"),
+          stderr: `Headless ${label} timed out after ${timeoutSec}s`,
+          timedOut: true,
+        });
+      }
+    }, timeoutMs);
+
+    proc.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      console.error(`[work-terminal] Headless ${label} error:`, err);
+      resolve({
+        exitCode: -1,
+        stdout: Buffer.concat(stdoutChunks).toString("utf8"),
+        stderr: err.message,
+      });
+    });
+
+    proc.on("exit", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve({
+        exitCode: code ?? -1,
+        stdout: Buffer.concat(stdoutChunks).toString("utf8"),
+        stderr: Buffer.concat(stderrChunks).toString("utf8"),
+      });
+    });
+
+    proc.stdin?.end();
+  });
+}

--- a/src/framework/PromptBox.ts
+++ b/src/framework/PromptBox.ts
@@ -132,10 +132,22 @@ export class PromptBox {
           const profileMgr = (this.plugin as any).profileManager;
           const profile = profileMgr?.getProfile?.(profileId);
           if (profile) {
+            // Resolve prompt injection mode from the profile's agent type
+            let promptMode: "claude" | "flag" | "positional" = "claude";
+            if (profile.promptInjectionMode === "flag") {
+              promptMode = "flag";
+            } else if (profile.promptInjectionMode === "positional") {
+              promptMode = "positional";
+            } else if (profile.agentType === "claude") {
+              promptMode = "claude";
+            }
             enrichmentSettings._enrichmentProfile = {
               command: profile.command,
               args: profile.arguments,
               cwd: profile.defaultCwd,
+              agentName: profile.name,
+              promptMode,
+              promptFlag: profile.promptFlag,
             };
           }
         }


### PR DESCRIPTION
## Problem

The enrichment profile setting (#357) only borrowed the selected profile's command/args/cwd while still running through Claude-specific headless logic (`-p <prompt> --output-format text`). Non-Claude agents with different prompt injection protocols couldn't function as enrichment agents (#366).

## Solution

Added `spawnHeadlessAgent()` to HeadlessClaude.ts - a generic headless spawn function supporting three prompt injection modes:

| Mode | Behaviour | Example |
|------|-----------|---------|
| `claude` | `-p <prompt> --output-format text` | Claude, pi |
| `flag` | `<promptFlag> <prompt>` | Custom agents with `-i` or `--prompt` flags |
| `positional` | `<prompt>` as trailing argument | Simple CLI tools |

`BackgroundEnrich.ts` routes through `spawnHeadlessAgent` when the profile has a non-Claude `promptMode`, and through the existing `spawnHeadlessClaude` otherwise (backwards-compatible).

`PromptBox.ts` resolves the profile's `promptInjectionMode` and `promptFlag` and passes them through the `EnrichmentProfileOverride`.

## Testing

870 tests pass. 3 new tests:
- Flag mode routes to `spawnHeadlessAgent` with correct config
- Positional mode routes to `spawnHeadlessAgent`
- Claude-mode profiles still use `spawnHeadlessClaude`

Closes #366