### PR TITLE
Add state resolution settings UI with column ordering

### DIFF
--- a/src/adapters/task-agent/TaskAgentConfig.test.ts
+++ b/src/adapters/task-agent/TaskAgentConfig.test.ts
@@ -118,6 +118,14 @@ describe("TaskAgentConfig column helpers", () => {
       const result = resolveCreationColumns('["done"]');
       expect(result).toEqual([{ id: "done", label: "Done", default: true }]);
     });
+
+    it("deduplicates repeated IDs", () => {
+      const result = resolveCreationColumns('["todo", "todo", "active"]');
+      expect(result).toEqual([
+        { id: "todo", label: "To Do", default: true },
+        { id: "active", label: "Active" },
+      ]);
+    });
   });
 
   describe("TASK_AGENT_CONFIG defaults", () => {

--- a/src/adapters/task-agent/TaskAgentConfig.test.ts
+++ b/src/adapters/task-agent/TaskAgentConfig.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseColumnOrderJson,
+  resolveColumns,
+  resolveCreationColumns,
+  DEFAULT_COLUMNS,
+  DEFAULT_CREATION_COLUMNS,
+  TASK_AGENT_CONFIG,
+} from "./TaskAgentConfig";
+
+describe("TaskAgentConfig column helpers", () => {
+  describe("parseColumnOrderJson", () => {
+    it("returns empty array for undefined input", () => {
+      expect(parseColumnOrderJson(undefined)).toEqual([]);
+    });
+
+    it("returns empty array for empty string", () => {
+      expect(parseColumnOrderJson("")).toEqual([]);
+    });
+
+    it("returns empty array for invalid JSON", () => {
+      expect(parseColumnOrderJson("not json")).toEqual([]);
+    });
+
+    it("returns empty array for non-array JSON", () => {
+      expect(parseColumnOrderJson('{"a": 1}')).toEqual([]);
+    });
+
+    it("returns empty array for array with non-string elements", () => {
+      expect(parseColumnOrderJson("[1, 2, 3]")).toEqual([]);
+    });
+
+    it("parses valid JSON array of strings", () => {
+      expect(parseColumnOrderJson('["todo", "active", "done"]')).toEqual([
+        "todo",
+        "active",
+        "done",
+      ]);
+    });
+
+    it("returns empty array for mixed-type array", () => {
+      expect(parseColumnOrderJson('["todo", 1, "active"]')).toEqual([]);
+    });
+  });
+
+  describe("resolveColumns", () => {
+    it("returns default columns for empty/undefined input", () => {
+      expect(resolveColumns(undefined)).toEqual(DEFAULT_COLUMNS);
+      expect(resolveColumns("")).toEqual(DEFAULT_COLUMNS);
+    });
+
+    it("reorders columns according to provided order", () => {
+      const result = resolveColumns('["done", "todo", "active", "priority"]');
+      expect(result.map((c) => c.id)).toEqual(["done", "todo", "active", "priority"]);
+    });
+
+    it("preserves column metadata (label, folderName) during reorder", () => {
+      const result = resolveColumns('["done", "priority"]');
+      const doneCol = result.find((c) => c.id === "done");
+      expect(doneCol?.label).toBe("Done");
+      expect(doneCol?.folderName).toBe("archive");
+    });
+
+    it("appends missing columns at the end", () => {
+      const result = resolveColumns('["todo", "active"]');
+      expect(result.map((c) => c.id)).toEqual(["todo", "active", "priority", "done"]);
+    });
+
+    it("ignores unknown column IDs", () => {
+      const result = resolveColumns('["todo", "unknown", "active"]');
+      expect(result.map((c) => c.id)).toEqual(["todo", "active", "priority", "done"]);
+    });
+
+    it("deduplicates repeated IDs", () => {
+      const result = resolveColumns('["todo", "todo", "active"]');
+      expect(result.map((c) => c.id)).toEqual(["todo", "active", "priority", "done"]);
+    });
+
+    it("returns default columns for invalid JSON", () => {
+      expect(resolveColumns("not json")).toEqual(DEFAULT_COLUMNS);
+    });
+  });
+
+  describe("resolveCreationColumns", () => {
+    it("returns default creation columns for empty/undefined input", () => {
+      expect(resolveCreationColumns(undefined)).toEqual(DEFAULT_CREATION_COLUMNS);
+      expect(resolveCreationColumns("")).toEqual(DEFAULT_CREATION_COLUMNS);
+    });
+
+    it("creates creation columns from provided IDs", () => {
+      const result = resolveCreationColumns('["active", "priority"]');
+      expect(result).toEqual([
+        { id: "active", label: "Active", default: true },
+        { id: "priority", label: "Priority" },
+      ]);
+    });
+
+    it("marks the first column as default", () => {
+      const result = resolveCreationColumns('["todo", "active"]');
+      expect(result[0].default).toBe(true);
+      expect(result[1].default).toBeUndefined();
+    });
+
+    it("ignores unknown column IDs", () => {
+      const result = resolveCreationColumns('["unknown", "todo"]');
+      expect(result).toEqual([{ id: "todo", label: "To Do", default: true }]);
+    });
+
+    it("falls back to default when all IDs are invalid", () => {
+      expect(resolveCreationColumns('["x", "y"]')).toEqual(DEFAULT_CREATION_COLUMNS);
+    });
+
+    it("falls back to default for invalid JSON", () => {
+      expect(resolveCreationColumns("bad")).toEqual(DEFAULT_CREATION_COLUMNS);
+    });
+
+    it("uses a single column as both the only option and default", () => {
+      const result = resolveCreationColumns('["done"]');
+      expect(result).toEqual([{ id: "done", label: "Done", default: true }]);
+    });
+  });
+
+  describe("TASK_AGENT_CONFIG defaults", () => {
+    it("has columnOrder and creationColumnIds in defaultSettings", () => {
+      expect(TASK_AGENT_CONFIG.defaultSettings).toHaveProperty("columnOrder", "");
+      expect(TASK_AGENT_CONFIG.defaultSettings).toHaveProperty("creationColumnIds", "");
+    });
+
+    it("does not expose columnOrder or creationColumnIds in settingsSchema", () => {
+      const schemaKeys = TASK_AGENT_CONFIG.settingsSchema.map((f) => f.key);
+      expect(schemaKeys).not.toContain("columnOrder");
+      expect(schemaKeys).not.toContain("creationColumnIds");
+    });
+
+    it("default columns match KANBAN_COLUMNS order", () => {
+      expect(DEFAULT_COLUMNS.map((c) => c.id)).toEqual(["priority", "active", "todo", "done"]);
+    });
+  });
+});

--- a/src/adapters/task-agent/TaskAgentConfig.ts
+++ b/src/adapters/task-agent/TaskAgentConfig.ts
@@ -1,5 +1,6 @@
-import type { CardFlagRule, PluginConfig } from "../../core/interfaces";
+import type { CardFlagRule, CreationColumn, ListColumn, PluginConfig } from "../../core/interfaces";
 import { KANBAN_COLUMNS, COLUMN_LABELS, STATE_FOLDER_MAP } from "./types";
+import type { KanbanColumn } from "./types";
 
 /**
  * Default card flag rules for the task-agent adapter.
@@ -46,6 +47,22 @@ export const TASK_AGENT_CONFIG: PluginConfig = {
         frontmatter: "Frontmatter field",
         composite: "Composite (frontmatter + folder fallback)",
       },
+    },
+    {
+      key: "columnOrder",
+      name: "Column display order",
+      description:
+        "JSON array of column IDs defining the display order on the kanban board. Use the reorder controls below to change this, or edit the JSON directly. Default order: priority, active, todo, done.",
+      type: "text",
+      default: "",
+    },
+    {
+      key: "creationColumnIds",
+      name: "New task columns",
+      description:
+        "JSON array of column IDs that appear in the new task column selector, in order. First entry is the default. Empty uses the built-in default (todo, active).",
+      type: "text",
+      default: "",
     },
     {
       key: "jiraBaseUrl",
@@ -100,6 +117,8 @@ export const TASK_AGENT_CONFIG: PluginConfig = {
   defaultSettings: {
     taskBasePath: "2 - Areas/Tasks",
     stateStrategy: "folder",
+    columnOrder: "",
+    creationColumnIds: "",
     jiraBaseUrl: "",
     enrichmentEnabled: true,
     enrichmentPrompt: "",
@@ -112,3 +131,88 @@ export const TASK_AGENT_CONFIG: PluginConfig = {
   terminalStates: ["done", "abandoned"],
   cardFlags: DEFAULT_CARD_FLAGS,
 };
+
+/** The built-in default columns before any user customisation. */
+export const DEFAULT_COLUMNS: ListColumn[] = KANBAN_COLUMNS.map((col) => ({
+  id: col,
+  label: COLUMN_LABELS[col],
+  folderName: STATE_FOLDER_MAP[col],
+}));
+
+/** The built-in default creation columns before any user customisation. */
+export const DEFAULT_CREATION_COLUMNS: CreationColumn[] = [
+  { id: "todo", label: "To Do" },
+  { id: "active", label: "Active", default: true },
+];
+
+/**
+ * Parse a JSON string containing an array of column IDs.
+ * Returns an empty array on invalid/empty input.
+ */
+export function parseColumnOrderJson(json: string | undefined): string[] {
+  if (!json) return [];
+  try {
+    const parsed = JSON.parse(json);
+    if (Array.isArray(parsed) && parsed.every((item) => typeof item === "string")) {
+      return parsed;
+    }
+  } catch {
+    // Invalid JSON - fall back to empty
+  }
+  return [];
+}
+
+/**
+ * Resolve the effective column list from a custom order setting.
+ * Re-orders DEFAULT_COLUMNS to match the provided column IDs.
+ * Unknown IDs are ignored; columns missing from the order are appended.
+ */
+export function resolveColumns(columnOrderJson: string | undefined): ListColumn[] {
+  const order = parseColumnOrderJson(columnOrderJson);
+  if (order.length === 0) return DEFAULT_COLUMNS;
+
+  const columnById = new Map(DEFAULT_COLUMNS.map((col) => [col.id, col]));
+  const result: ListColumn[] = [];
+  const seen = new Set<string>();
+
+  for (const id of order) {
+    const col = columnById.get(id);
+    if (col && !seen.has(id)) {
+      result.push(col);
+      seen.add(id);
+    }
+  }
+
+  // Append any columns not mentioned in the custom order
+  for (const col of DEFAULT_COLUMNS) {
+    if (!seen.has(col.id)) {
+      result.push(col);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Resolve the effective creation columns from a custom setting.
+ * The first column in the list is marked as the default.
+ */
+export function resolveCreationColumns(
+  creationColumnIdsJson: string | undefined,
+): CreationColumn[] {
+  const ids = parseColumnOrderJson(creationColumnIdsJson);
+  if (ids.length === 0) return DEFAULT_CREATION_COLUMNS;
+
+  const labelById = new Map(DEFAULT_COLUMNS.map((col) => [col.id, col.label]));
+  const result: CreationColumn[] = [];
+
+  for (let i = 0; i < ids.length; i++) {
+    const id = ids[i];
+    const label = labelById.get(id);
+    if (label) {
+      result.push({ id, label, ...(i === 0 ? { default: true } : {}) });
+    }
+  }
+
+  return result.length > 0 ? result : DEFAULT_CREATION_COLUMNS;
+}

--- a/src/adapters/task-agent/TaskAgentConfig.ts
+++ b/src/adapters/task-agent/TaskAgentConfig.ts
@@ -49,22 +49,6 @@ export const TASK_AGENT_CONFIG: PluginConfig = {
       },
     },
     {
-      key: "columnOrder",
-      name: "Column display order",
-      description:
-        "JSON array of column IDs defining the display order on the kanban board. Use the reorder controls below to change this, or edit the JSON directly. Default order: priority, active, todo, done.",
-      type: "text",
-      default: "",
-    },
-    {
-      key: "creationColumnIds",
-      name: "New task columns",
-      description:
-        "JSON array of column IDs that appear in the new task column selector, in order. First entry is the default. Empty uses the built-in default (todo, active).",
-      type: "text",
-      default: "",
-    },
-    {
       key: "jiraBaseUrl",
       name: "Jira base URL",
       description:
@@ -206,11 +190,10 @@ export function resolveCreationColumns(
   const labelById = new Map(DEFAULT_COLUMNS.map((col) => [col.id, col.label]));
   const result: CreationColumn[] = [];
 
-  for (let i = 0; i < ids.length; i++) {
-    const id = ids[i];
+  for (const id of ids) {
     const label = labelById.get(id);
     if (label) {
-      result.push({ id, label, ...(i === 0 ? { default: true } : {}) });
+      result.push({ id, label, ...(result.length === 0 ? { default: true } : {}) });
     }
   }
 

--- a/src/adapters/task-agent/TaskAgentConfig.ts
+++ b/src/adapters/task-agent/TaskAgentConfig.ts
@@ -1,6 +1,5 @@
 import type { CardFlagRule, CreationColumn, ListColumn, PluginConfig } from "../../core/interfaces";
 import { KANBAN_COLUMNS, COLUMN_LABELS, STATE_FOLDER_MAP } from "./types";
-import type { KanbanColumn } from "./types";
 
 /**
  * Default card flag rules for the task-agent adapter.
@@ -189,11 +188,14 @@ export function resolveCreationColumns(
 
   const labelById = new Map(DEFAULT_COLUMNS.map((col) => [col.id, col.label]));
   const result: CreationColumn[] = [];
+  const seen = new Set<string>();
 
   for (const id of ids) {
+    if (seen.has(id)) continue;
     const label = labelById.get(id);
     if (label) {
       result.push({ id, label, ...(result.length === 0 ? { default: true } : {}) });
+      seen.add(id);
     }
   }
 

--- a/src/adapters/task-agent/index.ts
+++ b/src/adapters/task-agent/index.ts
@@ -10,7 +10,7 @@ import {
   type PluginConfig,
   type StateResolver,
 } from "../../core/interfaces";
-import { TASK_AGENT_CONFIG } from "./TaskAgentConfig";
+import { TASK_AGENT_CONFIG, resolveColumns, resolveCreationColumns } from "./TaskAgentConfig";
 import { TaskParser } from "./TaskParser";
 import { TaskMover } from "./TaskMover";
 import { TaskCard } from "./TaskCard";
@@ -58,6 +58,13 @@ export class TaskAgentAdapter extends BaseAdapter {
     const resolvedSettings = settings ?? {};
     this._app = app;
     this._settings = resolvedSettings;
+    // Apply column settings on first load
+    this.config.columns = resolveColumns(
+      resolvedSettings["adapter.columnOrder"] as string | undefined,
+    );
+    this.config.creationColumns = resolveCreationColumns(
+      resolvedSettings["adapter.creationColumnIds"] as string | undefined,
+    );
     const taskBasePath = (resolvedSettings["adapter.taskBasePath"] as string) || "2 - Areas/Tasks";
     const resolver = this.getStateResolver(taskBasePath, resolvedSettings);
     return new TaskParser(app, basePath, resolvedSettings, resolver);
@@ -80,8 +87,9 @@ export class TaskAgentAdapter extends BaseAdapter {
 
   /**
    * Called by the framework when settings change. Updates the card renderer's
-   * flag rules and invalidates the cached state resolver so it's recreated
-   * with the new strategy on next use.
+   * flag rules, invalidates the cached state resolver so it's recreated
+   * with the new strategy on next use, and applies column order/creation
+   * column overrides from user settings.
    */
   onSettingsChanged(settings: Record<string, unknown>): void {
     this._settings = settings;
@@ -90,6 +98,11 @@ export class TaskAgentAdapter extends BaseAdapter {
     if (this._cardRenderer) {
       this._cardRenderer.updateFlagRules(this.getMergedFlagRules());
     }
+    // Update column order and creation columns from settings
+    this.config.columns = resolveColumns(settings["adapter.columnOrder"] as string | undefined);
+    this.config.creationColumns = resolveCreationColumns(
+      settings["adapter.creationColumnIds"] as string | undefined,
+    );
   }
 
   /** Merge adapter-default card flags with user-defined custom flags from settings. */

--- a/src/framework/MainView.ts
+++ b/src/framework/MainView.ts
@@ -75,8 +75,10 @@ export class MainView extends ItemView {
   // Settings change handler - keeps this.settings in sync and notifies adapter
   private readonly _handleSettingsChanged = (event: Event) => {
     this.settings = { ...(event as CustomEvent<Record<string, any>>).detail };
-    // Notify adapter so it can update internal state (e.g. card flag rules)
+    // Notify adapter so it can update internal state (e.g. card flag rules, column order)
     this.adapter.onSettingsChanged?.(this.settings);
+    // Update PromptBox creation columns if the adapter modified them
+    this.promptBox?.updateCreationColumns();
     this.scheduleRefresh();
   };
 

--- a/src/framework/MainView.ts
+++ b/src/framework/MainView.ts
@@ -74,11 +74,15 @@ export class MainView extends ItemView {
 
   // Settings change handler - keeps this.settings in sync and notifies adapter
   private readonly _handleSettingsChanged = (event: Event) => {
+    const prevCreationColumnIds = this.adapter.config.creationColumns;
     this.settings = { ...(event as CustomEvent<Record<string, any>>).detail };
     // Notify adapter so it can update internal state (e.g. card flag rules, column order)
     this.adapter.onSettingsChanged?.(this.settings);
-    // Update PromptBox creation columns if the adapter modified them
-    this.promptBox?.updateCreationColumns();
+    // Only rebuild PromptBox creation columns when they actually changed
+    const newCreationColumnIds = this.adapter.config.creationColumns;
+    if (prevCreationColumnIds !== newCreationColumnIds) {
+      this.promptBox?.updateCreationColumns();
+    }
     this.scheduleRefresh();
   };
 

--- a/src/framework/PromptBox.test.ts
+++ b/src/framework/PromptBox.test.ts
@@ -320,46 +320,28 @@ describe("PromptBox", () => {
   });
 
   it("updateCreationColumns rebuilds the select options from adapter config", () => {
+    const parentEl = document.createElement("div");
+    document.body.appendChild(parentEl);
     const adapter = makeAdapter();
-    const { parentEl } = createPromptBox({ adapter });
+    const pb = new PromptBox(parentEl, adapter, makePlugin(), {}, vi.fn(), vi.fn(), vi.fn());
 
     const selectEl = parentEl.querySelector(".wt-prompt-column-select") as HTMLSelectElement;
     expect(selectEl.options.length).toBe(2);
-    expect(selectEl.options[0].value).toBe("todo");
-    expect(selectEl.options[1].value).toBe("doing");
-
-    // Simulate settings change that modifies adapter config
-    adapter.config.creationColumns = [
-      { id: "active", label: "Active", default: true },
-      { id: "priority", label: "Priority" },
-      { id: "done", label: "Done" },
-    ];
-
-    // Get the PromptBox instance to call updateCreationColumns
-    // Since createPromptBox doesn't return the PromptBox, we need a different approach
-    // Let's create one manually
-    const parentEl2 = document.createElement("div");
-    document.body.appendChild(parentEl2);
-    const adapter2 = makeAdapter();
-    const pb = new PromptBox(parentEl2, adapter2, makePlugin(), {}, vi.fn(), vi.fn(), vi.fn());
-
-    const selectEl2 = parentEl2.querySelector(".wt-prompt-column-select") as HTMLSelectElement;
-    expect(selectEl2.options.length).toBe(2);
 
     // Modify adapter config and call update
-    adapter2.config.creationColumns = [
+    adapter.config.creationColumns = [
       { id: "priority", label: "Priority", default: true },
       { id: "done", label: "Done" },
       { id: "active", label: "Active" },
     ];
     pb.updateCreationColumns();
 
-    expect(selectEl2.options.length).toBe(3);
-    expect(selectEl2.options[0].value).toBe("priority");
-    expect(selectEl2.options[0].textContent).toBe("Priority");
-    expect(selectEl2.options[0].selected).toBe(true);
-    expect(selectEl2.options[1].value).toBe("done");
-    expect(selectEl2.options[2].value).toBe("active");
+    expect(selectEl.options.length).toBe(3);
+    expect(selectEl.options[0].value).toBe("priority");
+    expect(selectEl.options[0].textContent).toBe("Priority");
+    expect(selectEl.options[0].selected).toBe(true);
+    expect(selectEl.options[1].value).toBe("done");
+    expect(selectEl.options[2].value).toBe("active");
   });
 
   it("ignores blank titles and resolves failures as unsuccessful placeholders", async () => {

--- a/src/framework/PromptBox.test.ts
+++ b/src/framework/PromptBox.test.ts
@@ -319,6 +319,49 @@ describe("PromptBox", () => {
     expect(parentKeydown).not.toHaveBeenCalled();
   });
 
+  it("updateCreationColumns rebuilds the select options from adapter config", () => {
+    const adapter = makeAdapter();
+    const { parentEl } = createPromptBox({ adapter });
+
+    const selectEl = parentEl.querySelector(".wt-prompt-column-select") as HTMLSelectElement;
+    expect(selectEl.options.length).toBe(2);
+    expect(selectEl.options[0].value).toBe("todo");
+    expect(selectEl.options[1].value).toBe("doing");
+
+    // Simulate settings change that modifies adapter config
+    adapter.config.creationColumns = [
+      { id: "active", label: "Active", default: true },
+      { id: "priority", label: "Priority" },
+      { id: "done", label: "Done" },
+    ];
+
+    // Get the PromptBox instance to call updateCreationColumns
+    // Since createPromptBox doesn't return the PromptBox, we need a different approach
+    // Let's create one manually
+    const parentEl2 = document.createElement("div");
+    document.body.appendChild(parentEl2);
+    const adapter2 = makeAdapter();
+    const pb = new PromptBox(parentEl2, adapter2, makePlugin(), {}, vi.fn(), vi.fn(), vi.fn());
+
+    const selectEl2 = parentEl2.querySelector(".wt-prompt-column-select") as HTMLSelectElement;
+    expect(selectEl2.options.length).toBe(2);
+
+    // Modify adapter config and call update
+    adapter2.config.creationColumns = [
+      { id: "priority", label: "Priority", default: true },
+      { id: "done", label: "Done" },
+      { id: "active", label: "Active" },
+    ];
+    pb.updateCreationColumns();
+
+    expect(selectEl2.options.length).toBe(3);
+    expect(selectEl2.options[0].value).toBe("priority");
+    expect(selectEl2.options[0].textContent).toBe("Priority");
+    expect(selectEl2.options[0].selected).toBe(true);
+    expect(selectEl2.options[1].value).toBe("done");
+    expect(selectEl2.options[2].value).toBe("active");
+  });
+
   it("ignores blank titles and resolves failures as unsuccessful placeholders", async () => {
     vi.spyOn(Date, "now").mockReturnValue(555);
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/src/framework/PromptBox.ts
+++ b/src/framework/PromptBox.ts
@@ -110,18 +110,26 @@ export class PromptBox {
    * Called when settings change and adapter.config.creationColumns is modified.
    */
   updateCreationColumns(): void {
+    // Capture current selection so we can restore it after rebuild
+    const previousValue = this.columnSelect.value;
+
     // Clear existing options
     while (this.columnSelect.firstChild) {
       this.columnSelect.removeChild(this.columnSelect.firstChild);
     }
     // Rebuild from current adapter config
-    for (const col of this.adapter.config.creationColumns) {
-      const opt = this.columnSelect.createEl("option", {
+    const columns = this.adapter.config.creationColumns;
+    const defaultId = columns.find((c) => c.default)?.id;
+    for (const col of columns) {
+      this.columnSelect.createEl("option", {
         text: col.label,
         value: col.id,
       });
-      if (col.default) opt.selected = true;
     }
+
+    // Restore previous selection if still present, otherwise fall back to default
+    const stillExists = columns.some((c) => c.id === previousValue);
+    this.columnSelect.value = stillExists ? previousValue : (defaultId ?? columns[0]?.id ?? "");
   }
 
   private async submit(): Promise<void> {

--- a/src/framework/PromptBox.ts
+++ b/src/framework/PromptBox.ts
@@ -105,6 +105,25 @@ export class PromptBox {
     sendBtn.addEventListener("click", () => this.submit());
   }
 
+  /**
+   * Rebuild the column selector dropdown to reflect updated creation columns.
+   * Called when settings change and adapter.config.creationColumns is modified.
+   */
+  updateCreationColumns(): void {
+    // Clear existing options
+    while (this.columnSelect.firstChild) {
+      this.columnSelect.removeChild(this.columnSelect.firstChild);
+    }
+    // Rebuild from current adapter config
+    for (const col of this.adapter.config.creationColumns) {
+      const opt = this.columnSelect.createEl("option", {
+        text: col.label,
+        value: col.id,
+      });
+      if (col.default) opt.selected = true;
+    }
+  }
+
   private async submit(): Promise<void> {
     const title = this.inputEl.value.trim();
     if (!title) return;

--- a/src/framework/SettingsTab.test.ts
+++ b/src/framework/SettingsTab.test.ts
@@ -233,8 +233,11 @@ function makePlugin(initialSettings: Record<string, unknown>): MockPlugin {
 
 const adapter = {
   config: {
+    columns: [],
+    creationColumns: [],
     settingsSchema: [],
     defaultSettings: {},
+    itemName: "task",
   },
 } as any;
 

--- a/src/framework/SettingsTab.test.ts
+++ b/src/framework/SettingsTab.test.ts
@@ -321,6 +321,68 @@ describe("WorkTerminalSettingsTab", () => {
     expect(tab.containerEl.querySelector('[data-setting-key="core.defaultShell"]')).not.toBeNull();
   });
 
+  it("renders column order controls when adapter has columns", async () => {
+    const adapterWithColumns = {
+      config: {
+        columns: [
+          { id: "priority", label: "Priority", folderName: "priority" },
+          { id: "active", label: "Active", folderName: "active" },
+          { id: "todo", label: "To Do", folderName: "todo" },
+          { id: "done", label: "Done", folderName: "archive" },
+        ],
+        creationColumns: [
+          { id: "todo", label: "To Do" },
+          { id: "active", label: "Active", default: true },
+        ],
+        settingsSchema: [],
+        defaultSettings: {},
+        itemName: "task",
+      },
+    } as any;
+
+    const plugin = makePlugin({});
+    const tab = new WorkTerminalSettingsTab(
+      {} as any,
+      plugin as any,
+      adapterWithColumns,
+      mockProfileManager,
+    );
+
+    tab.display();
+    await flushAsyncWork();
+
+    // Should render the "Column Order & Creation" heading
+    const headings = Array.from(tab.containerEl.querySelectorAll("h2"));
+    const columnHeading = headings.find((h) => h.textContent === "Column Order & Creation");
+    expect(columnHeading).toBeDefined();
+
+    // Should render column order rows
+    const orderRows = tab.containerEl.querySelectorAll(".wt-column-order-row");
+    expect(orderRows.length).toBe(4);
+
+    // Should render creation column rows
+    const creationRows = tab.containerEl.querySelectorAll(".wt-creation-column-row");
+    expect(creationRows.length).toBeGreaterThan(0);
+
+    // Column labels should appear
+    expect(tab.containerEl.textContent).toContain("Priority");
+    expect(tab.containerEl.textContent).toContain("Active");
+    expect(tab.containerEl.textContent).toContain("To Do");
+    expect(tab.containerEl.textContent).toContain("Done");
+  });
+
+  it("does not render column controls when adapter has no columns", async () => {
+    const plugin = makePlugin({});
+    const tab = new WorkTerminalSettingsTab({} as any, plugin as any, adapter, mockProfileManager);
+
+    tab.display();
+    await flushAsyncWork();
+
+    const headings = Array.from(tab.containerEl.querySelectorAll("h2"));
+    const columnHeading = headings.find((h) => h.textContent === "Column Order & Creation");
+    expect(columnHeading).toBeUndefined();
+  });
+
   it("renders a reset guided tour button that calls resetGuidedTourStatus and shows a Notice", async () => {
     const plugin = makePlugin({});
     const tab = new WorkTerminalSettingsTab({} as any, plugin as any, adapter, mockProfileManager);

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -169,6 +169,13 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
       }
     }
 
+    // Column management section (shown when the adapter has columns)
+    if (this.adapter.config.columns.length > 0) {
+      containerEl.createEl("h2", { text: "Column Order & Creation" });
+      this.renderColumnOrderControls(containerEl);
+      this.renderCreationColumnControls(containerEl);
+    }
+
     // Card flag rules section (shown when the adapter provides cardFlags)
     if (this.adapter.config.cardFlags !== undefined) {
       containerEl.createEl("h2", { text: "Card Indicators" });
@@ -351,6 +358,199 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
             ).open();
           }),
       );
+  }
+
+  /**
+   * Render column display order controls: a list of columns with up/down
+   * buttons and a reset-to-default action.
+   */
+  private async renderColumnOrderControls(containerEl: HTMLElement): Promise<void> {
+    const data = (await this.plugin.loadData()) || {};
+    const settings = data.settings || {};
+    const orderJson = (settings["adapter.columnOrder"] as string) || "";
+
+    // Resolve effective column order (current config reflects it)
+    const columns = this.adapter.config.columns;
+
+    const desc = new Setting(containerEl)
+      .setName("Column display order")
+      .setDesc(
+        "Drag or use arrow buttons to reorder kanban board columns. Changes take effect immediately.",
+      );
+
+    // Reset button
+    desc.addButton((btn) =>
+      btn.setButtonText("Reset to default").onClick(async () => {
+        await this.saveSettings((settings) => {
+          settings["adapter.columnOrder"] = "";
+        });
+        this.display();
+      }),
+    );
+
+    const listEl = containerEl.createDiv({ cls: "wt-column-order-list" });
+
+    for (let i = 0; i < columns.length; i++) {
+      const col = columns[i];
+      const rowEl = listEl.createDiv({ cls: "wt-column-order-row" });
+
+      // Column label
+      rowEl.createSpan({ text: col.label, cls: "wt-column-order-label" });
+
+      // Up button
+      const upBtn = rowEl.createEl("button", {
+        text: "\u2191",
+        cls: "wt-column-order-btn",
+        attr: { "aria-label": `Move ${col.label} up` },
+      });
+      if (i === 0) upBtn.setAttribute("disabled", "true");
+      upBtn.addEventListener("click", async () => {
+        if (i === 0) return;
+        const ids = columns.map((c) => c.id);
+        [ids[i - 1], ids[i]] = [ids[i], ids[i - 1]];
+        await this.saveSettings((settings) => {
+          settings["adapter.columnOrder"] = JSON.stringify(ids);
+        });
+        this.display();
+      });
+
+      // Down button
+      const downBtn = rowEl.createEl("button", {
+        text: "\u2193",
+        cls: "wt-column-order-btn",
+        attr: { "aria-label": `Move ${col.label} down` },
+      });
+      if (i === columns.length - 1) downBtn.setAttribute("disabled", "true");
+      downBtn.addEventListener("click", async () => {
+        if (i === columns.length - 1) return;
+        const ids = columns.map((c) => c.id);
+        [ids[i], ids[i + 1]] = [ids[i + 1], ids[i]];
+        await this.saveSettings((settings) => {
+          settings["adapter.columnOrder"] = JSON.stringify(ids);
+        });
+        this.display();
+      });
+    }
+  }
+
+  /**
+   * Render creation column selection: checkboxes for each column, with
+   * the ability to toggle which columns appear in the new item prompt
+   * and reorder them.
+   */
+  private async renderCreationColumnControls(containerEl: HTMLElement): Promise<void> {
+    const data = (await this.plugin.loadData()) || {};
+    const settings = data.settings || {};
+
+    // All available columns from the adapter
+    const allColumns = this.adapter.config.columns;
+    // Current creation columns
+    const creationColumns = this.adapter.config.creationColumns;
+    const creationIds = new Set(creationColumns.map((c) => c.id));
+    const defaultId = creationColumns.find((c) => c.default)?.id || creationColumns[0]?.id;
+
+    const desc = new Setting(containerEl)
+      .setName("New item column selector")
+      .setDesc(
+        `Choose which columns appear in the "${this.adapter.config.itemName}" creation prompt. The first checked column is the default. Uncheck to hide a column from the creation dropdown.`,
+      );
+
+    desc.addButton((btn) =>
+      btn.setButtonText("Reset to default").onClick(async () => {
+        await this.saveSettings((settings) => {
+          settings["adapter.creationColumnIds"] = "";
+        });
+        this.display();
+      }),
+    );
+
+    const listEl = containerEl.createDiv({ cls: "wt-creation-column-list" });
+
+    // Show creation columns first (in order), then unchecked columns
+    const orderedColumns = [
+      ...creationColumns.map((cc) => allColumns.find((ac) => ac.id === cc.id)!).filter(Boolean),
+      ...allColumns.filter((ac) => !creationIds.has(ac.id)),
+    ];
+
+    for (let i = 0; i < orderedColumns.length; i++) {
+      const col = orderedColumns[i];
+      const isChecked = creationIds.has(col.id);
+      const isDefault = col.id === defaultId;
+
+      const rowEl = listEl.createDiv({ cls: "wt-creation-column-row" });
+
+      // Checkbox
+      const checkbox = rowEl.createEl("input", {
+        attr: {
+          type: "checkbox",
+          ...(isChecked ? { checked: "" } : {}),
+        },
+      });
+      checkbox.checked = isChecked;
+
+      // Label with default indicator
+      const labelText = isDefault ? `${col.label} (default)` : col.label;
+      rowEl.createSpan({ text: labelText, cls: "wt-creation-column-label" });
+
+      // Up button (only for checked items)
+      if (isChecked) {
+        const creationIdx = creationColumns.findIndex((c) => c.id === col.id);
+        const upBtn = rowEl.createEl("button", {
+          text: "\u2191",
+          cls: "wt-column-order-btn",
+          attr: { "aria-label": `Move ${col.label} up` },
+        });
+        if (creationIdx === 0) upBtn.setAttribute("disabled", "true");
+        upBtn.addEventListener("click", async () => {
+          if (creationIdx === 0) return;
+          const ids = creationColumns.map((c) => c.id);
+          [ids[creationIdx - 1], ids[creationIdx]] = [ids[creationIdx], ids[creationIdx - 1]];
+          await this.saveSettings((settings) => {
+            settings["adapter.creationColumnIds"] = JSON.stringify(ids);
+          });
+          this.display();
+        });
+
+        const downBtn = rowEl.createEl("button", {
+          text: "\u2193",
+          cls: "wt-column-order-btn",
+          attr: { "aria-label": `Move ${col.label} down` },
+        });
+        if (creationIdx === creationColumns.length - 1) downBtn.setAttribute("disabled", "true");
+        downBtn.addEventListener("click", async () => {
+          if (creationIdx === creationColumns.length - 1) return;
+          const ids = creationColumns.map((c) => c.id);
+          [ids[creationIdx], ids[creationIdx + 1]] = [ids[creationIdx + 1], ids[creationIdx]];
+          await this.saveSettings((settings) => {
+            settings["adapter.creationColumnIds"] = JSON.stringify(ids);
+          });
+          this.display();
+        });
+      }
+
+      // Toggle checkbox handler
+      checkbox.addEventListener("change", async () => {
+        const currentIds = creationColumns.map((c) => c.id);
+        if (checkbox.checked) {
+          // Add this column at the end
+          currentIds.push(col.id);
+        } else {
+          // Remove this column (must keep at least one)
+          const idx = currentIds.indexOf(col.id);
+          if (idx >= 0 && currentIds.length > 1) {
+            currentIds.splice(idx, 1);
+          } else if (currentIds.length <= 1) {
+            checkbox.checked = true; // Prevent unchecking the last one
+            new Notice("At least one creation column must remain selected");
+            return;
+          }
+        }
+        await this.saveSettings((settings) => {
+          settings["adapter.creationColumnIds"] = JSON.stringify(currentIds);
+        });
+        this.display();
+      });
+    }
   }
 
   private async addAdapterSetting(containerEl: HTMLElement, field: SettingField): Promise<void> {

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -188,11 +188,11 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
       if (!data.settings) data.settings = {};
       update(data.settings);
     });
-    window.dispatchEvent(
-      new CustomEvent(SETTINGS_CHANGED_EVENT, {
-        detail: await loadAllSettings(this.plugin, this.adapter),
-      }),
-    );
+    const allSettings = await loadAllSettings(this.plugin, this.adapter);
+    // Update adapter config directly so settings UI stays current even when
+    // the Work Terminal view is not open (and thus no MainView listener exists).
+    this.adapter.onSettingsChanged?.(allSettings);
+    window.dispatchEvent(new CustomEvent(SETTINGS_CHANGED_EVENT, { detail: allSettings }));
   }
 
   private async renderHookStatus(containerEl: HTMLElement): Promise<void> {
@@ -434,10 +434,7 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
    * the ability to toggle which columns appear in the new item prompt
    * and reorder them.
    */
-  private async renderCreationColumnControls(containerEl: HTMLElement): Promise<void> {
-    const data = (await this.plugin.loadData()) || {};
-    const settings = data.settings || {};
-
+  private renderCreationColumnControls(containerEl: HTMLElement): void {
     // All available columns from the adapter
     const allColumns = this.adapter.config.columns;
     // Current creation columns

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -365,17 +365,13 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
    * buttons and a reset-to-default action.
    */
   private async renderColumnOrderControls(containerEl: HTMLElement): Promise<void> {
-    const data = (await this.plugin.loadData()) || {};
-    const settings = data.settings || {};
-    const orderJson = (settings["adapter.columnOrder"] as string) || "";
-
     // Resolve effective column order (current config reflects it)
     const columns = this.adapter.config.columns;
 
     const desc = new Setting(containerEl)
       .setName("Column display order")
       .setDesc(
-        "Drag or use arrow buttons to reorder kanban board columns. Changes take effect immediately.",
+        "Use arrow buttons to reorder kanban board columns. Changes take effect immediately.",
       );
 
     // Reset button

--- a/styles.css
+++ b/styles.css
@@ -1978,3 +1978,60 @@ button.wt-spawn-claude-ctx:hover svg {
   justify-content: flex-end;
   margin-top: 16px;
 }
+
+/* =============================================================================
+   Column Order & Creation Settings
+   ============================================================================= */
+
+.wt-column-order-list,
+.wt-creation-column-list {
+  margin: 8px 0 16px;
+}
+
+.wt-column-order-row,
+.wt-creation-column-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: var(--radius-s);
+  background: var(--background-secondary);
+  margin-bottom: 4px;
+}
+
+.wt-column-order-row:hover,
+.wt-creation-column-row:hover {
+  background: var(--background-secondary-alt);
+}
+
+.wt-column-order-label,
+.wt-creation-column-label {
+  flex: 1;
+  font-size: var(--font-ui-small);
+}
+
+.wt-column-order-btn {
+  padding: 2px 8px;
+  font-size: var(--font-ui-smaller);
+  cursor: pointer;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-s);
+  background: var(--background-primary);
+  color: var(--text-normal);
+  min-width: 28px;
+  text-align: center;
+}
+
+.wt-column-order-btn:hover:not([disabled]) {
+  background: var(--background-modifier-hover);
+}
+
+.wt-column-order-btn[disabled] {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.wt-creation-column-row input[type="checkbox"] {
+  margin: 0;
+  flex-shrink: 0;
+}


### PR DESCRIPTION
## Summary

- Add settings UI for column display order (up/down reorder controls with reset to default)
- Add creation column selection (checkboxes to choose which columns appear in new task prompt, with reorder and default indicator)
- Wire settings changes to PromptBox at runtime so creation columns update without reload
- Column order and creation column overrides persist as JSON in adapter settings and apply on both initial load and settings change

Fixes #393

## Implementation details

**New settings infrastructure** (`TaskAgentConfig.ts`):
- `resolveColumns()` / `resolveCreationColumns()` / `parseColumnOrderJson()` helper functions
- `DEFAULT_COLUMNS` / `DEFAULT_CREATION_COLUMNS` exported constants
- Settings stored as `adapter.columnOrder` and `adapter.creationColumnIds` (JSON arrays)

**Settings UI** (`SettingsTab.ts`):
- "Column Order & Creation" section with column reorder rows and creation column checkboxes
- Up/down arrow buttons with disabled state at boundaries
- Reset to default button for both sections
- At least one creation column must remain selected

**Runtime wiring**:
- Adapter `onSettingsChanged` updates `config.columns` and `config.creationColumns`
- `createParser` applies column settings on initial load
- MainView calls `PromptBox.updateCreationColumns()` after settings change
- ListPanel reads `adapter.config.columns` on each render (already dynamic)

**Existing state strategy dropdown** from PR #392 was already in the adapter settings schema - it renders automatically and is now grouped naturally with the column management controls.

## Test plan

- [x] `parseColumnOrderJson` handles empty, invalid, non-array, mixed-type inputs
- [x] `resolveColumns` reorders, appends missing, deduplicates, ignores unknown IDs
- [x] `resolveCreationColumns` maps IDs to columns, marks first valid as default, falls back
- [x] `PromptBox.updateCreationColumns` rebuilds dropdown from modified adapter config
- [x] SettingsTab renders column controls when adapter has columns, skips when empty
- [x] All 1144 tests pass, build succeeds
- [ ] Manual: open settings, reorder columns, verify kanban board reflects new order
- [ ] Manual: toggle creation columns, verify new task prompt shows correct options
- [ ] Manual: change state strategy dropdown, verify task state resolution changes

Generated with [Claude Code](https://claude.com/claude-code)