### PR TITLE
Flatten nested frontmatter fields for Properties compatibility

### DIFF
--- a/src/adapters/task-agent/TaskFileTemplate.test.ts
+++ b/src/adapters/task-agent/TaskFileTemplate.test.ts
@@ -60,8 +60,29 @@ describe("generateTaskContent", () => {
     expect(content).toContain("agent-actionable: false");
     expect(content).toContain("goal: []");
     expect(content).toContain("related: []");
-    expect(content).toContain("score: 0");
-    expect(content).toContain("has-blocker: false");
+    expect(content).toContain("priority.score: 0");
+    expect(content).toContain("priority.has-blocker: false");
+  });
+
+  it("uses flat dot-notation keys for source fields", () => {
+    const content = generateTaskContent("Test", "todo");
+    expect(content).toMatch(/^source\.type: prompt$/m);
+    expect(content).toMatch(/^source\.id:/m);
+    expect(content).toMatch(/^source\.url:/m);
+    expect(content).toMatch(/^source\.captured:/m);
+    // Must NOT contain nested source block
+    expect(content).not.toMatch(/^source:\n\s+type:/m);
+  });
+
+  it("uses flat dot-notation keys for priority fields", () => {
+    const content = generateTaskContent("Test", "todo");
+    expect(content).toMatch(/^priority\.score: 0$/m);
+    expect(content).toMatch(/^priority\.deadline: ""$/m);
+    expect(content).toMatch(/^priority\.impact: medium$/m);
+    expect(content).toMatch(/^priority\.has-blocker: false$/m);
+    expect(content).toMatch(/^priority\.blocker-context: ""$/m);
+    // Must NOT contain nested priority block
+    expect(content).not.toMatch(/^priority:\n\s+score:/m);
   });
 
   it("uses block list syntax for split task related links", () => {

--- a/src/adapters/task-agent/TaskFileTemplate.ts
+++ b/src/adapters/task-agent/TaskFileTemplate.ts
@@ -59,18 +59,16 @@ state: ${state}
 
 title: ${safeTitle}
 
-source:
-  type: prompt
-  id: "${splitFrom ? `split-${now.replace(/[:.]/g, "")}` : ""}"
-  url: ""
-  captured: ${now}
+source.type: prompt
+source.id: "${splitFrom ? `split-${now.replace(/[:.]/g, "")}` : ""}"
+source.url: ""
+source.captured: ${now}
 
-priority:
-  score: 0
-  deadline: ""
-  impact: medium
-  has-blocker: false
-  blocker-context: ""
+priority.score: 0
+priority.deadline: ""
+priority.impact: medium
+priority.has-blocker: false
+priority.blocker-context: ""
 
 agent-actionable: false
 

--- a/src/adapters/task-agent/TaskParser.test.ts
+++ b/src/adapters/task-agent/TaskParser.test.ts
@@ -419,6 +419,36 @@ describe("TaskParser", () => {
       expect((item!.metadata as any).priority.impact).toBe("critical");
     });
 
+    it("empty flat string values take precedence over non-empty nested values", () => {
+      const file = makeFile("2 - Areas/Tasks/active/task.md");
+      const app = mockApp([file], {
+        [file.path]: makeFrontmatter({
+          priority: {
+            score: 80,
+            deadline: "2026-12-31",
+            impact: "critical",
+            "has-blocker": true,
+            "blocker-context": "waiting on deploy",
+          },
+          "priority.score": 0,
+          "priority.deadline": "",
+          "priority.impact": "",
+          "priority.has-blocker": false,
+          "priority.blocker-context": "",
+        }),
+      });
+      const parser = new TaskParser(app, "", defaultSettings);
+      const item = parser.parse(file as unknown as TFile);
+
+      expect((item!.metadata as any).priority).toMatchObject({
+        score: 0,
+        deadline: "",
+        impact: "",
+        "has-blocker": false,
+        "blocker-context": "",
+      });
+    });
+
     it("falls back to nested when flat keys are absent", () => {
       const file = makeFile("2 - Areas/Tasks/active/task.md");
       const app = mockApp([file], {

--- a/src/adapters/task-agent/TaskParser.test.ts
+++ b/src/adapters/task-agent/TaskParser.test.ts
@@ -343,6 +343,142 @@ describe("TaskParser", () => {
     });
   });
 
+  describe("flat dot-notation frontmatter (new format)", () => {
+    it("reads flat source fields", () => {
+      const file = makeFile("2 - Areas/Tasks/active/task.md");
+      const app = mockApp([file], {
+        [file.path]: makeFrontmatter({
+          source: undefined,
+          "source.type": "slack",
+          "source.id": "SLK-001",
+          "source.url": "https://slack.example.com/msg/001",
+          "source.captured": "2026-04-01",
+        }),
+      });
+      const parser = new TaskParser(app, "", defaultSettings);
+      const item = parser.parse(file as unknown as TFile);
+
+      expect((item!.metadata as any).source).toMatchObject({
+        type: "slack",
+        id: "SLK-001",
+        url: "https://slack.example.com/msg/001",
+        captured: "2026-04-01",
+      });
+    });
+
+    it("reads flat priority fields", () => {
+      const file = makeFile("2 - Areas/Tasks/active/task.md");
+      const app = mockApp([file], {
+        [file.path]: makeFrontmatter({
+          priority: undefined,
+          "priority.score": 75,
+          "priority.deadline": "2026-05-01",
+          "priority.impact": "high",
+          "priority.has-blocker": true,
+          "priority.blocker-context": "waiting on API",
+        }),
+      });
+      const parser = new TaskParser(app, "", defaultSettings);
+      const item = parser.parse(file as unknown as TFile);
+
+      expect((item!.metadata as any).priority).toMatchObject({
+        score: 75,
+        deadline: "2026-05-01",
+        impact: "high",
+        "has-blocker": true,
+        "blocker-context": "waiting on API",
+      });
+    });
+
+    it("flat keys take precedence over nested keys", () => {
+      const file = makeFile("2 - Areas/Tasks/active/task.md");
+      const app = mockApp([file], {
+        [file.path]: makeFrontmatter({
+          source: { type: "other", id: "old", url: "", captured: "" },
+          "source.type": "jira",
+          "source.id": "PROJ-999",
+          "source.url": "https://example.atlassian.net/browse/PROJ-999",
+          "source.captured": "PROJ-999",
+          priority: {
+            score: 10,
+            deadline: "",
+            impact: "low",
+            "has-blocker": false,
+            "blocker-context": "",
+          },
+          "priority.score": 90,
+          "priority.impact": "critical",
+        }),
+      });
+      const parser = new TaskParser(app, "", defaultSettings);
+      const item = parser.parse(file as unknown as TFile);
+
+      expect((item!.metadata as any).source.type).toBe("jira");
+      expect((item!.metadata as any).source.id).toBe("PROJ-999");
+      expect((item!.metadata as any).priority.score).toBe(90);
+      expect((item!.metadata as any).priority.impact).toBe("critical");
+    });
+
+    it("falls back to nested when flat keys are absent", () => {
+      const file = makeFile("2 - Areas/Tasks/active/task.md");
+      const app = mockApp([file], {
+        [file.path]: makeFrontmatter({
+          source: {
+            type: "confluence",
+            id: "C-1",
+            url: "https://wiki.example.com",
+            captured: "2026-01-01",
+          },
+          priority: {
+            score: 42,
+            deadline: "2026-06-01",
+            impact: "high",
+            "has-blocker": true,
+            "blocker-context": "blocked",
+          },
+        }),
+      });
+      const parser = new TaskParser(app, "", defaultSettings);
+      const item = parser.parse(file as unknown as TFile);
+
+      expect((item!.metadata as any).source).toMatchObject({
+        type: "confluence",
+        id: "C-1",
+        url: "https://wiki.example.com",
+        captured: "2026-01-01",
+      });
+      expect((item!.metadata as any).priority).toMatchObject({
+        score: 42,
+        deadline: "2026-06-01",
+        impact: "high",
+        "has-blocker": true,
+        "blocker-context": "blocked",
+      });
+    });
+
+    it("detects Jira source from flat keys", () => {
+      const file = makeFile("2 - Areas/Tasks/active/task.md");
+      const jiraUrl = "https://example.atlassian.net/browse/PROJ-5555";
+      const app = mockApp([file], {
+        [file.path]: makeFrontmatter({
+          source: undefined,
+          "source.type": "other",
+          "source.id": "",
+          "source.url": jiraUrl,
+          "source.captured": "",
+        }),
+      });
+      const parser = new TaskParser(app, "", defaultSettings);
+      const item = parser.parse(file as unknown as TFile);
+
+      expect((item!.metadata as any).source).toMatchObject({
+        type: "jira",
+        id: "PROJ-5555",
+        url: jiraUrl,
+      });
+    });
+  });
+
   describe("goal normalisation", () => {
     it("passes through array goal", () => {
       const file = makeFile("2 - Areas/Tasks/active/task.md");

--- a/src/adapters/task-agent/TaskParser.ts
+++ b/src/adapters/task-agent/TaskParser.ts
@@ -3,6 +3,7 @@ import type { WorkItem, WorkItemParser } from "../../core/interfaces";
 import { extractYamlFrontmatterString } from "../../core/frontmatter";
 import {
   type TaskFile,
+  type TaskPriority,
   type TaskSource,
   type TaskState,
   type KanbanColumn,
@@ -51,7 +52,7 @@ export class TaskParser implements WorkItemParser {
     const state = this.normaliseState(fm.state, fallbackState);
     if (!state) return null;
 
-    const priority = fm.priority || {};
+    const priority = this.resolvePriority(fm);
     const tags = this.normaliseTags(fm.tags);
     const goal: string[] = Array.isArray(fm.goal) ? fm.goal : fm.goal ? [fm.goal] : [];
 
@@ -67,13 +68,7 @@ export class TaskParser implements WorkItemParser {
       title: fm.title || file.basename,
       tags,
       source: this.resolveSource(fm, tags),
-      priority: {
-        score: priority.score ?? 0,
-        deadline: priority.deadline || "",
-        impact: priority.impact || "medium",
-        "has-blocker": priority["has-blocker"] ?? false,
-        "blocker-context": priority["blocker-context"] || "",
-      },
+      priority,
       agentActionable: fm["agent-actionable"] ?? false,
       goal,
       color: fm.color || undefined,
@@ -119,8 +114,39 @@ export class TaskParser implements WorkItemParser {
     return [];
   }
 
+  private resolvePriority(fm: Record<string, any>): TaskPriority {
+    // Support flat dot-notation keys (new format) with fallback to nested (old format)
+    const nested = fm.priority || {};
+    return {
+      score: fm["priority.score"] ?? nested.score ?? 0,
+      deadline: fm["priority.deadline"] || nested.deadline || "",
+      impact: fm["priority.impact"] || nested.impact || "medium",
+      "has-blocker": fm["priority.has-blocker"] ?? nested["has-blocker"] ?? false,
+      "blocker-context": fm["priority.blocker-context"] || nested["blocker-context"] || "",
+    };
+  }
+
+  private extractSourceFromFrontmatter(fm: Record<string, any>): Record<string, any> {
+    // Support flat dot-notation keys (new format) with fallback to nested (old format)
+    const nested = fm.source || {};
+    const hasFlat =
+      fm["source.type"] !== undefined ||
+      fm["source.id"] !== undefined ||
+      fm["source.url"] !== undefined ||
+      fm["source.captured"] !== undefined;
+    if (hasFlat) {
+      return {
+        type: fm["source.type"] ?? nested.type,
+        id: fm["source.id"] ?? nested.id,
+        url: fm["source.url"] ?? nested.url,
+        captured: fm["source.captured"] ?? nested.captured,
+      };
+    }
+    return nested;
+  }
+
   private resolveSource(frontmatter: Record<string, any>, tags: string[]): TaskSource {
-    const source = frontmatter.source || {};
+    const source = this.extractSourceFromFrontmatter(frontmatter);
     const explicit = this.normaliseSource(source);
     if (explicit.type === "jira") {
       const explicitJira = this.detectJiraSource([explicit.id, explicit.url, explicit.captured]);

--- a/src/adapters/task-agent/TaskParser.ts
+++ b/src/adapters/task-agent/TaskParser.ts
@@ -116,13 +116,14 @@ export class TaskParser implements WorkItemParser {
 
   private resolvePriority(fm: Record<string, any>): TaskPriority {
     // Support flat dot-notation keys (new format) with fallback to nested (old format)
+    // Use ?? (not ||) for string fields so empty strings from flat keys are preserved
     const nested = fm.priority || {};
     return {
       score: fm["priority.score"] ?? nested.score ?? 0,
-      deadline: fm["priority.deadline"] || nested.deadline || "",
-      impact: fm["priority.impact"] || nested.impact || "medium",
+      deadline: fm["priority.deadline"] ?? nested.deadline ?? "",
+      impact: fm["priority.impact"] ?? nested.impact ?? "medium",
       "has-blocker": fm["priority.has-blocker"] ?? nested["has-blocker"] ?? false,
-      "blocker-context": fm["priority.blocker-context"] || nested["blocker-context"] || "",
+      "blocker-context": fm["priority.blocker-context"] ?? nested["blocker-context"] ?? "",
     };
   }
 


### PR DESCRIPTION
## Summary

- Flatten `source` and `priority` frontmatter from nested YAML objects to dot-notation keys (e.g. `source.type`, `priority.score`) so each sub-field is individually editable in Obsidian's Properties view
- TaskParser reads both flat (new) and nested (old) formats for backwards compatibility - flat keys take precedence when both are present
- No changes needed to TaskMover, types, or downstream consumers (TaskCard, TaskPromptBuilder, TerminalPanelView) since internal interfaces remain unchanged

Fixes #380

## Test plan

- [x] All 935 tests pass (7 new tests added)
- [x] Build succeeds
- [ ] Verify new task files use flat dot-notation keys in Obsidian Properties view
- [ ] Verify existing task files with nested format still parse correctly
- [ ] Verify Jira source detection works with flat keys