### PR TITLE
Add per-profile login shell wrap toggle

### DIFF
--- a/pty-wrapper.py
+++ b/pty-wrapper.py
@@ -48,13 +48,17 @@ def main():
             pass
 
         # If the command is already a shell, exec directly (e.g. /bin/zsh -i).
-        # If the command is an absolute path, exec directly to avoid shell
-        # quoting issues with arguments (e.g. multi-line context prompts).
-        # The caller (ClaudeLauncher.ts) resolves commands to absolute paths.
+        # If WT_LOGIN_SHELL_WRAP is set, always wrap in a login shell so that
+        # shell functions/aliases from ~/.zshrc etc. are available.
+        # If the command is an absolute path (and no login-shell-wrap), exec
+        # directly to avoid shell quoting issues with arguments.
         # Otherwise, wrap in a login shell for the full user environment.
+        login_shell_wrap = os.environ.get("WT_LOGIN_SHELL_WRAP") == "1"
         shells = {"/bin/zsh", "/bin/bash", "/bin/sh", "/usr/bin/zsh", "/usr/bin/bash",
                   "zsh", "bash", "sh"}
-        if args[0] in shells or args[0].startswith("/"):
+        if args[0] in shells:
+            os.execvp(args[0], args)
+        elif args[0].startswith("/") and not login_shell_wrap:
             os.execvp(args[0], args)
         else:
             shell = os.environ.get("SHELL", "/bin/zsh")

--- a/src/core/agents/AgentProfile.ts
+++ b/src/core/agents/AgentProfile.ts
@@ -109,6 +109,12 @@ export interface AgentProfile {
   promptInjectionMode?: "positional" | "flag";
   /** CLI flag for injecting context prompt (e.g. "-i"). Used when promptInjectionMode is "flag". */
   promptFlag?: string;
+  /**
+   * When true, the command is launched through a login shell even if it
+   * resolves to an absolute path. This preserves shell wrapper functions
+   * (e.g. auto-update wrappers) defined in ~/.zshrc or ~/.bashrc.
+   */
+  loginShellWrap?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -147,6 +153,7 @@ const AgentProfileSchema = z.object({
   resumeFlagFormat: z.enum(RESUME_FLAG_FORMATS).optional(),
   promptInjectionMode: z.enum(PROMPT_INJECTION_MODES).optional(),
   promptFlag: z.string().optional(),
+  loginShellWrap: z.boolean().optional(),
 });
 
 /**
@@ -176,6 +183,7 @@ const StoredProfileSchema = z
     resumeFlagFormat: z.enum(RESUME_FLAG_FORMATS).optional(),
     promptInjectionMode: z.enum(PROMPT_INJECTION_MODES).optional(),
     promptFlag: z.string().optional(),
+    loginShellWrap: z.boolean().optional(),
   })
   .passthrough();
 

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -121,6 +121,11 @@ export class TerminalTab {
    * config is profile-level rather than type-level.
    */
   isResumableOverride?: boolean;
+  /**
+   * When true, the command is launched through a login shell even if it
+   * resolves to an absolute path. Enables shell wrapper functions.
+   */
+  loginShellWrap?: boolean;
 
   terminal: Terminal;
   containerEl: HTMLElement;
@@ -859,16 +864,21 @@ export class TerminalTab {
     console.log("[work-terminal] Spawning via pty-wrapper:", python3Path, args.join(" "));
     console.log("[work-terminal] cwd:", this.cwd);
 
+    const spawnEnv: Record<string, string | undefined> = {
+      ...process.env,
+      TERM: "xterm-256color",
+      COLUMNS: String(cols),
+      LINES: String(rows),
+      PATH: getFullPath(),
+    };
+    if (this.loginShellWrap) {
+      spawnEnv.WT_LOGIN_SHELL_WRAP = "1";
+    }
+
     const proc = cp.spawn(python3Path, args, {
       cwd: this.cwd,
       stdio: ["pipe", "pipe", "pipe"],
-      env: {
-        ...process.env,
-        TERM: "xterm-256color",
-        COLUMNS: String(cols),
-        LINES: String(rows),
-        PATH: getFullPath(),
-      },
+      env: spawnEnv,
     });
 
     console.log("[work-terminal] spawn pid:", proc.pid);

--- a/src/framework/AgentProfileModal.ts
+++ b/src/framework/AgentProfileModal.ts
@@ -185,6 +185,19 @@ export class AgentProfileEditModal extends Modal {
     argsSetting.settingEl.style.flexWrap = "wrap";
     argsSetting.controlEl.style.width = "100%";
 
+    // Login shell wrap
+    new Setting(contentEl)
+      .setName("Launch through login shell")
+      .setDesc(
+        "When enabled, the command is launched through a login shell even if it resolves to an absolute path. " +
+          "This preserves shell wrapper functions (e.g. auto-update wrappers) defined in ~/.zshrc or ~/.bashrc.",
+      )
+      .addToggle((toggle) => {
+        toggle.setValue(this.draft.loginShellWrap ?? false).onChange((value) => {
+          this.draft.loginShellWrap = value;
+        });
+      });
+
     // Container for adapter prompt preview and suppress toggle - gated on useContext
     const contextDependentEl = contentEl.createDiv();
 

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -1368,6 +1368,7 @@ export class TerminalPanelView {
       if (tab) {
         tab.profileId = profile.id;
         if (profile.button.color) tab.profileColor = profile.button.color;
+        if (profile.loginShellWrap) tab.loginShellWrap = true;
       }
       this.renderTabBar();
       return;
@@ -1449,6 +1450,10 @@ export class TerminalPanelView {
         // whether session tracking should be active
         if (profile.agentType === "custom") {
           lastTab.isResumableOverride = resolvedConfig.resumable;
+        }
+        // Launch through login shell when profile requests it
+        if (profile.loginShellWrap) {
+          lastTab.loginShellWrap = true;
         }
         this.renderTabBar();
       }


### PR DESCRIPTION
## Problem

When launching agents from Work Terminal, `resolveCommandInfo()` resolves command names to absolute paths. `pty-wrapper.py` then execs these directly, bypassing login shell wrapper functions defined in `~/.zshrc` or `~/.bashrc` (#368).

## Solution

Added a per-profile "Launch through login shell" toggle:

1. **AgentProfile.ts**: New `loginShellWrap?: boolean` field + Zod schema entries
2. **TerminalTab.ts**: Sets `WT_LOGIN_SHELL_WRAP=1` env var when the flag is set
3. **pty-wrapper.py**: Respects the env var - when set, routes through login shell (`shell -l -i -c ...`) even for absolute-path commands
4. **AgentProfileModal.ts**: Toggle in the profile edit UI after the Arguments field
5. **TerminalPanelView.ts**: Propagates `loginShellWrap` from profile to tab for both shell and agent session paths

## Trade-offs

Login shell wrapping uses `shlex.quote()` for argument joining, which handles most cases but may have edge cases with very complex multi-line prompts containing special characters. The toggle is opt-in (default off), so existing behaviour is unchanged.

870 tests pass.

Fixes #368