### PR TITLE
Fix nvm/fnm binary resolution for custom CLI tools

### DIFF
--- a/src/core/agents/AgentLauncher.loginShell.test.ts
+++ b/src/core/agents/AgentLauncher.loginShell.test.ts
@@ -39,6 +39,8 @@ import {
   resolveLoginShellPath,
   getFullPath,
   getExtraPathDirs,
+  resolveNvmDefaultBin,
+  resolveFnmDefaultBin,
   _resetLoginShellPathCache,
 } from "./AgentLauncher";
 import { expandTilde } from "../utils";
@@ -286,12 +288,21 @@ describe("getFullPath (mocked)", () => {
 });
 
 describe("getExtraPathDirs (platform-aware)", () => {
-  it("returns Unix paths for darwin", () => {
+  it("returns static Unix paths for darwin", () => {
     const dirs = getExtraPathDirs("darwin", {} as NodeJS.ProcessEnv);
     expect(dirs).toContain(expandTilde("~/.local/bin"));
-    expect(dirs).toContain(expandTilde("~/.nvm/versions/node/current/bin"));
     expect(dirs).toContain("/usr/local/bin");
     expect(dirs).toContain("/opt/homebrew/bin");
+  });
+
+  it("includes dynamically resolved nvm bin dir when nvm is installed", () => {
+    const nvmBin = resolveNvmDefaultBin();
+    const dirs = getExtraPathDirs("darwin", {} as NodeJS.ProcessEnv);
+    if (nvmBin) {
+      expect(dirs).toContain(nvmBin);
+    }
+    // Old static path should never be present
+    expect(dirs).not.toContain(expandTilde("~/.nvm/versions/node/current/bin"));
   });
 
   it("returns Unix paths for linux", () => {
@@ -330,5 +341,37 @@ describe("getExtraPathDirs (platform-aware)", () => {
     const dirs = getExtraPathDirs("darwin", {} as NodeJS.ProcessEnv);
     const hasWindowsPaths = dirs.some((d) => d.includes("LOCALAPPDATA") || d.includes("APPDATA"));
     expect(hasWindowsPaths).toBe(false);
+  });
+});
+
+describe("resolveNvmDefaultBin", () => {
+  it("returns a bin dir ending in /bin when nvm is installed with a default alias", () => {
+    const result = resolveNvmDefaultBin();
+    const fs = require("fs") as typeof import("fs");
+    const hasNvm = fs.existsSync(expandTilde("~/.nvm/alias/default"));
+    if (hasNvm) {
+      expect(result).not.toBeNull();
+      expect(result!).toMatch(/\/bin$/);
+      expect(fs.existsSync(result!)).toBe(true);
+    } else {
+      expect(result).toBeNull();
+    }
+  });
+
+  it("returns null when nvm is not installed", () => {
+    // This test uses the real filesystem - if nvm IS installed,
+    // it will return a valid path; we just verify the return type
+    const result = resolveNvmDefaultBin();
+    expect(result === null || typeof result === "string").toBe(true);
+  });
+});
+
+describe("resolveFnmDefaultBin", () => {
+  it("returns null or a valid path", () => {
+    const result = resolveFnmDefaultBin();
+    expect(result === null || typeof result === "string").toBe(true);
+    if (result) {
+      expect(result).toMatch(/\/bin$/);
+    }
   });
 });

--- a/src/core/agents/AgentLauncher.loginShell.test.ts
+++ b/src/core/agents/AgentLauncher.loginShell.test.ts
@@ -39,8 +39,6 @@ import {
   resolveLoginShellPath,
   getFullPath,
   getExtraPathDirs,
-  resolveNvmDefaultBin,
-  resolveFnmDefaultBin,
   _resetLoginShellPathCache,
 } from "./AgentLauncher";
 import { expandTilde } from "../utils";
@@ -295,13 +293,9 @@ describe("getExtraPathDirs (platform-aware)", () => {
     expect(dirs).toContain("/opt/homebrew/bin");
   });
 
-  it("includes dynamically resolved nvm bin dir when nvm is installed", () => {
-    const nvmBin = resolveNvmDefaultBin();
+  it("does not include the old static nvm current symlink path", () => {
     const dirs = getExtraPathDirs("darwin", {} as NodeJS.ProcessEnv);
-    if (nvmBin) {
-      expect(dirs).toContain(nvmBin);
-    }
-    // Old static path should never be present
+    // Old static path should never be present (nvm does not create a current symlink)
     expect(dirs).not.toContain(expandTilde("~/.nvm/versions/node/current/bin"));
   });
 
@@ -344,34 +338,7 @@ describe("getExtraPathDirs (platform-aware)", () => {
   });
 });
 
-describe("resolveNvmDefaultBin", () => {
-  it("returns a bin dir ending in /bin when nvm is installed with a default alias", () => {
-    const result = resolveNvmDefaultBin();
-    const fs = require("fs") as typeof import("fs");
-    const hasNvm = fs.existsSync(expandTilde("~/.nvm/alias/default"));
-    if (hasNvm) {
-      expect(result).not.toBeNull();
-      expect(result!).toMatch(/\/bin$/);
-      expect(fs.existsSync(result!)).toBe(true);
-    } else {
-      expect(result).toBeNull();
-    }
-  });
-
-  it("returns null when nvm is not installed", () => {
-    // This test uses the real filesystem - if nvm IS installed,
-    // it will return a valid path; we just verify the return type
-    const result = resolveNvmDefaultBin();
-    expect(result === null || typeof result === "string").toBe(true);
-  });
-});
-
-describe("resolveFnmDefaultBin", () => {
-  it("returns null or a valid path", () => {
-    const result = resolveFnmDefaultBin();
-    expect(result === null || typeof result === "string").toBe(true);
-    if (result) {
-      expect(result).toMatch(/\/bin$/);
-    }
-  });
-});
+// Real-FS tests for resolveNvmDefaultBin/resolveFnmDefaultBin removed:
+// they are environment-dependent (CI may have nvm aliases pointing to
+// uninstalled versions). All nvm/fnm resolution is comprehensively tested
+// with mocked fs in AgentLauncher.nvmFnm.test.ts (17 tests).

--- a/src/core/agents/AgentLauncher.loginShell.test.ts
+++ b/src/core/agents/AgentLauncher.loginShell.test.ts
@@ -182,7 +182,7 @@ describe("getFullPath (mocked)", () => {
     _resetLoginShellPathCache();
   });
 
-  it("merges login shell PATH, EXTRA_PATH_DIRS, and env.PATH with deduplication", () => {
+  it("merges login shell PATH, static extra dirs, and env.PATH with deduplication", () => {
     mockSpawnSyncResult = {
       status: 0,
       stdout: "___PATH_START___/login/bin:/usr/bin___PATH_END___",
@@ -193,8 +193,11 @@ describe("getFullPath (mocked)", () => {
     const result = getFullPath(env, path, "linux");
     const dirs = result.split(":");
 
-    // Platform-appropriate EXTRA_PATH_DIRS come first
-    for (const extraDir of getExtraPathDirs("linux", env)) {
+    // Login shell dirs come first (highest priority) when login-shell succeeds
+    expect(dirs.indexOf("/login/bin")).toBeLessThan(dirs.indexOf(expandTilde("~/.local/bin")));
+
+    // Static extra dirs are included as supplements
+    for (const extraDir of getExtraPathDirs("linux", env, false)) {
       expect(dirs).toContain(extraDir);
     }
 

--- a/src/core/agents/AgentLauncher.nvmFnm.test.ts
+++ b/src/core/agents/AgentLauncher.nvmFnm.test.ts
@@ -220,6 +220,69 @@ describe("resolveFnmDefaultBin (mocked fs)", () => {
 
     expect(resolveFnmDefaultBin()).toBeNull();
   });
+
+  it("respects FNM_DIR environment variable", () => {
+    const customDir = "/custom/fnm";
+    const origFnmDir = process.env.FNM_DIR;
+    process.env.FNM_DIR = customDir;
+    try {
+      setMockFs({
+        [`${customDir}/aliases/default`]: true,
+        [`${customDir}/aliases/default/bin`]: true,
+      });
+
+      expect(resolveFnmDefaultBin()).toBe(`${customDir}/aliases/default/bin`);
+    } finally {
+      if (origFnmDir === undefined) delete process.env.FNM_DIR;
+      else process.env.FNM_DIR = origFnmDir;
+    }
+  });
+
+  it("respects XDG_DATA_HOME environment variable", () => {
+    const xdgDir = "/custom/xdg-data";
+    const origXdg = process.env.XDG_DATA_HOME;
+    const origFnm = process.env.FNM_DIR;
+    delete process.env.FNM_DIR;
+    process.env.XDG_DATA_HOME = xdgDir;
+    try {
+      setMockFs({
+        [`${xdgDir}/fnm/aliases/default`]: true,
+        [`${xdgDir}/fnm/aliases/default/bin`]: true,
+      });
+
+      expect(resolveFnmDefaultBin()).toBe(`${xdgDir}/fnm/aliases/default/bin`);
+    } finally {
+      if (origXdg === undefined) delete process.env.XDG_DATA_HOME;
+      else process.env.XDG_DATA_HOME = origXdg;
+      if (origFnm === undefined) delete process.env.FNM_DIR;
+      else process.env.FNM_DIR = origFnm;
+    }
+  });
+
+  it("prefers FNM_DIR over XDG_DATA_HOME", () => {
+    const fnmDirPath = "/custom/fnm";
+    const xdgDir = "/custom/xdg-data";
+    const origFnm = process.env.FNM_DIR;
+    const origXdg = process.env.XDG_DATA_HOME;
+    process.env.FNM_DIR = fnmDirPath;
+    process.env.XDG_DATA_HOME = xdgDir;
+    try {
+      setMockFs({
+        [`${fnmDirPath}/aliases/default`]: true,
+        [`${fnmDirPath}/aliases/default/bin`]: true,
+        [`${xdgDir}/fnm/aliases/default`]: true,
+        [`${xdgDir}/fnm/aliases/default/bin`]: true,
+      });
+
+      // FNM_DIR takes precedence
+      expect(resolveFnmDefaultBin()).toBe(`${fnmDirPath}/aliases/default/bin`);
+    } finally {
+      if (origFnm === undefined) delete process.env.FNM_DIR;
+      else process.env.FNM_DIR = origFnm;
+      if (origXdg === undefined) delete process.env.XDG_DATA_HOME;
+      else process.env.XDG_DATA_HOME = origXdg;
+    }
+  });
 });
 
 describe("getExtraPathDirs with mocked nvm/fnm", () => {

--- a/src/core/agents/AgentLauncher.nvmFnm.test.ts
+++ b/src/core/agents/AgentLauncher.nvmFnm.test.ts
@@ -145,6 +145,20 @@ describe("resolveNvmDefaultBin (mocked fs)", () => {
     expect(result).toBe(`${nvmDir}/versions/node/v22.22.0/bin`);
   });
 
+  it("resolves partial version using numeric sort (v22.10.0 > v22.9.0)", () => {
+    setMockFs({
+      [`${nvmDir}/alias/default`]: "v22",
+      [`${nvmDir}/versions/node`]: true,
+      [`${nvmDir}/versions/node/v22.9.0/bin`]: true,
+      [`${nvmDir}/versions/node/v22.10.0/bin`]: true,
+    });
+
+    // Lexicographic sort would pick v22.9.0 (sorts after v22.10.0);
+    // numeric-aware sort correctly picks v22.10.0
+    const result = resolveNvmDefaultBin();
+    expect(result).toBe(`${nvmDir}/versions/node/v22.10.0/bin`);
+  });
+
   it("handles alias chain that leads to empty string gracefully", () => {
     setMockFs({
       [`${nvmDir}/alias/default`]: "node",

--- a/src/core/agents/AgentLauncher.nvmFnm.test.ts
+++ b/src/core/agents/AgentLauncher.nvmFnm.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for resolveNvmDefaultBin() and resolveFnmDefaultBin() with mocked
+ * filesystem via electronRequire("fs"). Separated from the main test files
+ * because the vi.mock must be at module top level.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Configurable mock filesystem
+let mockFs: Record<string, string | true> = {};
+
+function resetMockFs() {
+  mockFs = {};
+}
+
+/**
+ * Set up a mock filesystem. Keys are file paths. Values are file contents
+ * (string) or `true` for directories.
+ */
+function setMockFs(files: Record<string, string | true>) {
+  mockFs = { ...files };
+}
+
+vi.mock("../utils", async () => {
+  const actual = await vi.importActual<typeof import("../utils")>("../utils");
+  return {
+    ...actual,
+    electronRequire: vi.fn((moduleName: string) => {
+      if (moduleName === "fs") {
+        return {
+          existsSync: (p: string) => p in mockFs,
+          readFileSync: (p: string, encoding: string) => {
+            if (p in mockFs && typeof mockFs[p] === "string") {
+              return mockFs[p];
+            }
+            const err = new Error(
+              `ENOENT: no such file or directory, open '${p}'`,
+            ) as NodeJS.ErrnoException;
+            err.code = "ENOENT";
+            throw err;
+          },
+          readdirSync: (p: string) => {
+            const prefix = p.endsWith("/") ? p : p + "/";
+            const entries = new Set<string>();
+            for (const key of Object.keys(mockFs)) {
+              if (key.startsWith(prefix)) {
+                const rest = key.slice(prefix.length);
+                const firstSegment = rest.split("/")[0];
+                if (firstSegment) entries.add(firstSegment);
+              }
+            }
+            return [...entries].sort();
+          },
+        };
+      }
+      if (moduleName === "child_process") {
+        return {
+          spawnSync: () => ({ status: 1, stdout: "", stderr: "" }),
+        };
+      }
+      return actual.electronRequire(moduleName);
+    }),
+  };
+});
+
+import {
+  resolveNvmDefaultBin,
+  resolveFnmDefaultBin,
+  getExtraPathDirs,
+  _resetLoginShellPathCache,
+} from "./AgentLauncher";
+import { expandTilde } from "../utils";
+
+afterEach(() => {
+  resetMockFs();
+  _resetLoginShellPathCache();
+});
+
+describe("resolveNvmDefaultBin (mocked fs)", () => {
+  const home = expandTilde("~");
+  const nvmDir = `${home}/.nvm`;
+
+  it("returns the bin dir for a simple version alias", () => {
+    setMockFs({
+      [`${nvmDir}/alias/default`]: "v22.22.0",
+      [`${nvmDir}/versions/node/v22.22.0/bin`]: true,
+    });
+
+    expect(resolveNvmDefaultBin()).toBe(`${nvmDir}/versions/node/v22.22.0/bin`);
+  });
+
+  it("adds v prefix when alias omits it", () => {
+    setMockFs({
+      [`${nvmDir}/alias/default`]: "22.22.0",
+      [`${nvmDir}/versions/node/v22.22.0/bin`]: true,
+    });
+
+    expect(resolveNvmDefaultBin()).toBe(`${nvmDir}/versions/node/v22.22.0/bin`);
+  });
+
+  it("follows alias chains (e.g. default -> lts/* -> lts/jod -> v22.22.0)", () => {
+    setMockFs({
+      [`${nvmDir}/alias/default`]: "lts/*",
+      [`${nvmDir}/alias/lts/*`]: "lts/jod",
+      [`${nvmDir}/alias/lts/jod`]: "v22.22.0",
+      [`${nvmDir}/versions/node/v22.22.0/bin`]: true,
+    });
+
+    expect(resolveNvmDefaultBin()).toBe(`${nvmDir}/versions/node/v22.22.0/bin`);
+  });
+
+  it("returns null when nvm is not installed", () => {
+    setMockFs({});
+
+    expect(resolveNvmDefaultBin()).toBeNull();
+  });
+
+  it("returns null when default alias file is empty", () => {
+    setMockFs({
+      [`${nvmDir}/alias/default`]: "",
+    });
+
+    expect(resolveNvmDefaultBin()).toBeNull();
+  });
+
+  it("returns null when version directory does not exist", () => {
+    setMockFs({
+      [`${nvmDir}/alias/default`]: "v99.99.99",
+      // No matching version directory
+    });
+
+    expect(resolveNvmDefaultBin()).toBeNull();
+  });
+
+  it("resolves partial version via directory listing", () => {
+    setMockFs({
+      [`${nvmDir}/alias/default`]: "v22",
+      [`${nvmDir}/versions/node`]: true,
+      [`${nvmDir}/versions/node/v22.21.0/bin`]: true,
+      [`${nvmDir}/versions/node/v22.22.0/bin`]: true,
+      [`${nvmDir}/versions/node/v20.10.0/bin`]: true,
+    });
+
+    // Should match the highest v22.x (reverse-sorted, first match)
+    const result = resolveNvmDefaultBin();
+    expect(result).toBe(`${nvmDir}/versions/node/v22.22.0/bin`);
+  });
+
+  it("handles alias chain that leads to empty string gracefully", () => {
+    setMockFs({
+      [`${nvmDir}/alias/default`]: "node",
+      [`${nvmDir}/alias/node`]: "",
+    });
+
+    expect(resolveNvmDefaultBin()).toBeNull();
+  });
+
+  it("limits alias chain depth to prevent infinite loops", () => {
+    // Create a circular alias chain
+    setMockFs({
+      [`${nvmDir}/alias/default`]: "a",
+      [`${nvmDir}/alias/a`]: "b",
+      [`${nvmDir}/alias/b`]: "c",
+      [`${nvmDir}/alias/c`]: "d",
+      [`${nvmDir}/alias/d`]: "e",
+      [`${nvmDir}/alias/e`]: "f", // depth 5, should stop here
+      [`${nvmDir}/alias/f`]: "g",
+    });
+
+    // Should not infinite loop; version "f" won't match a version dir
+    expect(resolveNvmDefaultBin()).toBeNull();
+  });
+});
+
+describe("resolveFnmDefaultBin (mocked fs)", () => {
+  const home = expandTilde("~");
+  const fnmDir = `${home}/.local/share/fnm`;
+
+  it("returns the bin dir when fnm aliases/default exists with bin/", () => {
+    setMockFs({
+      [`${fnmDir}/aliases/default`]: true,
+      [`${fnmDir}/aliases/default/bin`]: true,
+    });
+
+    expect(resolveFnmDefaultBin()).toBe(`${fnmDir}/aliases/default/bin`);
+  });
+
+  it("returns installation/bin when bin/ does not exist", () => {
+    setMockFs({
+      [`${fnmDir}/aliases/default`]: true,
+      [`${fnmDir}/aliases/default/installation/bin`]: true,
+    });
+
+    expect(resolveFnmDefaultBin()).toBe(`${fnmDir}/aliases/default/installation/bin`);
+  });
+
+  it("returns null when fnm is not installed", () => {
+    setMockFs({});
+
+    expect(resolveFnmDefaultBin()).toBeNull();
+  });
+
+  it("returns null when aliases/default exists but has no bin directory", () => {
+    setMockFs({
+      [`${fnmDir}/aliases/default`]: true,
+    });
+
+    expect(resolveFnmDefaultBin()).toBeNull();
+  });
+});
+
+describe("getExtraPathDirs with mocked nvm/fnm", () => {
+  const home = expandTilde("~");
+  const nvmDir = `${home}/.nvm`;
+  const fnmDir = `${home}/.local/share/fnm`;
+
+  it("includes resolved nvm bin dir on Unix", () => {
+    setMockFs({
+      [`${nvmDir}/alias/default`]: "v22.22.0",
+      [`${nvmDir}/versions/node/v22.22.0/bin`]: true,
+    });
+
+    const dirs = getExtraPathDirs("darwin", {} as NodeJS.ProcessEnv);
+    expect(dirs).toContain(`${nvmDir}/versions/node/v22.22.0/bin`);
+  });
+
+  it("includes resolved fnm bin dir on Unix", () => {
+    setMockFs({
+      [`${fnmDir}/aliases/default`]: true,
+      [`${fnmDir}/aliases/default/bin`]: true,
+    });
+
+    const dirs = getExtraPathDirs("linux", {} as NodeJS.ProcessEnv);
+    expect(dirs).toContain(`${fnmDir}/aliases/default/bin`);
+  });
+
+  it("does not include nvm/fnm dirs on Windows", () => {
+    setMockFs({
+      [`${nvmDir}/alias/default`]: "v22.22.0",
+      [`${nvmDir}/versions/node/v22.22.0/bin`]: true,
+    });
+
+    const dirs = getExtraPathDirs("win32", {} as NodeJS.ProcessEnv);
+    const hasNvmPath = dirs.some((d) => d.includes(".nvm"));
+    // Windows uses its own nvm-windows path pattern, not Unix nvm
+    expect(hasNvmPath).toBe(false);
+  });
+
+  it("still includes static dirs when nvm/fnm are not installed", () => {
+    setMockFs({});
+
+    const dirs = getExtraPathDirs("darwin", {} as NodeJS.ProcessEnv);
+    expect(dirs).toContain(expandTilde("~/.local/bin"));
+    expect(dirs).toContain("/usr/local/bin");
+    expect(dirs).toContain("/opt/homebrew/bin");
+  });
+});

--- a/src/core/agents/AgentLauncher.ts
+++ b/src/core/agents/AgentLauncher.ts
@@ -62,7 +62,8 @@ export function resolveNvmDefaultBin(): string | null {
     // Try partial version match (e.g. "v22" -> "v22.22.0")
     const versionsDir = `${nvmDir}/versions/node`;
     if (fs.existsSync(versionsDir)) {
-      const entries = fs.readdirSync(versionsDir).sort().reverse();
+      const numericCollator = new Intl.Collator(undefined, { numeric: true });
+      const entries = fs.readdirSync(versionsDir).sort(numericCollator.compare).reverse();
       const match = entries.find((e) => e.startsWith(version));
       if (match) {
         const matchBin = `${versionsDir}/${match}/bin`;

--- a/src/core/agents/AgentLauncher.ts
+++ b/src/core/agents/AgentLauncher.ts
@@ -109,19 +109,65 @@ export function resolveFnmDefaultBin(): string | null {
   return null;
 }
 
-export function getExtraPathDirs(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): string[] {
+/** Cached nvm/fnm resolution results (process lifetime, like login-shell PATH). */
+let _nvmBinCache: string | null = null;
+let _nvmBinResolved = false;
+let _fnmBinCache: string | null = null;
+let _fnmBinResolved = false;
+
+/** Return cached nvm default bin dir, resolving on first call. */
+function getCachedNvmBin(): string | null {
+  if (!_nvmBinResolved) {
+    _nvmBinResolved = true;
+    _nvmBinCache = resolveNvmDefaultBin();
+  }
+  return _nvmBinCache;
+}
+
+/** Return cached fnm default bin dir, resolving on first call. */
+function getCachedFnmBin(): string | null {
+  if (!_fnmBinResolved) {
+    _fnmBinResolved = true;
+    _fnmBinCache = resolveFnmDefaultBin();
+  }
+  return _fnmBinCache;
+}
+
+/** Reset cached nvm/fnm bin paths (for testing). */
+export function _resetNvmFnmBinCache(): void {
+  _nvmBinCache = null;
+  _nvmBinResolved = false;
+  _fnmBinCache = null;
+  _fnmBinResolved = false;
+}
+
+/**
+ * Return platform-appropriate extra PATH directories.
+ *
+ * When `includeDynamic` is true (default), also resolves nvm/fnm default
+ * version bin directories via cached filesystem probing. Set to false when
+ * login-shell PATH already includes these (to avoid overriding the shell's
+ * own resolution).
+ */
+export function getExtraPathDirs(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+  includeDynamic = true,
+): string[] {
   if (isWindowsPlatform(platform)) {
     return WINDOWS_EXTRA_PATH_DIRS.map((d) => expandWindowsEnvVars(d, env));
   }
 
   const dirs = UNIX_STATIC_EXTRA_DIRS.map((d) => expandTilde(d));
 
-  // Dynamically resolve nvm/fnm default version bin directories
-  const nvmBin = resolveNvmDefaultBin();
-  if (nvmBin) dirs.push(nvmBin);
+  if (includeDynamic) {
+    // Dynamically resolve nvm/fnm default version bin directories
+    const nvmBin = getCachedNvmBin();
+    if (nvmBin) dirs.push(nvmBin);
 
-  const fnmBin = resolveFnmDefaultBin();
-  if (fnmBin) dirs.push(fnmBin);
+    const fnmBin = getCachedFnmBin();
+    if (fnmBin) dirs.push(fnmBin);
+  }
 
   return dirs;
 }
@@ -320,10 +366,14 @@ export function resolveLoginShellPath(): string | null {
 /**
  * Build the full augmented PATH including the user's login-shell PATH.
  *
- * Merges (in priority order):
- * 1. getExtraPathDirs() (platform-aware common tool directories)
- * 2. Login shell PATH (nvm, fnm, Homebrew, etc.)
+ * When login-shell PATH resolution succeeds, merges (in priority order):
+ * 1. Login shell PATH (nvm, fnm, Homebrew, etc. - already resolved by shell init)
+ * 2. Static extra dirs (~/.local/bin, /usr/local/bin, /opt/homebrew/bin)
  * 3. Current process.env.PATH (Electron baseline)
+ *
+ * When login-shell PATH resolution fails, falls back to:
+ * 1. Static extra dirs + dynamically resolved nvm/fnm bin dirs
+ * 2. Current process.env.PATH (Electron baseline)
  *
  * Deduplicates while preserving order.
  */
@@ -334,20 +384,31 @@ export function getFullPath(
 ): string {
   const delimiter = getPathDelimiter(pathModule, platform);
   const loginPath = resolveLoginShellPath();
-  const extraDirs = getExtraPathDirs(platform, env);
-  const loginDirs = loginPath ? loginPath.split(delimiter) : [];
   const existingDirs = (
     env.PATH || (isWindowsPlatform(platform) ? "" : "/usr/local/bin:/usr/bin:/bin")
   ).split(delimiter);
 
-  const all = [...extraDirs, ...loginDirs, ...existingDirs].filter(Boolean);
-  return [...new Set(all)].join(delimiter);
+  let all: string[];
+  if (loginPath) {
+    // Login shell succeeded - it already includes nvm/fnm paths from shell init.
+    // Only add static extra dirs as supplements, not dynamic nvm/fnm probing.
+    const staticDirs = getExtraPathDirs(platform, env, /* includeDynamic */ false);
+    const loginDirs = loginPath.split(delimiter);
+    all = [...loginDirs, ...staticDirs, ...existingDirs];
+  } else {
+    // Login shell failed - use dynamic nvm/fnm resolution as fallback.
+    const extraDirs = getExtraPathDirs(platform, env, /* includeDynamic */ true);
+    all = [...extraDirs, ...existingDirs];
+  }
+
+  return [...new Set(all.filter(Boolean))].join(delimiter);
 }
 
-/** Reset cached login-shell PATH (for testing). */
+/** Reset cached login-shell PATH and nvm/fnm caches (for testing). */
 export function _resetLoginShellPathCache(): void {
   _loginShellPathCache = null;
   _loginShellPathResolved = false;
+  _resetNvmFnmBinCache();
 }
 
 /**

--- a/src/core/agents/AgentLauncher.ts
+++ b/src/core/agents/AgentLauncher.ts
@@ -79,16 +79,20 @@ export function resolveNvmDefaultBin(): string | null {
 /**
  * Resolve the fnm default Node.js bin directory.
  *
- * fnm (Fast Node Manager) stores its versions under ~/.local/share/fnm/node-versions/
- * with an "aliases/default" symlink. Returns the bin directory of the default
- * version, or null if fnm is not installed.
+ * fnm (Fast Node Manager) stores its versions under FNM_DIR, XDG_DATA_HOME/fnm,
+ * or ~/.local/share/fnm, with an "aliases/default" symlink. Returns the bin
+ * directory of the default version, or null if fnm is not installed.
  */
 export function resolveFnmDefaultBin(): string | null {
   try {
     const fs = electronRequire("fs") as typeof import("fs");
 
-    // fnm stores data in XDG_DATA_HOME/fnm or ~/.local/share/fnm
-    const fnmDir = expandTilde("~/.local/share/fnm");
+    // fnm stores data in FNM_DIR, XDG_DATA_HOME/fnm, or ~/.local/share/fnm
+    const fnmDir = process.env.FNM_DIR
+      ? expandTilde(process.env.FNM_DIR)
+      : process.env.XDG_DATA_HOME
+        ? expandTilde(`${process.env.XDG_DATA_HOME}/fnm`)
+        : expandTilde("~/.local/share/fnm");
     const aliasDir = `${fnmDir}/aliases/default`;
 
     // fnm creates a symlink at aliases/default -> the version directory

--- a/src/core/agents/AgentLauncher.ts
+++ b/src/core/agents/AgentLauncher.ts
@@ -4,12 +4,8 @@
 import { expandTilde, electronRequire } from "../utils";
 import { type AgentType, getResumeConfig } from "./AgentProfile";
 
-const UNIX_EXTRA_PATH_DIRS = [
-  "~/.local/bin",
-  "~/.nvm/versions/node/current/bin",
-  "/usr/local/bin",
-  "/opt/homebrew/bin",
-];
+/** Static directories that are always included in Unix PATH augmentation. */
+const UNIX_STATIC_EXTRA_DIRS = ["~/.local/bin", "/usr/local/bin", "/opt/homebrew/bin"];
 
 const WINDOWS_EXTRA_PATH_DIRS = [
   "%LOCALAPPDATA%\\Programs\\node",
@@ -22,11 +18,107 @@ function expandWindowsEnvVars(p: string, env: NodeJS.ProcessEnv): string {
   return p.replace(/%([^%]+)%/g, (_match, varName: string) => env[varName] ?? `%${varName}%`);
 }
 
+/**
+ * Resolve the nvm default Node.js bin directory by reading ~/.nvm/alias/default.
+ *
+ * nvm does not create a `current` symlink. Instead, the active version is set
+ * via shell init scripts that modify PATH. For GUI-launched processes (like
+ * Obsidian), the shell init hasn't run, so we read the default alias file to
+ * discover which version the user has configured and return its bin directory.
+ *
+ * Returns null if nvm is not installed or the alias cannot be resolved.
+ */
+export function resolveNvmDefaultBin(): string | null {
+  try {
+    const fs = electronRequire("fs") as typeof import("fs");
+    const nvmDir = expandTilde("~/.nvm");
+    const aliasPath = `${nvmDir}/alias/default`;
+
+    if (!fs.existsSync(aliasPath)) return null;
+
+    let version = fs.readFileSync(aliasPath, "utf8").trim();
+    if (!version) return null;
+
+    // The alias may be a named alias (e.g. "lts/*", "node") or a version
+    // string (e.g. "v22.22.0", "22.22.0"). Resolve named aliases by following
+    // the chain.
+    const maxDepth = 5;
+    for (let i = 0; i < maxDepth; i++) {
+      const nextAliasPath = `${nvmDir}/alias/${version}`;
+      if (fs.existsSync(nextAliasPath)) {
+        version = fs.readFileSync(nextAliasPath, "utf8").trim();
+        if (!version) return null;
+      } else {
+        break;
+      }
+    }
+
+    // Ensure version has a "v" prefix for directory lookup
+    if (!version.startsWith("v")) version = `v${version}`;
+
+    const binDir = `${nvmDir}/versions/node/${version}/bin`;
+    if (fs.existsSync(binDir)) return binDir;
+
+    // Try partial version match (e.g. "v22" -> "v22.22.0")
+    const versionsDir = `${nvmDir}/versions/node`;
+    if (fs.existsSync(versionsDir)) {
+      const entries = fs.readdirSync(versionsDir).sort().reverse();
+      const match = entries.find((e) => e.startsWith(version));
+      if (match) {
+        const matchBin = `${versionsDir}/${match}/bin`;
+        if (fs.existsSync(matchBin)) return matchBin;
+      }
+    }
+  } catch {
+    // nvm not installed or alias unreadable - not an error
+  }
+  return null;
+}
+
+/**
+ * Resolve the fnm default Node.js bin directory.
+ *
+ * fnm (Fast Node Manager) stores its versions under ~/.local/share/fnm/node-versions/
+ * with an "aliases/default" symlink. Returns the bin directory of the default
+ * version, or null if fnm is not installed.
+ */
+export function resolveFnmDefaultBin(): string | null {
+  try {
+    const fs = electronRequire("fs") as typeof import("fs");
+
+    // fnm stores data in XDG_DATA_HOME/fnm or ~/.local/share/fnm
+    const fnmDir = expandTilde("~/.local/share/fnm");
+    const aliasDir = `${fnmDir}/aliases/default`;
+
+    // fnm creates a symlink at aliases/default -> the version directory
+    if (fs.existsSync(aliasDir)) {
+      const binDir = `${aliasDir}/bin`;
+      if (fs.existsSync(binDir)) return binDir;
+      // Some fnm layouts put the binary in installation/bin
+      const installBin = `${aliasDir}/installation/bin`;
+      if (fs.existsSync(installBin)) return installBin;
+    }
+  } catch {
+    // fnm not installed - not an error
+  }
+  return null;
+}
+
 export function getExtraPathDirs(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): string[] {
   if (isWindowsPlatform(platform)) {
     return WINDOWS_EXTRA_PATH_DIRS.map((d) => expandWindowsEnvVars(d, env));
   }
-  return UNIX_EXTRA_PATH_DIRS.map((d) => expandTilde(d));
+
+  const dirs = UNIX_STATIC_EXTRA_DIRS.map((d) => expandTilde(d));
+
+  // Dynamically resolve nvm/fnm default version bin directories
+  const nvmBin = resolveNvmDefaultBin();
+  if (nvmBin) dirs.push(nvmBin);
+
+  const fnmBin = resolveFnmDefaultBin();
+  if (fnmBin) dirs.push(fnmBin);
+
+  return dirs;
 }
 
 const DEFAULT_WINDOWS_PATHEXT = ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC";


### PR DESCRIPTION
## Summary

- Replace the static `~/.nvm/versions/node/current/bin` PATH entry (which never existed - nvm does not create a `current` symlink) with dynamic resolution that reads `~/.nvm/alias/default` to find the actual installed version
- Add fnm (Fast Node Manager) support by probing `~/.local/share/fnm/aliases/default/bin`
- Both resolvers handle alias chains, partial version matching, and gracefully return null when the respective tool is not installed

The existing `resolveLoginShellPath()` mechanism (which spawns a login shell to read the full PATH) remains the primary resolver. The nvm/fnm probing acts as a reliable fallback in the `getExtraPathDirs()` list, covering cases where the login shell spawn fails or times out in the Electron sandbox.

Fixes #387

## Test plan

- [x] Existing 961 tests still pass
- [x] 21 new tests covering nvm resolution (alias chains, partial versions, missing nvm, empty aliases, depth limit), fnm resolution (bin/, installation/bin, missing fnm), and platform-aware `getExtraPathDirs` integration
- [x] Build passes
- [ ] Manual: configure a custom agent profile with a binary installed via nvm (e.g. `pi`) and verify the settings validation shows "Found" instead of "Not found"
- [ ] Manual: launch the custom agent and verify it starts successfully

Generated with [Claude Code](https://claude.com/claude-code)