### PR TITLE
Handle Escape key in terminal capture phase

### DIFF
--- a/src/core/terminal/KeyboardCapture.test.ts
+++ b/src/core/terminal/KeyboardCapture.test.ts
@@ -301,6 +301,31 @@ describe("KeyboardCapture", () => {
     expect(event.defaultPrevented).toBe(true);
   });
 
+  it("does not intercept Ctrl+Escape (lets modified Escape pass through)", () => {
+    const write = vi.fn();
+    const cleanup = attachCapturePhase(
+      containerEl,
+      () =>
+        ({
+          stdin: { destroyed: false, write },
+        }) as any,
+    );
+
+    const event = new KeyboardEvent("keydown", {
+      key: "Escape",
+      code: "Escape",
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(event);
+
+    cleanup();
+
+    expect(write).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
   it("does not treat Cmd+Shift+F as plain Cmd+F", () => {
     const onSearch = vi.fn();
     const cleanup = attachCapturePhase(containerEl, () => null, onSearch);

--- a/src/core/terminal/KeyboardCapture.test.ts
+++ b/src/core/terminal/KeyboardCapture.test.ts
@@ -235,6 +235,72 @@ describe("KeyboardCapture", () => {
     expect(downEvent.defaultPrevented).toBe(true);
   });
 
+  it("sends Escape as \\x1b to PTY and prevents propagation", () => {
+    const write = vi.fn();
+    const cleanup = attachCapturePhase(
+      containerEl,
+      () =>
+        ({
+          stdin: { destroyed: false, write },
+        }) as any,
+    );
+
+    const event = new KeyboardEvent("keydown", {
+      key: "Escape",
+      code: "Escape",
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(event);
+
+    cleanup();
+
+    expect(write).toHaveBeenCalledWith("\x1b");
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("does not send Escape when PTY stdin is destroyed", () => {
+    const write = vi.fn();
+    const cleanup = attachCapturePhase(
+      containerEl,
+      () =>
+        ({
+          stdin: { destroyed: true, write },
+        }) as any,
+    );
+
+    const event = new KeyboardEvent("keydown", {
+      key: "Escape",
+      code: "Escape",
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(event);
+
+    cleanup();
+
+    expect(write).not.toHaveBeenCalled();
+    // Event should still be consumed to prevent Obsidian from acting on it
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("does not send Escape when no process is available", () => {
+    const cleanup = attachCapturePhase(containerEl, () => null);
+
+    const event = new KeyboardEvent("keydown", {
+      key: "Escape",
+      code: "Escape",
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(event);
+
+    cleanup();
+
+    // Event should still be consumed to prevent Obsidian from acting on it
+    expect(event.defaultPrevented).toBe(true);
+  });
+
   it("does not treat Cmd+Shift+F as plain Cmd+F", () => {
     const onSearch = vi.fn();
     const cleanup = attachCapturePhase(containerEl, () => null, onSearch);

--- a/src/core/terminal/KeyboardCapture.ts
+++ b/src/core/terminal/KeyboardCapture.ts
@@ -89,6 +89,19 @@ export function attachCapturePhase(
   const handler = (e: KeyboardEvent) => {
     if (!textareaEl || document.activeElement !== textareaEl) return;
 
+    // Plain Escape: send ESC to PTY before Obsidian's capture-phase handler
+    // can intercept it. Required for vi/vim keybindings, TUI apps, and
+    // cancelling shell completions.
+    if (e.key === "Escape") {
+      const proc = getProcess();
+      if (proc?.stdin && !proc.stdin.destroyed) {
+        proc.stdin.write("\x1b");
+      }
+      e.stopImmediatePropagation();
+      e.preventDefault();
+      return;
+    }
+
     // Cmd+F: toggle search bar (intercept before Obsidian's find)
     if (e.metaKey && !e.altKey && !e.ctrlKey && !e.shiftKey && e.code === "KeyF" && onSearch) {
       e.stopImmediatePropagation();

--- a/src/core/terminal/KeyboardCapture.ts
+++ b/src/core/terminal/KeyboardCapture.ts
@@ -92,7 +92,7 @@ export function attachCapturePhase(
     // Plain Escape: send ESC to PTY before Obsidian's capture-phase handler
     // can intercept it. Required for vi/vim keybindings, TUI apps, and
     // cancelling shell completions.
-    if (e.key === "Escape") {
+    if (e.key === "Escape" && !e.metaKey && !e.altKey && !e.ctrlKey && !e.shiftKey) {
       const proc = getProcess();
       if (proc?.stdin && !proc.stdin.destroyed) {
         proc.stdin.write("\x1b");


### PR DESCRIPTION
## Summary

- Add Escape key handling to `attachCapturePhase` in `KeyboardCapture.ts` so it fires before Obsidian's capture-phase handler
- Sends `\x1b` (ESC) to PTY stdin and consumes the event with `stopImmediatePropagation` + `preventDefault`
- Restores vi/vim keybindings, TUI app escape, and shell completion cancellation in terminal tabs

Fixes #378

## Test plan

- [x] Added 3 new tests: Escape sends `\x1b`, Escape with destroyed stdin, Escape with no process
- [x] All 927 tests pass (`pnpm exec vitest run`)
- [x] Clean build (`pnpm run build`)
- [ ] Manual: open a terminal tab, press Escape - should not trigger Obsidian behaviour
- [ ] Manual: use vim in terminal - Escape should exit insert mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)