### PR TITLE
Decouple categories/states from folder location (#386)

### DIFF
--- a/src/adapters/task-agent/TaskAgentConfig.ts
+++ b/src/adapters/task-agent/TaskAgentConfig.ts
@@ -38,7 +38,7 @@ export const TASK_AGENT_CONFIG: PluginConfig = {
       key: "stateStrategy",
       name: "State resolution strategy",
       description:
-        "How task state is determined. Folder: derived from folder location (default). Frontmatter: read from the state field. Composite: check frontmatter first, fall back to folder.",
+        "How task state is determined. Folder: derived from folder location (default). Frontmatter: reads from the state frontmatter field, falling back to folder location if the field is missing. Composite: check frontmatter first, fall back to folder, and apply both on transition.",
       type: "dropdown",
       default: "folder",
       choices: {

--- a/src/adapters/task-agent/TaskAgentConfig.ts
+++ b/src/adapters/task-agent/TaskAgentConfig.ts
@@ -35,6 +35,19 @@ export const TASK_AGENT_CONFIG: PluginConfig = {
       default: "2 - Areas/Tasks",
     },
     {
+      key: "stateStrategy",
+      name: "State resolution strategy",
+      description:
+        "How task state is determined. Folder: derived from folder location (default). Frontmatter: read from the state field. Composite: check frontmatter first, fall back to folder.",
+      type: "dropdown",
+      default: "folder",
+      choices: {
+        folder: "Folder-based (default)",
+        frontmatter: "Frontmatter field",
+        composite: "Composite (frontmatter + folder fallback)",
+      },
+    },
+    {
       key: "jiraBaseUrl",
       name: "Jira base URL",
       description:
@@ -86,6 +99,7 @@ export const TASK_AGENT_CONFIG: PluginConfig = {
   ],
   defaultSettings: {
     taskBasePath: "2 - Areas/Tasks",
+    stateStrategy: "folder",
     jiraBaseUrl: "",
     enrichmentEnabled: true,
     enrichmentPrompt: "",

--- a/src/adapters/task-agent/TaskMover.test.ts
+++ b/src/adapters/task-agent/TaskMover.test.ts
@@ -189,6 +189,38 @@ created: 2026-03-26T00:00:00Z
     expect(callOrder).toEqual(["modify", "rename"]);
   });
 
+  describe("with stateResolver", () => {
+    it("returns false when stateResolver.applyState fails", async () => {
+      const failingResolver = {
+        applyState: vi.fn().mockResolvedValue(false),
+        resolveState: vi.fn().mockReturnValue("todo"),
+        getFolderForState: vi.fn().mockReturnValue("todo"),
+      };
+      const { app } = createMockApp();
+      const mover = new TaskMover(app, "", defaultSettings, failingResolver as any);
+      const file = { path: "2 - Areas/Tasks/todo/task.md", name: "task.md" } as TFile;
+
+      const result = await mover.move(file, "active");
+
+      expect(result).toBe(false);
+    });
+
+    it("returns true when stateResolver.applyState succeeds", async () => {
+      const successResolver = {
+        applyState: vi.fn().mockResolvedValue(true),
+        resolveState: vi.fn().mockReturnValue("todo"),
+        getFolderForState: vi.fn().mockReturnValue("active"),
+      };
+      const { app } = createMockApp();
+      const mover = new TaskMover(app, "", defaultSettings, successResolver as any);
+      const file = { path: "2 - Areas/Tasks/todo/task.md", name: "task.md" } as TFile;
+
+      const result = await mover.move(file, "active");
+
+      expect(result).toBe(true);
+    });
+  });
+
   it("maps done column to archive folder", async () => {
     const { app, rename, getAbstractFileByPath } = createMockApp();
     getAbstractFileByPath.mockReturnValue(null);

--- a/src/adapters/task-agent/TaskMover.ts
+++ b/src/adapters/task-agent/TaskMover.ts
@@ -1,22 +1,28 @@
 import type { App, TFile } from "obsidian";
-import type { WorkItemMover } from "../../core/interfaces";
+import type { WorkItemMover, StateResolver } from "../../core/interfaces";
 import { type KanbanColumn, STATE_FOLDER_MAP } from "./types";
 
 export class TaskMover implements WorkItemMover {
   private basePath: string;
+  private stateResolver: StateResolver | null;
 
   constructor(
     private app: App,
     _basePath: string,
     private settings: Record<string, any>,
+    stateResolver?: StateResolver,
   ) {
     this.basePath = this.settings["adapter.taskBasePath"] || "2 - Areas/Tasks";
+    this.stateResolver = stateResolver ?? null;
   }
 
   async move(file: TFile, targetColumnId: string): Promise<boolean> {
     const newColumn = targetColumnId as KanbanColumn;
-    const targetFolder = STATE_FOLDER_MAP[newColumn];
-    if (!targetFolder) return false;
+
+    // Validate target: either the resolver knows it or STATE_FOLDER_MAP does
+    if (!this.stateResolver?.getFolderForState?.(newColumn) && !STATE_FOLDER_MAP[newColumn]) {
+      return false;
+    }
 
     try {
       const content = await this.app.vault.read(file);
@@ -64,17 +70,24 @@ export class TaskMover implements WorkItemMover {
       // Write updated content first (write-then-move pattern)
       await this.app.vault.modify(file, updated);
 
-      // Move file to target folder
-      const newFolderPath = `${this.basePath}/${targetFolder}`;
-      const newPath = `${newFolderPath}/${file.name}`;
+      // Apply the state transition (file move or other mechanism)
+      if (this.stateResolver) {
+        await this.stateResolver.applyState(this.app, file, newColumn, oldState, this.basePath);
+      } else {
+        // Legacy fallback: direct folder move using STATE_FOLDER_MAP
+        const targetFolder = STATE_FOLDER_MAP[newColumn];
+        if (targetFolder) {
+          const newFolderPath = `${this.basePath}/${targetFolder}`;
+          const newPath = `${newFolderPath}/${file.name}`;
 
-      if (file.path !== newPath) {
-        // Ensure target folder exists
-        const folder = this.app.vault.getAbstractFileByPath(newFolderPath);
-        if (!folder) {
-          await this.app.vault.createFolder(newFolderPath);
+          if (file.path !== newPath) {
+            const folder = this.app.vault.getAbstractFileByPath(newFolderPath);
+            if (!folder) {
+              await this.app.vault.createFolder(newFolderPath);
+            }
+            await this.app.vault.rename(file, newPath);
+          }
         }
-        await this.app.vault.rename(file, newPath);
       }
 
       return true;

--- a/src/adapters/task-agent/TaskMover.ts
+++ b/src/adapters/task-agent/TaskMover.ts
@@ -72,7 +72,16 @@ export class TaskMover implements WorkItemMover {
 
       // Apply the state transition (file move or other mechanism)
       if (this.stateResolver) {
-        await this.stateResolver.applyState(this.app, file, newColumn, oldState, this.basePath);
+        const stateApplied = await this.stateResolver.applyState(
+          this.app,
+          file,
+          newColumn,
+          oldState,
+          this.basePath,
+        );
+        if (!stateApplied) {
+          return false;
+        }
       } else {
         // Legacy fallback: direct folder move using STATE_FOLDER_MAP
         const targetFolder = STATE_FOLDER_MAP[newColumn];

--- a/src/adapters/task-agent/TaskParser.ts
+++ b/src/adapters/task-agent/TaskParser.ts
@@ -1,5 +1,5 @@
 import type { App, TFile } from "obsidian";
-import type { WorkItem, WorkItemParser } from "../../core/interfaces";
+import type { WorkItem, WorkItemParser, StateResolver } from "../../core/interfaces";
 import { extractYamlFrontmatterString } from "../../core/frontmatter";
 import {
   type TaskFile,
@@ -19,15 +19,18 @@ export class TaskParser implements WorkItemParser {
   private static loggedFallbackPaths = new Set<string>();
   private transientIdsByPath = new Map<string, string>();
   private backfillPromisesByPath = new Map<string, Promise<WorkItem | null>>();
+  private stateResolver: StateResolver | null;
 
   constructor(
     private app: App,
     _basePath: string,
     private settings: Record<string, any>,
+    stateResolver?: StateResolver,
   ) {
     this.basePath = this.normaliseBasePath(
       this.settings["adapter.taskBasePath"] || "2 - Areas/Tasks",
     );
+    this.stateResolver = stateResolver ?? null;
   }
 
   parse(file: TFile): WorkItem | null {
@@ -40,7 +43,7 @@ export class TaskParser implements WorkItemParser {
     const cache = this.app.metadataCache.getFileCache(file);
     const fm = cache?.frontmatter;
     const transientId = this.transientIdsByPath.get(file.path);
-    const fallbackState = this.getStateFromPath(file.path);
+    const fallbackState = this.resolveStateFromFile(file.path, fm);
     if (!fm) {
       return this.createFallbackTaskFile(file, fallbackState, transientId);
     }
@@ -258,6 +261,25 @@ export class TaskParser implements WorkItemParser {
         ? this.settings["adapter.jiraBaseUrl"].trim()
         : defaultJiraBaseUrl;
     return `${baseUrl.replace(/\/+$/, "")}/${id}`;
+  }
+
+  /**
+   * Resolve state for a file using the configured StateResolver if available,
+   * falling back to the legacy path-based resolution.
+   */
+  private resolveStateFromFile(
+    path: string,
+    frontmatter: Record<string, unknown> | undefined,
+  ): TaskState | null {
+    if (this.stateResolver) {
+      const resolved = this.stateResolver.resolveState(path, frontmatter);
+      if (resolved !== null && VALID_STATES.includes(resolved as TaskState)) {
+        return resolved as TaskState;
+      }
+      // If resolver returned a value but it's not a valid TaskState, fall through
+      if (resolved !== null) return null;
+    }
+    return this.getStateFromPath(path);
   }
 
   private getStateFromPath(path: string): TaskState | null {

--- a/src/adapters/task-agent/TaskParser.ts
+++ b/src/adapters/task-agent/TaskParser.ts
@@ -276,8 +276,8 @@ export class TaskParser implements WorkItemParser {
       if (resolved !== null && VALID_STATES.includes(resolved as TaskState)) {
         return resolved as TaskState;
       }
-      // If resolver returned a value but it's not a valid TaskState, fall through
-      if (resolved !== null) return null;
+      // If resolver returned null or an unrecognized state, fall back to the
+      // legacy path-based resolution below.
     }
     return this.getStateFromPath(path);
   }

--- a/src/adapters/task-agent/TaskParserWithResolver.test.ts
+++ b/src/adapters/task-agent/TaskParserWithResolver.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi } from "vitest";
+import { TaskParser } from "./TaskParser";
+import { FrontmatterStateResolver } from "../../core/resolvers/FrontmatterStateResolver";
+import { CompositeStateResolver } from "../../core/resolvers/CompositeStateResolver";
+import { FolderStateResolver } from "../../core/resolvers/FolderStateResolver";
+import { STATE_FOLDER_MAP } from "./types";
+import type { App, TFile, CachedMetadata } from "obsidian";
+
+function mockApp(
+  files: Array<{ path: string; name: string; basename: string; extension: string }>,
+  caches: Record<string, CachedMetadata | null>,
+): App {
+  return {
+    metadataCache: {
+      getFileCache: (file: TFile) => caches[file.path] ?? null,
+    },
+    vault: {
+      getAbstractFileByPath: (path: string) => {
+        const knownFolders = [
+          "2 - Areas/Tasks/priority",
+          "2 - Areas/Tasks/todo",
+          "2 - Areas/Tasks/active",
+          "2 - Areas/Tasks/archive",
+        ];
+        if (knownFolders.includes(path)) return { path };
+        return files.find((f) => f.path === path) || null;
+      },
+      getMarkdownFiles: () =>
+        files.map((f) => ({
+          path: f.path,
+          name: f.name,
+          basename: f.basename,
+          extension: f.extension,
+        })),
+      read: vi.fn(),
+      modify: vi.fn(),
+    },
+  } as unknown as App;
+}
+
+function makeFile(path: string) {
+  const name = path.split("/").pop() || "";
+  const basename = name.replace(/\.md$/, "");
+  return { path, name, basename, extension: "md" };
+}
+
+function makeFrontmatter(overrides: Record<string, any> = {}) {
+  return {
+    frontmatter: {
+      id: "test-uuid",
+      state: "active",
+      title: "Test Task",
+      tags: ["task", "task/active"],
+      source: { type: "prompt", id: "p1", url: "", captured: "2026-03-27" },
+      priority: {
+        score: 50,
+        deadline: "",
+        impact: "medium",
+        "has-blocker": false,
+        "blocker-context": "",
+      },
+      "agent-actionable": false,
+      goal: [],
+      created: "2026-03-27T00:00:00Z",
+      updated: "2026-03-27T12:00:00Z",
+      ...overrides,
+    },
+  } as unknown as CachedMetadata;
+}
+
+const defaultSettings = {
+  "adapter.taskBasePath": "2 - Areas/Tasks",
+  "adapter.jiraBaseUrl": "https://example.atlassian.net/browse",
+};
+
+describe("TaskParser with StateResolver", () => {
+  describe("with FrontmatterStateResolver", () => {
+    const validStates = ["priority", "todo", "active", "done", "abandoned"];
+    const resolver = new FrontmatterStateResolver("state", validStates);
+
+    it("uses frontmatter state field instead of folder path", () => {
+      // File is in 'todo' folder but frontmatter says 'active'
+      const file = makeFile("2 - Areas/Tasks/todo/task.md");
+      const app = mockApp([file], {
+        [file.path]: makeFrontmatter({ state: "active" }),
+      });
+      const parser = new TaskParser(app, "", defaultSettings, resolver);
+      const item = parser.parse(file as unknown as TFile);
+
+      expect(item).not.toBeNull();
+      expect(item!.state).toBe("active");
+    });
+
+    it("falls back to folder when frontmatter state is missing", () => {
+      const file = makeFile("2 - Areas/Tasks/active/task.md");
+      const app = mockApp([file], {
+        [file.path]: makeFrontmatter({ state: undefined }),
+      });
+      const parser = new TaskParser(app, "", defaultSettings, resolver);
+      const item = parser.parse(file as unknown as TFile);
+
+      // Frontmatter resolver returns null, parser falls back to getStateFromPath
+      expect(item).not.toBeNull();
+      expect(item!.state).toBe("active");
+    });
+  });
+
+  describe("with CompositeStateResolver (frontmatter + folder)", () => {
+    const validStates = ["priority", "todo", "active", "done", "abandoned"];
+    const basePath = "2 - Areas/Tasks";
+    const resolver = new CompositeStateResolver([
+      new FrontmatterStateResolver("state", validStates),
+      new FolderStateResolver(STATE_FOLDER_MAP, basePath),
+    ]);
+
+    it("prefers frontmatter state over folder", () => {
+      const file = makeFile("2 - Areas/Tasks/todo/task.md");
+      const app = mockApp([file], {
+        [file.path]: makeFrontmatter({ state: "done" }),
+      });
+      const parser = new TaskParser(app, "", defaultSettings, resolver);
+      const item = parser.parse(file as unknown as TFile);
+
+      expect(item!.state).toBe("done");
+    });
+
+    it("falls back to folder when frontmatter has no state", () => {
+      const file = makeFile("2 - Areas/Tasks/priority/task.md");
+      const app = mockApp([file], {
+        [file.path]: makeFrontmatter({ state: undefined }),
+      });
+      const parser = new TaskParser(app, "", defaultSettings, resolver);
+      const item = parser.parse(file as unknown as TFile);
+
+      expect(item!.state).toBe("priority");
+    });
+
+    it("maps archive folder to done state", () => {
+      const file = makeFile("2 - Areas/Tasks/archive/task.md");
+      const app = mockApp([file], {
+        [file.path]: makeFrontmatter({ state: undefined }),
+      });
+      const parser = new TaskParser(app, "", defaultSettings, resolver);
+      const item = parser.parse(file as unknown as TFile);
+
+      expect(item!.state).toBe("done");
+    });
+  });
+
+  describe("without resolver (backward compatibility)", () => {
+    it("still resolves state from folder path", () => {
+      const file = makeFile("2 - Areas/Tasks/active/task.md");
+      const app = mockApp([file], {
+        [file.path]: makeFrontmatter({ state: "invalid" }),
+      });
+      // No resolver passed
+      const parser = new TaskParser(app, "", defaultSettings);
+      const item = parser.parse(file as unknown as TFile);
+
+      expect(item!.state).toBe("active");
+    });
+  });
+});

--- a/src/adapters/task-agent/TaskParserWithResolver.test.ts
+++ b/src/adapters/task-agent/TaskParserWithResolver.test.ts
@@ -147,6 +147,26 @@ describe("TaskParser with StateResolver", () => {
     });
   });
 
+  describe("resolver returns unrecognized state", () => {
+    it("falls back to folder path instead of dropping the task", () => {
+      // A resolver that always returns an unrecognized state
+      const badResolver = {
+        resolveState: () => "custom-unknown-state",
+        applyState: async () => false,
+      };
+      const file = makeFile("2 - Areas/Tasks/active/task.md");
+      const app = mockApp([file], {
+        [file.path]: makeFrontmatter({ state: "custom-unknown-state" }),
+      });
+      const parser = new TaskParser(app, "", defaultSettings, badResolver as any);
+      const item = parser.parse(file as unknown as TFile);
+
+      // Should fall back to folder-based resolution, not return null
+      expect(item).not.toBeNull();
+      expect(item!.state).toBe("active");
+    });
+  });
+
   describe("without resolver (backward compatibility)", () => {
     it("still resolves state from folder path", () => {
       const file = makeFile("2 - Areas/Tasks/active/task.md");

--- a/src/adapters/task-agent/index.ts
+++ b/src/adapters/task-agent/index.ts
@@ -24,7 +24,7 @@ import {
 } from "./BackgroundEnrich";
 import type { KanbanColumn } from "./types";
 import { parseCustomCardFlags } from "./customCardFlags";
-import { createDefaultStateResolver } from "./stateResolverFactory";
+import { createStateResolver, type StateStrategy } from "./stateResolverFactory";
 
 export class TaskAgentAdapter extends BaseAdapter {
   config: PluginConfig = TASK_AGENT_CONFIG;
@@ -35,11 +35,21 @@ export class TaskAgentAdapter extends BaseAdapter {
   private detailView: TaskDetailView | null = null;
   private _cardRenderer: TaskCard | null = null;
   private _stateResolver: StateResolver | null = null;
+  private _resolverStrategy: StateStrategy | null = null;
+  private _resolverBasePath: string | null = null;
 
   /** Get or create the state resolver based on current settings. */
-  private getStateResolver(basePath: string): StateResolver {
-    if (!this._stateResolver) {
-      this._stateResolver = createDefaultStateResolver(basePath);
+  private getStateResolver(basePath: string, settings: Record<string, unknown>): StateResolver {
+    const strategy = ((settings["adapter.stateStrategy"] as string) || "folder") as StateStrategy;
+    // Recreate resolver if strategy or basePath changed
+    if (
+      !this._stateResolver ||
+      this._resolverStrategy !== strategy ||
+      this._resolverBasePath !== basePath
+    ) {
+      this._stateResolver = createStateResolver(strategy, basePath);
+      this._resolverStrategy = strategy;
+      this._resolverBasePath = basePath;
     }
     return this._stateResolver;
   }
@@ -49,7 +59,7 @@ export class TaskAgentAdapter extends BaseAdapter {
     this._app = app;
     this._settings = resolvedSettings;
     const taskBasePath = (resolvedSettings["adapter.taskBasePath"] as string) || "2 - Areas/Tasks";
-    const resolver = this.getStateResolver(taskBasePath);
+    const resolver = this.getStateResolver(taskBasePath, resolvedSettings);
     return new TaskParser(app, basePath, resolvedSettings, resolver);
   }
 
@@ -58,7 +68,7 @@ export class TaskAgentAdapter extends BaseAdapter {
     this._app = app;
     this._settings = resolvedSettings;
     const taskBasePath = (resolvedSettings["adapter.taskBasePath"] as string) || "2 - Areas/Tasks";
-    const resolver = this.getStateResolver(taskBasePath);
+    const resolver = this.getStateResolver(taskBasePath, resolvedSettings);
     return new TaskMover(app, basePath, resolvedSettings, resolver);
   }
 
@@ -70,10 +80,13 @@ export class TaskAgentAdapter extends BaseAdapter {
 
   /**
    * Called by the framework when settings change. Updates the card renderer's
-   * flag rules so the next list refresh picks up user-defined card flags.
+   * flag rules and invalidates the cached state resolver so it's recreated
+   * with the new strategy on next use.
    */
   onSettingsChanged(settings: Record<string, unknown>): void {
     this._settings = settings;
+    // Invalidate the cached resolver so it's recreated with new settings
+    this._stateResolver = null;
     if (this._cardRenderer) {
       this._cardRenderer.updateFlagRules(this.getMergedFlagRules());
     }

--- a/src/adapters/task-agent/index.ts
+++ b/src/adapters/task-agent/index.ts
@@ -8,6 +8,7 @@ import {
   type WorkItemPromptBuilder,
   type CardFlagRule,
   type PluginConfig,
+  type StateResolver,
 } from "../../core/interfaces";
 import { TASK_AGENT_CONFIG } from "./TaskAgentConfig";
 import { TaskParser } from "./TaskParser";
@@ -23,6 +24,7 @@ import {
 } from "./BackgroundEnrich";
 import type { KanbanColumn } from "./types";
 import { parseCustomCardFlags } from "./customCardFlags";
+import { createDefaultStateResolver } from "./stateResolverFactory";
 
 export class TaskAgentAdapter extends BaseAdapter {
   config: PluginConfig = TASK_AGENT_CONFIG;
@@ -32,19 +34,32 @@ export class TaskAgentAdapter extends BaseAdapter {
   private _settings: Record<string, unknown> = {};
   private detailView: TaskDetailView | null = null;
   private _cardRenderer: TaskCard | null = null;
+  private _stateResolver: StateResolver | null = null;
+
+  /** Get or create the state resolver based on current settings. */
+  private getStateResolver(basePath: string): StateResolver {
+    if (!this._stateResolver) {
+      this._stateResolver = createDefaultStateResolver(basePath);
+    }
+    return this._stateResolver;
+  }
 
   createParser(app: App, basePath: string, settings?: Record<string, unknown>): WorkItemParser {
     const resolvedSettings = settings ?? {};
     this._app = app;
     this._settings = resolvedSettings;
-    return new TaskParser(app, basePath, resolvedSettings);
+    const taskBasePath = (resolvedSettings["adapter.taskBasePath"] as string) || "2 - Areas/Tasks";
+    const resolver = this.getStateResolver(taskBasePath);
+    return new TaskParser(app, basePath, resolvedSettings, resolver);
   }
 
   createMover(app: App, basePath: string, settings?: Record<string, unknown>): WorkItemMover {
     const resolvedSettings = settings ?? {};
     this._app = app;
     this._settings = resolvedSettings;
-    return new TaskMover(app, basePath, resolvedSettings);
+    const taskBasePath = (resolvedSettings["adapter.taskBasePath"] as string) || "2 - Areas/Tasks";
+    const resolver = this.getStateResolver(taskBasePath);
+    return new TaskMover(app, basePath, resolvedSettings, resolver);
   }
 
   createCardRenderer(): CardRenderer {

--- a/src/adapters/task-agent/stateResolverFactory.test.ts
+++ b/src/adapters/task-agent/stateResolverFactory.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { createStateResolver } from "./stateResolverFactory";
+import { FolderStateResolver } from "../../core/resolvers/FolderStateResolver";
+import { FrontmatterStateResolver } from "../../core/resolvers/FrontmatterStateResolver";
+import { CompositeStateResolver } from "../../core/resolvers/CompositeStateResolver";
+
+describe("stateResolverFactory", () => {
+  describe("createStateResolver", () => {
+    it("creates a FolderStateResolver for 'folder' strategy", () => {
+      const resolver = createStateResolver("folder", "2 - Areas/Tasks");
+      expect(resolver).toBeInstanceOf(FolderStateResolver);
+    });
+
+    it("creates a FrontmatterStateResolver for 'frontmatter' strategy", () => {
+      const resolver = createStateResolver("frontmatter", "2 - Areas/Tasks");
+      expect(resolver).toBeInstanceOf(FrontmatterStateResolver);
+    });
+
+    it("creates a CompositeStateResolver for 'composite' strategy", () => {
+      const resolver = createStateResolver("composite", "2 - Areas/Tasks");
+      expect(resolver).toBeInstanceOf(CompositeStateResolver);
+    });
+
+    it("defaults to FolderStateResolver for unknown strategy", () => {
+      const resolver = createStateResolver("unknown" as any, "2 - Areas/Tasks");
+      expect(resolver).toBeInstanceOf(FolderStateResolver);
+    });
+
+    it("folder resolver uses STATE_FOLDER_MAP mappings", () => {
+      const resolver = createStateResolver("folder", "Tasks");
+      // Verify the folder-to-state mapping works
+      expect(resolver.resolveState("Tasks/archive/task.md", undefined)).toBe("done");
+      expect(resolver.resolveState("Tasks/active/task.md", undefined)).toBe("active");
+      expect(resolver.resolveState("Tasks/priority/task.md", undefined)).toBe("priority");
+      expect(resolver.resolveState("Tasks/todo/task.md", undefined)).toBe("todo");
+    });
+
+    it("frontmatter resolver validates against task states", () => {
+      const resolver = createStateResolver("frontmatter", "Tasks");
+      expect(resolver.resolveState("any.md", { state: "active" })).toBe("active");
+      expect(resolver.resolveState("any.md", { state: "done" })).toBe("done");
+      expect(resolver.resolveState("any.md", { state: "abandoned" })).toBe("abandoned");
+      // Invalid state
+      expect(resolver.resolveState("any.md", { state: "invalid" })).toBeNull();
+    });
+
+    it("composite resolver checks frontmatter first, then folder", () => {
+      const resolver = createStateResolver("composite", "Tasks");
+      // Frontmatter wins when present
+      expect(resolver.resolveState("Tasks/active/task.md", { state: "done" })).toBe("done");
+      // Folder fallback when frontmatter is absent
+      expect(resolver.resolveState("Tasks/active/task.md", undefined)).toBe("active");
+      // Folder fallback when frontmatter state field is missing
+      expect(resolver.resolveState("Tasks/active/task.md", { title: "test" })).toBe("active");
+    });
+
+    it("composite resolver folder mapping is available via getFolderForState", () => {
+      const resolver = createStateResolver("composite", "Tasks");
+      expect(resolver.getFolderForState!("done")).toBe("archive");
+      expect(resolver.getFolderForState!("active")).toBe("active");
+    });
+  });
+});

--- a/src/adapters/task-agent/stateResolverFactory.ts
+++ b/src/adapters/task-agent/stateResolverFactory.ts
@@ -1,0 +1,47 @@
+import type { StateResolver } from "../../core/interfaces";
+import { FolderStateResolver } from "../../core/resolvers/FolderStateResolver";
+import { FrontmatterStateResolver } from "../../core/resolvers/FrontmatterStateResolver";
+import { CompositeStateResolver } from "../../core/resolvers/CompositeStateResolver";
+import { STATE_FOLDER_MAP } from "./types";
+
+/** State resolution strategy identifier. */
+export type StateStrategy = "folder" | "frontmatter" | "composite";
+
+const VALID_TASK_STATES = ["priority", "todo", "active", "done", "abandoned"];
+
+/**
+ * Create the default state resolver for the task-agent adapter.
+ * Uses a composite that checks frontmatter first, then falls back to folder.
+ * This preserves backward compatibility: existing folder-based tasks still
+ * work, while tasks with a `state` frontmatter field use that value.
+ *
+ * The folder resolver handles file moves on state transition. The frontmatter
+ * resolver handles the `state:` field update (which TaskMover also does
+ * directly for now - the resolver is used for state *resolution*, the mover
+ * handles the full transition including tags, timestamps, and activity log).
+ */
+export function createDefaultStateResolver(basePath: string): StateResolver {
+  return createStateResolver("folder", basePath);
+}
+
+/**
+ * Create a state resolver for the given strategy.
+ */
+export function createStateResolver(strategy: StateStrategy, basePath: string): StateResolver {
+  switch (strategy) {
+    case "folder":
+      return new FolderStateResolver(STATE_FOLDER_MAP, basePath);
+
+    case "frontmatter":
+      return new FrontmatterStateResolver("state", VALID_TASK_STATES);
+
+    case "composite":
+      return new CompositeStateResolver([
+        new FrontmatterStateResolver("state", VALID_TASK_STATES),
+        new FolderStateResolver(STATE_FOLDER_MAP, basePath),
+      ]);
+
+    default:
+      return new FolderStateResolver(STATE_FOLDER_MAP, basePath);
+  }
+}

--- a/src/adapters/task-agent/stateResolverFactory.ts
+++ b/src/adapters/task-agent/stateResolverFactory.ts
@@ -11,14 +11,10 @@ const VALID_TASK_STATES = ["priority", "todo", "active", "done", "abandoned"];
 
 /**
  * Create the default state resolver for the task-agent adapter.
- * Uses a composite that checks frontmatter first, then falls back to folder.
- * This preserves backward compatibility: existing folder-based tasks still
- * work, while tasks with a `state` frontmatter field use that value.
+ * Defaults to folder-based resolution for backward compatibility: state is
+ * derived from folder location and transitions move files between folders.
  *
- * The folder resolver handles file moves on state transition. The frontmatter
- * resolver handles the `state:` field update (which TaskMover also does
- * directly for now - the resolver is used for state *resolution*, the mover
- * handles the full transition including tags, timestamps, and activity log).
+ * Use the `stateStrategy` setting to switch to frontmatter or composite mode.
  */
 export function createDefaultStateResolver(basePath: string): StateResolver {
   return createStateResolver("folder", basePath);

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -97,6 +97,49 @@ export interface CardFlagRule {
 }
 
 /**
+ * Resolves the state of a work item and applies state transitions.
+ * Adapters provide a StateResolver to decouple state from any particular
+ * storage mechanism (folder location, frontmatter field, tags, etc.).
+ *
+ * The framework calls `resolveState` during parsing to determine an item's
+ * current state, and `applyState` when the user triggers a state transition
+ * (e.g. drag-drop between kanban columns).
+ */
+export interface StateResolver {
+  /**
+   * Determine the current state of a file. Returns null if the file's
+   * state cannot be determined by this resolver (e.g. not in a known folder,
+   * no frontmatter field present).
+   */
+  resolveState(filePath: string, frontmatter: Record<string, unknown> | undefined): string | null;
+
+  /**
+   * Apply a state change to a file. Implementations may update frontmatter,
+   * move the file to a different folder, or both. Returns true on success.
+   */
+  applyState(
+    app: App,
+    file: TFile,
+    newState: string,
+    oldState: string,
+    basePath: string,
+  ): Promise<boolean>;
+
+  /**
+   * Return the folder path (relative to basePath) for a given state, or
+   * null if this resolver does not use folder-based storage.
+   * Used by file creation logic to determine where to place new items.
+   */
+  getFolderForState?(state: string): string | null;
+
+  /**
+   * Return all valid state identifiers this resolver recognises.
+   * Used for validation when parsing items.
+   */
+  getValidStates?(): string[];
+}
+
+/**
  * Adapter-provided plugin configuration. Defines the kanban columns,
  * creation options, settings schema, and display name for items.
  */

--- a/src/core/resolvers/CompositeStateResolver.test.ts
+++ b/src/core/resolvers/CompositeStateResolver.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi } from "vitest";
+import { CompositeStateResolver } from "./CompositeStateResolver";
+import type { StateResolver } from "../interfaces";
+import type { App, TFile } from "obsidian";
+
+function createMockResolver(overrides: Partial<StateResolver> = {}): StateResolver {
+  return {
+    resolveState: vi.fn().mockReturnValue(null),
+    applyState: vi.fn().mockResolvedValue(true),
+    getFolderForState: vi.fn().mockReturnValue(null),
+    getValidStates: vi.fn().mockReturnValue([]),
+    ...overrides,
+  };
+}
+
+describe("CompositeStateResolver", () => {
+  describe("resolveState", () => {
+    it("returns the first non-null result", () => {
+      const r1 = createMockResolver({ resolveState: vi.fn().mockReturnValue(null) });
+      const r2 = createMockResolver({ resolveState: vi.fn().mockReturnValue("active") });
+      const r3 = createMockResolver({ resolveState: vi.fn().mockReturnValue("done") });
+
+      const composite = new CompositeStateResolver([r1, r2, r3]);
+      expect(composite.resolveState("path.md", {})).toBe("active");
+      // r3 should not be called since r2 returned a value
+      expect(r3.resolveState).not.toHaveBeenCalled();
+    });
+
+    it("returns null when all resolvers return null", () => {
+      const r1 = createMockResolver();
+      const r2 = createMockResolver();
+
+      const composite = new CompositeStateResolver([r1, r2]);
+      expect(composite.resolveState("path.md", {})).toBeNull();
+    });
+
+    it("passes filePath and frontmatter to each resolver", () => {
+      const r1 = createMockResolver();
+      const fm = { state: "test" };
+
+      const composite = new CompositeStateResolver([r1]);
+      composite.resolveState("my/path.md", fm);
+
+      expect(r1.resolveState).toHaveBeenCalledWith("my/path.md", fm);
+    });
+
+    it("handles empty resolver list", () => {
+      const composite = new CompositeStateResolver([]);
+      expect(composite.resolveState("path.md", {})).toBeNull();
+    });
+  });
+
+  describe("applyState", () => {
+    const mockApp = {} as App;
+    const mockFile = {} as TFile;
+
+    it("runs all resolvers and returns true if any succeed", async () => {
+      const r1 = createMockResolver({ applyState: vi.fn().mockResolvedValue(true) });
+      const r2 = createMockResolver({ applyState: vi.fn().mockResolvedValue(false) });
+
+      const composite = new CompositeStateResolver([r1, r2]);
+      const result = await composite.applyState(mockApp, mockFile, "active", "todo", "/base");
+
+      expect(result).toBe(true);
+      expect(r1.applyState).toHaveBeenCalled();
+      expect(r2.applyState).toHaveBeenCalled();
+    });
+
+    it("returns false when all resolvers fail", async () => {
+      const r1 = createMockResolver({ applyState: vi.fn().mockResolvedValue(false) });
+      const r2 = createMockResolver({ applyState: vi.fn().mockResolvedValue(false) });
+
+      const composite = new CompositeStateResolver([r1, r2]);
+      const result = await composite.applyState(mockApp, mockFile, "active", "todo", "/base");
+
+      expect(result).toBe(false);
+    });
+
+    it("continues running resolvers even if one throws", async () => {
+      const r1 = createMockResolver({
+        applyState: vi.fn().mockRejectedValue(new Error("fail")),
+      });
+      const r2 = createMockResolver({ applyState: vi.fn().mockResolvedValue(true) });
+
+      const composite = new CompositeStateResolver([r1, r2]);
+      const result = await composite.applyState(mockApp, mockFile, "active", "todo", "/base");
+
+      expect(result).toBe(true);
+      expect(r2.applyState).toHaveBeenCalled();
+    });
+
+    it("passes correct arguments to each resolver", async () => {
+      const r1 = createMockResolver();
+
+      const composite = new CompositeStateResolver([r1]);
+      await composite.applyState(mockApp, mockFile, "done", "active", "/base/path");
+
+      expect(r1.applyState).toHaveBeenCalledWith(mockApp, mockFile, "done", "active", "/base/path");
+    });
+  });
+
+  describe("getFolderForState", () => {
+    it("returns the first non-null folder", () => {
+      const r1 = createMockResolver({ getFolderForState: vi.fn().mockReturnValue(null) });
+      const r2 = createMockResolver({ getFolderForState: vi.fn().mockReturnValue("archive") });
+
+      const composite = new CompositeStateResolver([r1, r2]);
+      expect(composite.getFolderForState("done")).toBe("archive");
+    });
+
+    it("returns null when no resolver has a folder mapping", () => {
+      const r1 = createMockResolver();
+      const composite = new CompositeStateResolver([r1]);
+      expect(composite.getFolderForState("done")).toBeNull();
+    });
+
+    it("handles resolvers without getFolderForState", () => {
+      const r1: StateResolver = {
+        resolveState: vi.fn().mockReturnValue(null),
+        applyState: vi.fn().mockResolvedValue(true),
+        // No getFolderForState
+      };
+
+      const composite = new CompositeStateResolver([r1]);
+      expect(composite.getFolderForState("done")).toBeNull();
+    });
+  });
+
+  describe("getValidStates", () => {
+    it("merges valid states from all resolvers", () => {
+      const r1 = createMockResolver({ getValidStates: vi.fn().mockReturnValue(["a", "b"]) });
+      const r2 = createMockResolver({ getValidStates: vi.fn().mockReturnValue(["b", "c"]) });
+
+      const composite = new CompositeStateResolver([r1, r2]);
+      const states = composite.getValidStates();
+      expect(states).toEqual(expect.arrayContaining(["a", "b", "c"]));
+      expect(states).toHaveLength(3); // no duplicates
+    });
+
+    it("handles resolvers without getValidStates", () => {
+      const r1: StateResolver = {
+        resolveState: vi.fn().mockReturnValue(null),
+        applyState: vi.fn().mockResolvedValue(true),
+      };
+
+      const composite = new CompositeStateResolver([r1]);
+      expect(composite.getValidStates()).toEqual([]);
+    });
+  });
+});

--- a/src/core/resolvers/CompositeStateResolver.ts
+++ b/src/core/resolvers/CompositeStateResolver.ts
@@ -1,0 +1,64 @@
+import type { App, TFile } from "obsidian";
+import type { StateResolver } from "../interfaces";
+
+/**
+ * Chains multiple state resolvers. For resolution, tries each resolver
+ * in order and returns the first non-null result. For applying state,
+ * runs all resolvers (so both frontmatter and folder can be updated).
+ */
+export class CompositeStateResolver implements StateResolver {
+  private resolvers: StateResolver[];
+
+  constructor(resolvers: StateResolver[]) {
+    this.resolvers = resolvers;
+  }
+
+  resolveState(filePath: string, frontmatter: Record<string, unknown> | undefined): string | null {
+    for (const resolver of this.resolvers) {
+      const state = resolver.resolveState(filePath, frontmatter);
+      if (state !== null) return state;
+    }
+    return null;
+  }
+
+  async applyState(
+    app: App,
+    file: TFile,
+    newState: string,
+    oldState: string,
+    basePath: string,
+  ): Promise<boolean> {
+    let anySucceeded = false;
+    for (const resolver of this.resolvers) {
+      try {
+        const result = await resolver.applyState(app, file, newState, oldState, basePath);
+        if (result) anySucceeded = true;
+      } catch (err) {
+        console.error("[work-terminal] CompositeStateResolver: resolver failed", err);
+      }
+    }
+    return anySucceeded;
+  }
+
+  getFolderForState(state: string): string | null {
+    for (const resolver of this.resolvers) {
+      if (resolver.getFolderForState) {
+        const folder = resolver.getFolderForState(state);
+        if (folder !== null) return folder;
+      }
+    }
+    return null;
+  }
+
+  getValidStates(): string[] {
+    const states = new Set<string>();
+    for (const resolver of this.resolvers) {
+      if (resolver.getValidStates) {
+        for (const s of resolver.getValidStates()) {
+          states.add(s);
+        }
+      }
+    }
+    return [...states];
+  }
+}

--- a/src/core/resolvers/FolderStateResolver.test.ts
+++ b/src/core/resolvers/FolderStateResolver.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi } from "vitest";
+import { FolderStateResolver } from "./FolderStateResolver";
+import type { App, TFile } from "obsidian";
+
+const STATE_TO_FOLDER: Record<string, string> = {
+  priority: "priority",
+  todo: "todo",
+  active: "active",
+  done: "archive",
+};
+
+describe("FolderStateResolver", () => {
+  describe("resolveState", () => {
+    it("resolves state from folder name within basePath", () => {
+      const resolver = new FolderStateResolver(STATE_TO_FOLDER, "2 - Areas/Tasks");
+      expect(resolver.resolveState("2 - Areas/Tasks/active/task.md", undefined)).toBe("active");
+    });
+
+    it("resolves done from archive folder", () => {
+      const resolver = new FolderStateResolver(STATE_TO_FOLDER, "2 - Areas/Tasks");
+      expect(resolver.resolveState("2 - Areas/Tasks/archive/task.md", undefined)).toBe("done");
+    });
+
+    it("resolves all mapped states", () => {
+      const resolver = new FolderStateResolver(STATE_TO_FOLDER, "2 - Areas/Tasks");
+      expect(resolver.resolveState("2 - Areas/Tasks/priority/task.md", undefined)).toBe("priority");
+      expect(resolver.resolveState("2 - Areas/Tasks/todo/task.md", undefined)).toBe("todo");
+      expect(resolver.resolveState("2 - Areas/Tasks/active/task.md", undefined)).toBe("active");
+      expect(resolver.resolveState("2 - Areas/Tasks/archive/task.md", undefined)).toBe("done");
+    });
+
+    it("returns null for unknown folders", () => {
+      const resolver = new FolderStateResolver(STATE_TO_FOLDER, "2 - Areas/Tasks");
+      expect(resolver.resolveState("2 - Areas/Tasks/unknown/task.md", undefined)).toBeNull();
+    });
+
+    it("returns null for files outside basePath", () => {
+      const resolver = new FolderStateResolver(STATE_TO_FOLDER, "2 - Areas/Tasks");
+      expect(resolver.resolveState("3 - Resources/notes/task.md", undefined)).toBeNull();
+    });
+
+    it("ignores frontmatter (folder-only resolution)", () => {
+      const resolver = new FolderStateResolver(STATE_TO_FOLDER, "2 - Areas/Tasks");
+      const fm = { state: "done" };
+      // Should resolve from folder, not frontmatter
+      expect(resolver.resolveState("2 - Areas/Tasks/active/task.md", fm)).toBe("active");
+    });
+
+    it("handles basePath with trailing slash", () => {
+      const resolver = new FolderStateResolver(STATE_TO_FOLDER, "2 - Areas/Tasks/");
+      expect(resolver.resolveState("2 - Areas/Tasks/active/task.md", undefined)).toBe("active");
+    });
+
+    it("handles empty basePath", () => {
+      const resolver = new FolderStateResolver(STATE_TO_FOLDER);
+      expect(resolver.resolveState("active/task.md", undefined)).toBe("active");
+    });
+
+    it("works after setBasePath", () => {
+      const resolver = new FolderStateResolver(STATE_TO_FOLDER, "old/path");
+      expect(resolver.resolveState("new/path/todo/task.md", undefined)).toBeNull();
+      resolver.setBasePath("new/path");
+      expect(resolver.resolveState("new/path/todo/task.md", undefined)).toBe("todo");
+    });
+  });
+
+  describe("applyState", () => {
+    function createMockApp() {
+      return {
+        vault: {
+          rename: vi.fn().mockResolvedValue(undefined),
+          createFolder: vi.fn().mockResolvedValue(undefined),
+          getAbstractFileByPath: vi.fn().mockReturnValue(null),
+        },
+      } as unknown as App;
+    }
+
+    it("moves file to the target folder", async () => {
+      const app = createMockApp();
+      const resolver = new FolderStateResolver(STATE_TO_FOLDER, "Tasks");
+      const file = { path: "Tasks/todo/task.md", name: "task.md" } as TFile;
+
+      const result = await resolver.applyState(app, file, "active", "todo", "Tasks");
+
+      expect(result).toBe(true);
+      expect(app.vault.rename).toHaveBeenCalledWith(file, "Tasks/active/task.md");
+    });
+
+    it("creates target folder if missing", async () => {
+      const app = createMockApp();
+      const resolver = new FolderStateResolver(STATE_TO_FOLDER, "Tasks");
+      const file = { path: "Tasks/todo/task.md", name: "task.md" } as TFile;
+
+      await resolver.applyState(app, file, "active", "todo", "Tasks");
+
+      expect(app.vault.createFolder).toHaveBeenCalledWith("Tasks/active");
+    });
+
+    it("skips rename when path is unchanged", async () => {
+      const app = createMockApp();
+      const resolver = new FolderStateResolver(STATE_TO_FOLDER, "Tasks");
+      const file = { path: "Tasks/active/task.md", name: "task.md" } as TFile;
+
+      const result = await resolver.applyState(app, file, "active", "active", "Tasks");
+
+      expect(result).toBe(true);
+      expect(app.vault.rename).not.toHaveBeenCalled();
+    });
+
+    it("maps done state to archive folder", async () => {
+      const app = createMockApp();
+      const resolver = new FolderStateResolver(STATE_TO_FOLDER, "Tasks");
+      const file = { path: "Tasks/todo/task.md", name: "task.md" } as TFile;
+
+      await resolver.applyState(app, file, "done", "todo", "Tasks");
+
+      expect(app.vault.rename).toHaveBeenCalledWith(file, "Tasks/archive/task.md");
+    });
+
+    it("returns false for unknown state", async () => {
+      const app = createMockApp();
+      const resolver = new FolderStateResolver(STATE_TO_FOLDER, "Tasks");
+      const file = { path: "Tasks/todo/task.md", name: "task.md" } as TFile;
+
+      const result = await resolver.applyState(app, file, "nonexistent", "todo", "Tasks");
+
+      expect(result).toBe(false);
+    });
+
+    it("does not create folder when it already exists", async () => {
+      const app = createMockApp();
+      (app.vault.getAbstractFileByPath as ReturnType<typeof vi.fn>).mockReturnValue({
+        path: "Tasks/active",
+      });
+      const resolver = new FolderStateResolver(STATE_TO_FOLDER, "Tasks");
+      const file = { path: "Tasks/todo/task.md", name: "task.md" } as TFile;
+
+      await resolver.applyState(app, file, "active", "todo", "Tasks");
+
+      expect(app.vault.createFolder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getFolderForState", () => {
+    it("returns folder name for valid state", () => {
+      const resolver = new FolderStateResolver(STATE_TO_FOLDER);
+      expect(resolver.getFolderForState("done")).toBe("archive");
+      expect(resolver.getFolderForState("active")).toBe("active");
+    });
+
+    it("returns null for unknown state", () => {
+      const resolver = new FolderStateResolver(STATE_TO_FOLDER);
+      expect(resolver.getFolderForState("nonexistent")).toBeNull();
+    });
+  });
+
+  describe("getValidStates", () => {
+    it("returns all state keys", () => {
+      const resolver = new FolderStateResolver(STATE_TO_FOLDER);
+      expect(resolver.getValidStates()).toEqual(
+        expect.arrayContaining(["priority", "todo", "active", "done"]),
+      );
+    });
+  });
+});

--- a/src/core/resolvers/FolderStateResolver.test.ts
+++ b/src/core/resolvers/FolderStateResolver.test.ts
@@ -127,6 +127,28 @@ describe("FolderStateResolver", () => {
       expect(result).toBe(false);
     });
 
+    it("handles empty basePath without leading slash", async () => {
+      const app = createMockApp();
+      const resolver = new FolderStateResolver(STATE_TO_FOLDER);
+      const file = { path: "todo/task.md", name: "task.md" } as TFile;
+
+      const result = await resolver.applyState(app, file, "active", "todo", "");
+
+      expect(result).toBe(true);
+      expect(app.vault.rename).toHaveBeenCalledWith(file, "active/task.md");
+    });
+
+    it("handles basePath with trailing slash without double slashes", async () => {
+      const app = createMockApp();
+      const resolver = new FolderStateResolver(STATE_TO_FOLDER, "Tasks/");
+      const file = { path: "Tasks/todo/task.md", name: "task.md" } as TFile;
+
+      const result = await resolver.applyState(app, file, "active", "todo", "Tasks/");
+
+      expect(result).toBe(true);
+      expect(app.vault.rename).toHaveBeenCalledWith(file, "Tasks/active/task.md");
+    });
+
     it("does not create folder when it already exists", async () => {
       const app = createMockApp();
       (app.vault.getAbstractFileByPath as ReturnType<typeof vi.fn>).mockReturnValue({

--- a/src/core/resolvers/FolderStateResolver.ts
+++ b/src/core/resolvers/FolderStateResolver.ts
@@ -21,22 +21,29 @@ export class FolderStateResolver implements StateResolver {
    * Example: { priority: "priority", todo: "todo", active: "active", archive: "done" }
    */
   private folderToState: Record<string, string>;
+  /**
+   * Base path for resolving relative folder positions. Set at construction
+   * time so resolveState() doesn't need extra parameters.
+   */
+  private basePath: string;
 
-  constructor(stateToFolder: Record<string, string>) {
+  constructor(stateToFolder: Record<string, string>, basePath = "") {
     this.stateToFolder = stateToFolder;
+    this.basePath = basePath.replace(/\/+$/, "");
     this.folderToState = {};
     for (const [state, folder] of Object.entries(stateToFolder)) {
       this.folderToState[folder] = state;
     }
   }
 
-  resolveState(
-    filePath: string,
-    _frontmatter: Record<string, unknown> | undefined,
-    basePath?: string,
-  ): string | null {
+  /** Update the base path after construction (e.g. when settings change). */
+  setBasePath(basePath: string): void {
+    this.basePath = basePath.replace(/\/+$/, "");
+  }
+
+  resolveState(filePath: string, _frontmatter: Record<string, unknown> | undefined): string | null {
     // Extract the first folder segment relative to basePath
-    const prefix = basePath ? `${basePath}/` : "";
+    const prefix = this.basePath ? `${this.basePath}/` : "";
     const relativePath =
       prefix && filePath.startsWith(prefix) ? filePath.slice(prefix.length) : filePath;
     const folder = relativePath.split("/")[0];

--- a/src/core/resolvers/FolderStateResolver.ts
+++ b/src/core/resolvers/FolderStateResolver.ts
@@ -60,7 +60,8 @@ export class FolderStateResolver implements StateResolver {
     const targetFolder = this.stateToFolder[newState];
     if (!targetFolder) return false;
 
-    const newFolderPath = `${basePath}/${targetFolder}`;
+    const normalizedBase = basePath.replace(/\/+$/, "");
+    const newFolderPath = normalizedBase ? `${normalizedBase}/${targetFolder}` : targetFolder;
     const newPath = `${newFolderPath}/${file.name}`;
 
     if (file.path === newPath) return true;

--- a/src/core/resolvers/FolderStateResolver.ts
+++ b/src/core/resolvers/FolderStateResolver.ts
@@ -1,0 +1,77 @@
+import type { App, TFile } from "obsidian";
+import type { StateResolver } from "../interfaces";
+
+/**
+ * Resolves state from the file's folder location within the base path.
+ * Applies state changes by moving the file to the corresponding folder.
+ *
+ * This is the default resolver and preserves the original behavior where
+ * folder names map directly to states (e.g. `priority/`, `todo/`, `active/`,
+ * `archive/` -> done).
+ */
+export class FolderStateResolver implements StateResolver {
+  /**
+   * Maps state IDs to folder names. The folder name is the directory
+   * within the base path where items in that state are stored.
+   * Example: { priority: "priority", todo: "todo", active: "active", done: "archive" }
+   */
+  private stateToFolder: Record<string, string>;
+  /**
+   * Reverse map: folder name -> state ID.
+   * Example: { priority: "priority", todo: "todo", active: "active", archive: "done" }
+   */
+  private folderToState: Record<string, string>;
+
+  constructor(stateToFolder: Record<string, string>) {
+    this.stateToFolder = stateToFolder;
+    this.folderToState = {};
+    for (const [state, folder] of Object.entries(stateToFolder)) {
+      this.folderToState[folder] = state;
+    }
+  }
+
+  resolveState(
+    filePath: string,
+    _frontmatter: Record<string, unknown> | undefined,
+    basePath?: string,
+  ): string | null {
+    // Extract the first folder segment relative to basePath
+    const prefix = basePath ? `${basePath}/` : "";
+    const relativePath =
+      prefix && filePath.startsWith(prefix) ? filePath.slice(prefix.length) : filePath;
+    const folder = relativePath.split("/")[0];
+    return this.folderToState[folder] ?? null;
+  }
+
+  async applyState(
+    app: App,
+    file: TFile,
+    newState: string,
+    _oldState: string,
+    basePath: string,
+  ): Promise<boolean> {
+    const targetFolder = this.stateToFolder[newState];
+    if (!targetFolder) return false;
+
+    const newFolderPath = `${basePath}/${targetFolder}`;
+    const newPath = `${newFolderPath}/${file.name}`;
+
+    if (file.path === newPath) return true;
+
+    // Ensure target folder exists
+    const folder = app.vault.getAbstractFileByPath(newFolderPath);
+    if (!folder) {
+      await app.vault.createFolder(newFolderPath);
+    }
+    await app.vault.rename(file, newPath);
+    return true;
+  }
+
+  getFolderForState(state: string): string | null {
+    return this.stateToFolder[state] ?? null;
+  }
+
+  getValidStates(): string[] {
+    return Object.keys(this.stateToFolder);
+  }
+}

--- a/src/core/resolvers/FrontmatterStateResolver.test.ts
+++ b/src/core/resolvers/FrontmatterStateResolver.test.ts
@@ -93,7 +93,7 @@ title: "Test Task"
       expect(written).not.toMatch(/^state: todo$/m);
     });
 
-    it("returns false when the field is not found", async () => {
+    it("inserts the field when it is missing from frontmatter", async () => {
       const contentNoState = `---
 id: abc-123
 title: "Test Task"
@@ -106,8 +106,42 @@ title: "Test Task"
 
       const result = await resolver.applyState(app, file, "active", "todo", "");
 
+      expect(result).toBe(true);
+      const written = modify.mock.calls[0][1] as string;
+      expect(written).toMatch(/^state: active$/m);
+      // Field should be inside frontmatter, before closing ---
+      expect(written).toMatch(/state: active\n---/);
+    });
+
+    it("returns false when there is no frontmatter block", async () => {
+      const contentNoFrontmatter = `# Just a heading\nSome content\n`;
+      const { app, modify } = createMockApp(contentNoFrontmatter);
+      const resolver = new FrontmatterStateResolver();
+      const file = { path: "task.md" } as TFile;
+
+      const result = await resolver.applyState(app, file, "active", "todo", "");
+
       expect(result).toBe(false);
       expect(modify).not.toHaveBeenCalled();
+    });
+
+    it("updates a blank field value (e.g. 'state:')", async () => {
+      const contentBlankState = `---
+id: abc-123
+state:
+title: "Test Task"
+---
+# Test Task
+`;
+      const { app, modify } = createMockApp(contentBlankState);
+      const resolver = new FrontmatterStateResolver();
+      const file = { path: "task.md" } as TFile;
+
+      const result = await resolver.applyState(app, file, "active", "todo", "");
+
+      expect(result).toBe(true);
+      const written = modify.mock.calls[0][1] as string;
+      expect(written).toMatch(/^state: active$/m);
     });
 
     it("works with custom field names", async () => {

--- a/src/core/resolvers/FrontmatterStateResolver.test.ts
+++ b/src/core/resolvers/FrontmatterStateResolver.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi } from "vitest";
+import { FrontmatterStateResolver } from "./FrontmatterStateResolver";
+import type { App, TFile } from "obsidian";
+
+describe("FrontmatterStateResolver", () => {
+  describe("resolveState", () => {
+    it("resolves state from the default 'state' field", () => {
+      const resolver = new FrontmatterStateResolver();
+      expect(resolver.resolveState("any/path.md", { state: "active" })).toBe("active");
+    });
+
+    it("resolves state from a custom field name", () => {
+      const resolver = new FrontmatterStateResolver("status");
+      expect(resolver.resolveState("any/path.md", { status: "in-progress" })).toBe("in-progress");
+    });
+
+    it("returns null when frontmatter is undefined", () => {
+      const resolver = new FrontmatterStateResolver();
+      expect(resolver.resolveState("any/path.md", undefined)).toBeNull();
+    });
+
+    it("returns null when the field is missing", () => {
+      const resolver = new FrontmatterStateResolver();
+      expect(resolver.resolveState("any/path.md", { title: "Test" })).toBeNull();
+    });
+
+    it("returns null when the field is not a string", () => {
+      const resolver = new FrontmatterStateResolver();
+      expect(resolver.resolveState("any/path.md", { state: 42 })).toBeNull();
+      expect(resolver.resolveState("any/path.md", { state: true })).toBeNull();
+      expect(resolver.resolveState("any/path.md", { state: null })).toBeNull();
+    });
+
+    it("returns null when the field is an empty string", () => {
+      const resolver = new FrontmatterStateResolver();
+      expect(resolver.resolveState("any/path.md", { state: "" })).toBeNull();
+      expect(resolver.resolveState("any/path.md", { state: "   " })).toBeNull();
+    });
+
+    it("validates against valid states when provided", () => {
+      const resolver = new FrontmatterStateResolver("state", ["active", "done"]);
+      expect(resolver.resolveState("any/path.md", { state: "active" })).toBe("active");
+      expect(resolver.resolveState("any/path.md", { state: "invalid" })).toBeNull();
+    });
+
+    it("accepts any string when no valid states are specified", () => {
+      const resolver = new FrontmatterStateResolver();
+      expect(resolver.resolveState("any/path.md", { state: "custom-state" })).toBe("custom-state");
+    });
+
+    it("trims whitespace from the value", () => {
+      const resolver = new FrontmatterStateResolver();
+      expect(resolver.resolveState("any/path.md", { state: "  active  " })).toBe("active");
+    });
+
+    it("ignores file path entirely", () => {
+      const resolver = new FrontmatterStateResolver();
+      // Same frontmatter, different paths - should return the same result
+      expect(resolver.resolveState("folder-a/task.md", { state: "done" })).toBe("done");
+      expect(resolver.resolveState("folder-b/task.md", { state: "done" })).toBe("done");
+    });
+  });
+
+  describe("applyState", () => {
+    function createMockApp(content: string) {
+      const modify = vi.fn().mockResolvedValue(undefined);
+      const read = vi.fn().mockResolvedValue(content);
+      return {
+        app: { vault: { read, modify } } as unknown as App,
+        modify,
+        read,
+      };
+    }
+
+    const sampleContent = `---
+id: abc-123
+state: todo
+title: "Test Task"
+---
+# Test Task
+`;
+
+    it("updates the state field in frontmatter", async () => {
+      const { app, modify } = createMockApp(sampleContent);
+      const resolver = new FrontmatterStateResolver();
+      const file = { path: "task.md" } as TFile;
+
+      const result = await resolver.applyState(app, file, "active", "todo", "");
+
+      expect(result).toBe(true);
+      const written = modify.mock.calls[0][1] as string;
+      expect(written).toMatch(/^state: active$/m);
+      expect(written).not.toMatch(/^state: todo$/m);
+    });
+
+    it("returns false when the field is not found", async () => {
+      const contentNoState = `---
+id: abc-123
+title: "Test Task"
+---
+# Test Task
+`;
+      const { app, modify } = createMockApp(contentNoState);
+      const resolver = new FrontmatterStateResolver();
+      const file = { path: "task.md" } as TFile;
+
+      const result = await resolver.applyState(app, file, "active", "todo", "");
+
+      expect(result).toBe(false);
+      expect(modify).not.toHaveBeenCalled();
+    });
+
+    it("works with custom field names", async () => {
+      const customContent = `---
+id: abc-123
+status: pending
+title: "Test Task"
+---
+`;
+      const { app, modify } = createMockApp(customContent);
+      const resolver = new FrontmatterStateResolver("status");
+      const file = { path: "task.md" } as TFile;
+
+      const result = await resolver.applyState(app, file, "approved", "pending", "");
+
+      expect(result).toBe(true);
+      const written = modify.mock.calls[0][1] as string;
+      expect(written).toMatch(/^status: approved$/m);
+    });
+  });
+
+  describe("getValidStates", () => {
+    it("returns the configured valid states", () => {
+      const resolver = new FrontmatterStateResolver("state", ["a", "b", "c"]);
+      expect(resolver.getValidStates()).toEqual(["a", "b", "c"]);
+    });
+
+    it("returns empty array when no valid states configured", () => {
+      const resolver = new FrontmatterStateResolver();
+      expect(resolver.getValidStates()).toEqual([]);
+    });
+
+    it("returns a copy, not a reference", () => {
+      const resolver = new FrontmatterStateResolver("state", ["a", "b"]);
+      const states = resolver.getValidStates();
+      states.push("c");
+      expect(resolver.getValidStates()).toEqual(["a", "b"]);
+    });
+  });
+});

--- a/src/core/resolvers/FrontmatterStateResolver.ts
+++ b/src/core/resolvers/FrontmatterStateResolver.ts
@@ -40,12 +40,36 @@ export class FrontmatterStateResolver implements StateResolver {
     _basePath: string,
   ): Promise<boolean> {
     const content = await app.vault.read(file);
-    const fieldPattern = new RegExp(`^${escapeRegex(this.fieldName)}:\\s*.+$`, "m");
-    if (!fieldPattern.test(content)) return false;
-
-    const updated = content.replace(fieldPattern, `${this.fieldName}: ${newState}`);
+    const updated = this.upsertFrontmatterField(content, newState);
+    if (updated === null) return false;
     await app.vault.modify(file, updated);
     return true;
+  }
+
+  /**
+   * Update or insert the field within frontmatter. Only touches content
+   * inside the opening `--- ... ---` block. Returns null if there is no
+   * frontmatter block at all (caller should decide how to handle).
+   */
+  private upsertFrontmatterField(content: string, newState: string): string | null {
+    const fmMatch = content.match(/^(---\r?\n)([\s\S]*?)(^---(?:\r?\n|$))/m);
+    if (!fmMatch) return null;
+
+    const [fullMatch, openFence, body, closeFence] = fmMatch;
+    const eol = openFence.endsWith("\r\n") ? "\r\n" : "\n";
+    const fieldPattern = new RegExp(`^${escapeRegex(this.fieldName)}:\\s*.*$`, "m");
+
+    let updatedBody: string;
+    if (fieldPattern.test(body)) {
+      // Field exists (even if blank like `state:`) - replace it
+      updatedBody = body.replace(fieldPattern, `${this.fieldName}: ${newState}`);
+    } else {
+      // Field missing - append before closing fence
+      const trimmedBody = body.endsWith(eol) ? body : body + eol;
+      updatedBody = `${trimmedBody}${this.fieldName}: ${newState}${eol}`;
+    }
+
+    return content.replace(fullMatch, `${openFence}${updatedBody}${closeFence}`);
   }
 
   getValidStates(): string[] {

--- a/src/core/resolvers/FrontmatterStateResolver.ts
+++ b/src/core/resolvers/FrontmatterStateResolver.ts
@@ -1,0 +1,58 @@
+import type { App, TFile } from "obsidian";
+import type { StateResolver } from "../interfaces";
+
+/**
+ * Resolves state from a frontmatter field. Applies state changes by
+ * updating the frontmatter field in the file content.
+ *
+ * This resolver does not move files - state is purely metadata-driven.
+ * Use CompositeStateResolver to combine with folder moves.
+ */
+export class FrontmatterStateResolver implements StateResolver {
+  private fieldName: string;
+  private validStates: string[];
+
+  /**
+   * @param fieldName - The frontmatter field to read/write (default: "state")
+   * @param validStates - List of valid state values. If empty, any string value is accepted.
+   */
+  constructor(fieldName = "state", validStates: string[] = []) {
+    this.fieldName = fieldName;
+    this.validStates = validStates;
+  }
+
+  resolveState(_filePath: string, frontmatter: Record<string, unknown> | undefined): string | null {
+    if (!frontmatter) return null;
+    const value = frontmatter[this.fieldName];
+    if (typeof value !== "string" || !value.trim()) return null;
+    const state = value.trim();
+    if (this.validStates.length > 0 && !this.validStates.includes(state)) {
+      return null;
+    }
+    return state;
+  }
+
+  async applyState(
+    app: App,
+    file: TFile,
+    newState: string,
+    _oldState: string,
+    _basePath: string,
+  ): Promise<boolean> {
+    const content = await app.vault.read(file);
+    const fieldPattern = new RegExp(`^${escapeRegex(this.fieldName)}:\\s*.+$`, "m");
+    if (!fieldPattern.test(content)) return false;
+
+    const updated = content.replace(fieldPattern, `${this.fieldName}: ${newState}`);
+    await app.vault.modify(file, updated);
+    return true;
+  }
+
+  getValidStates(): string[] {
+    return [...this.validStates];
+  }
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/core/resolvers/index.ts
+++ b/src/core/resolvers/index.ts
@@ -1,0 +1,3 @@
+export { FolderStateResolver } from "./FolderStateResolver";
+export { FrontmatterStateResolver } from "./FrontmatterStateResolver";
+export { CompositeStateResolver } from "./CompositeStateResolver";


### PR DESCRIPTION
## Summary

Introduces a StateResolver strategy pattern that decouples task state from folder location. Users can now choose how state is determined:

- **Folder-based** (default) - existing behavior, derives state from folder path
- **Frontmatter-based** - reads/writes a `state` frontmatter field
- **Composite** - reads frontmatter first, falls back to folder

### Changes

- `StateResolver` interface in `src/core/interfaces.ts` with `resolveState()` and `applyState()` methods
- Three concrete resolvers: `FolderStateResolver`, `FrontmatterStateResolver`, `CompositeStateResolver`
- `TaskParser` refactored to use resolver instead of hardcoded folder lookup
- `TaskMover` refactored to delegate state transitions to resolver's `applyState()`
- Settings UI for choosing resolution strategy in adapter config
- Full backward compatibility - folder-based is default, zero-config upgrade

### Test plan

- [ ] Existing folder-based workflows unchanged (regression)
- [ ] Frontmatter strategy reads/writes `state` field correctly
- [ ] Composite strategy falls back from frontmatter to folder
- [ ] Settings UI reflects strategy choice
- [ ] Drag-drop between columns uses selected strategy

Closes #386