### PR TITLE
feat: dynamic columns for open state set

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -284,7 +284,7 @@ When using the **Frontmatter** or **Composite** state strategy, you can set the 
 Dynamic columns:
 
 - **Appear automatically** when any task has a state not in the predefined column list
-- **Are appended after** the configured columns (Priority, Active, To Do, Done)
+- **Initially appear after** the configured columns (Priority, Active, To Do, Done) until you reorder them
 - **Can be reordered** using the column display order controls in settings, just like built-in columns. Once reordered, the dynamic column's position is persisted.
 - **Are shown with a star** (\*) in the settings column ordering UI to distinguish them from built-in columns
 - **Do not have folder mappings** - dragging a task into a dynamic column updates its frontmatter `state` field but does not move the file to a different folder

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -25,6 +25,7 @@ Work Terminal turns your Obsidian vault into a work item board with per-item tab
   - [Agent profiles](#agent-profiles)
   - [Card indicator rules](#card-indicator-rules)
   - [State resolution strategies](#state-resolution-strategies)
+  - [Dynamic columns](#dynamic-columns)
   - [Background enrichment](#background-enrichment)
   - [Claude /resume hooks](#claude-resume-hooks)
   - [Core settings](#core-settings)
@@ -81,6 +82,8 @@ The board organises tasks into collapsible columns. The default adapter provides
 
 Each column header shows the column name and the count of tasks it contains. Click a column header to collapse or expand that section.
 
+When using the Frontmatter or Composite state strategy, additional **dynamic columns** may appear after the four built-in columns if any tasks have custom state values in their frontmatter. See [Dynamic columns](#dynamic-columns) for details.
+
 Tasks appear as cards within their column. The order within a column can be customised using drag-drop (see [Drag-drop reordering](#drag-drop-reordering)) or the "Move to Top" context menu action.
 
 ### Task card anatomy
@@ -115,7 +118,7 @@ Right-click any task card to open the context menu with these options:
 - **Move to Top** - moves the card to the top of its current column
 - **Retry Enrichment** - re-runs background enrichment (shown only when enrichment previously failed)
 - **Split Task** - creates a new task linked to this one and opens a Claude session to scope it
-- **Move to [column]** - moves the task to a different column (Priority, Active, To Do, or Done)
+- **Move to [column]** - moves the task to a different column (Priority, Active, To Do, Done, or any dynamic columns)
 - **Done & Close Sessions** - moves to Done and closes all terminal sessions for this task
 - **Copy Name** - copies the task title to clipboard
 - **Copy Path** - copies the vault file path to clipboard
@@ -142,7 +145,7 @@ Because the detail panel is a standard Obsidian markdown view, all Obsidian feat
 
 Tasks within a column can be reordered by dragging. Grab a card and drag it to a new position within the same column. The custom sort order is persisted and survives plugin reloads.
 
-You can also drag a task between columns to change its state. Dropping a task from "To Do" into "Active" will move the underlying file to the `active/` folder and update the frontmatter accordingly.
+You can also drag a task between columns to change its state. Dropping a task from "To Do" into "Active" will move the underlying file to the `active/` folder and update the frontmatter accordingly. Dropping a task into a dynamic column (one without a folder mapping) updates the frontmatter `state` field but leaves the file in its current folder.
 
 ### Filtering
 
@@ -268,11 +271,26 @@ The adapter determines task state (which column a task appears in) using one of 
 
 | Strategy | Description |
 |----------|-------------|
-| **Folder** (default) | State is derived from which folder the task file lives in. Moving a file to `active/` makes it an active task. |
-| **Frontmatter** | State is read from the `state` frontmatter field. Falls back to folder location if the field is missing. |
-| **Composite** | Checks frontmatter first, falls back to folder. On state transitions, both frontmatter and folder are updated. |
+| **Folder** (default) | State is derived from which folder the task file lives in. Moving a file to `active/` makes it an active task. Only the predefined states (priority, active, todo, done, abandoned) are supported. |
+| **Frontmatter** | State is read from the `state` frontmatter field. Any string value is valid - custom states create dynamic columns. Falls back to folder location if the field is missing. |
+| **Composite** | Checks frontmatter first, falls back to folder. Any frontmatter value is valid. On state transitions, both frontmatter and folder are updated for known states; dynamic states update frontmatter only. |
 
-For most users, the default folder strategy works well. Use frontmatter or composite if you need tasks to retain their state independently of folder structure.
+For most users, the default folder strategy works well. Use frontmatter or composite if you need tasks to retain their state independently of folder structure, or if you want to use custom states.
+
+### Dynamic columns
+
+When using the **Frontmatter** or **Composite** state strategy, you can set the `state` frontmatter field to any value - not just the predefined columns. For example, setting `state: review` or `state: blocked-upstream` in a task's frontmatter will create a new column on the kanban board for that state.
+
+Dynamic columns:
+
+- **Appear automatically** when any task has a state not in the predefined column list
+- **Are appended after** the configured columns (Priority, Active, To Do, Done)
+- **Can be reordered** using the column display order controls in settings, just like built-in columns. Once reordered, the dynamic column's position is persisted.
+- **Are shown with a star** (\*) in the settings column ordering UI to distinguish them from built-in columns
+- **Do not have folder mappings** - dragging a task into a dynamic column updates its frontmatter `state` field but does not move the file to a different folder
+- **Disappear** when no tasks have that state (they are not shown as empty columns)
+
+This is useful for workflows that need temporary or project-specific states like "review", "waiting", "testing", or any other status that makes sense for your work.
 
 ### Background enrichment
 
@@ -387,7 +405,7 @@ id: <uuid>                    # Unique identifier (survives renames)
 tags:
   - task
   - task/<state>              # State tag for Obsidian queries
-state: <state>                # priority | active | todo | done | abandoned
+state: <state>                # priority | active | todo | done | abandoned | <any custom value>
 title: "<title>"              # Task display name
 source:
   type: prompt|slack|jira|confluence|other # Where the task originated

--- a/src/adapters/task-agent/TaskAgentConfig.test.ts
+++ b/src/adapters/task-agent/TaskAgentConfig.test.ts
@@ -66,9 +66,13 @@ describe("TaskAgentConfig column helpers", () => {
       expect(result.map((c) => c.id)).toEqual(["todo", "active", "priority", "done"]);
     });
 
-    it("ignores unknown column IDs", () => {
-      const result = resolveColumns('["todo", "unknown", "active"]');
-      expect(result.map((c) => c.id)).toEqual(["todo", "active", "priority", "done"]);
+    it("preserves unknown column IDs as dynamic columns", () => {
+      const result = resolveColumns('["todo", "amazing", "active"]');
+      expect(result.map((c) => c.id)).toEqual(["todo", "amazing", "active", "priority", "done"]);
+      // Dynamic column has titlecased label and no folderName
+      const dynamicCol = result.find((c) => c.id === "amazing");
+      expect(dynamicCol?.label).toBe("Amazing");
+      expect(dynamicCol?.folderName).toBeUndefined();
     });
 
     it("deduplicates repeated IDs", () => {
@@ -101,13 +105,20 @@ describe("TaskAgentConfig column helpers", () => {
       expect(result[1].default).toBeUndefined();
     });
 
-    it("ignores unknown column IDs", () => {
-      const result = resolveCreationColumns('["unknown", "todo"]');
-      expect(result).toEqual([{ id: "todo", label: "To Do", default: true }]);
+    it("accepts unknown column IDs as dynamic creation columns", () => {
+      const result = resolveCreationColumns('["amazing", "todo"]');
+      expect(result).toEqual([
+        { id: "amazing", label: "Amazing", default: true },
+        { id: "todo", label: "To Do" },
+      ]);
     });
 
-    it("falls back to default when all IDs are invalid", () => {
-      expect(resolveCreationColumns('["x", "y"]')).toEqual(DEFAULT_CREATION_COLUMNS);
+    it("uses dynamic columns when all IDs are custom", () => {
+      const result = resolveCreationColumns('["x", "y"]');
+      expect(result).toEqual([
+        { id: "x", label: "X", default: true },
+        { id: "y", label: "Y" },
+      ]);
     });
 
     it("falls back to default for invalid JSON", () => {

--- a/src/adapters/task-agent/TaskAgentConfig.test.ts
+++ b/src/adapters/task-agent/TaskAgentConfig.test.ts
@@ -3,6 +3,7 @@ import {
   parseColumnOrderJson,
   resolveColumns,
   resolveCreationColumns,
+  makeDynamicColumn,
   DEFAULT_COLUMNS,
   DEFAULT_CREATION_COLUMNS,
   TASK_AGENT_CONFIG,
@@ -136,6 +137,51 @@ describe("TaskAgentConfig column helpers", () => {
         { id: "todo", label: "To Do", default: true },
         { id: "active", label: "Active" },
       ]);
+    });
+  });
+
+  describe("makeDynamicColumn", () => {
+    it("creates a column with titlecased label", () => {
+      const col = makeDynamicColumn("review");
+      expect(col).toEqual({ id: "review", label: "Review" });
+    });
+
+    it("has no folderName", () => {
+      const col = makeDynamicColumn("testing");
+      expect(col.folderName).toBeUndefined();
+    });
+
+    it("handles hyphenated IDs", () => {
+      const col = makeDynamicColumn("blocked-upstream");
+      expect(col.label).toBe("Blocked-upstream");
+    });
+
+    it("handles single character IDs", () => {
+      const col = makeDynamicColumn("x");
+      expect(col.label).toBe("X");
+    });
+  });
+
+  describe("resolveColumns with dynamic columns", () => {
+    it("interleaves dynamic and default columns based on order", () => {
+      const result = resolveColumns('["priority", "review", "active", "testing", "todo", "done"]');
+      expect(result.map((c) => c.id)).toEqual([
+        "priority",
+        "review",
+        "active",
+        "testing",
+        "todo",
+        "done",
+      ]);
+      // Default columns retain their metadata
+      expect(result.find((c) => c.id === "priority")?.folderName).toBe("priority");
+      // Dynamic columns have no folderName
+      expect(result.find((c) => c.id === "review")?.folderName).toBeUndefined();
+    });
+
+    it("appends default columns missing from order that includes dynamic columns", () => {
+      const result = resolveColumns('["review", "active"]');
+      expect(result.map((c) => c.id)).toEqual(["review", "active", "priority", "todo", "done"]);
     });
   });
 

--- a/src/adapters/task-agent/TaskAgentConfig.test.ts
+++ b/src/adapters/task-agent/TaskAgentConfig.test.ts
@@ -141,7 +141,7 @@ describe("TaskAgentConfig column helpers", () => {
   });
 
   describe("makeDynamicColumn", () => {
-    it("creates a column with titlecased label", () => {
+    it("creates a column with title-cased label", () => {
       const col = makeDynamicColumn("review");
       expect(col).toEqual({ id: "review", label: "Review" });
     });
@@ -151,9 +151,14 @@ describe("TaskAgentConfig column helpers", () => {
       expect(col.folderName).toBeUndefined();
     });
 
-    it("handles hyphenated IDs", () => {
+    it("title-cases hyphenated IDs", () => {
       const col = makeDynamicColumn("blocked-upstream");
-      expect(col.label).toBe("Blocked-upstream");
+      expect(col.label).toBe("Blocked Upstream");
+    });
+
+    it("title-cases underscored IDs", () => {
+      const col = makeDynamicColumn("my_custom_state");
+      expect(col.label).toBe("My Custom State");
     });
 
     it("handles single character IDs", () => {

--- a/src/adapters/task-agent/TaskAgentConfig.ts
+++ b/src/adapters/task-agent/TaskAgentConfig.ts
@@ -1,4 +1,5 @@
 import type { CardFlagRule, CreationColumn, ListColumn, PluginConfig } from "../../core/interfaces";
+import { titleCase } from "../../core/utils";
 import { KANBAN_COLUMNS, COLUMN_LABELS, STATE_FOLDER_MAP } from "./types";
 
 /**
@@ -167,7 +168,7 @@ export function resolveColumns(columnOrderJson: string | undefined): ListColumn[
       result.push(col);
     } else {
       // Dynamic column - created from a custom frontmatter state that was
-      // previously reordered in settings. Preserve it with a titlecased label.
+      // previously reordered in settings. Preserve it with a title-cased label.
       result.push(makeDynamicColumn(id));
     }
     seen.add(id);
@@ -185,13 +186,14 @@ export function resolveColumns(columnOrderJson: string | undefined): ListColumn[
 
 /**
  * Create a ListColumn for a dynamic state ID (not in the predefined list).
- * Uses a titlecased version of the ID as the display label.
+ * Uses a title-cased version of the ID as the display label
+ * (splits on `-`/`_` separators, capitalizes each word, joins with spaces).
  * No folderName since dynamic states are frontmatter-only.
  */
 export function makeDynamicColumn(stateId: string): ListColumn {
   return {
     id: stateId,
-    label: stateId.charAt(0).toUpperCase() + stateId.slice(1),
+    label: titleCase(stateId),
   };
 }
 
@@ -217,8 +219,8 @@ export function resolveCreationColumns(
       result.push({ id, label, ...(result.length === 0 ? { default: true } : {}) });
       seen.add(id);
     } else {
-      // Dynamic column - use titlecased ID as label
-      const dynLabel = id.charAt(0).toUpperCase() + id.slice(1);
+      // Dynamic column - use title-cased ID as label
+      const dynLabel = titleCase(id);
       result.push({ id, label: dynLabel, ...(result.length === 0 ? { default: true } : {}) });
       seen.add(id);
     }

--- a/src/adapters/task-agent/TaskAgentConfig.ts
+++ b/src/adapters/task-agent/TaskAgentConfig.ts
@@ -148,7 +148,9 @@ export function parseColumnOrderJson(json: string | undefined): string[] {
 /**
  * Resolve the effective column list from a custom order setting.
  * Re-orders DEFAULT_COLUMNS to match the provided column IDs.
- * Unknown IDs are ignored; columns missing from the order are appended.
+ * Unknown IDs in the order are preserved as dynamic columns (created from
+ * frontmatter states not in the predefined column list). Default columns
+ * missing from the order are appended at the end.
  */
 export function resolveColumns(columnOrderJson: string | undefined): ListColumn[] {
   const order = parseColumnOrderJson(columnOrderJson);
@@ -159,14 +161,19 @@ export function resolveColumns(columnOrderJson: string | undefined): ListColumn[
   const seen = new Set<string>();
 
   for (const id of order) {
+    if (seen.has(id)) continue;
     const col = columnById.get(id);
-    if (col && !seen.has(id)) {
+    if (col) {
       result.push(col);
-      seen.add(id);
+    } else {
+      // Dynamic column - created from a custom frontmatter state that was
+      // previously reordered in settings. Preserve it with a titlecased label.
+      result.push(makeDynamicColumn(id));
     }
+    seen.add(id);
   }
 
-  // Append any columns not mentioned in the custom order
+  // Append any default columns not mentioned in the custom order
   for (const col of DEFAULT_COLUMNS) {
     if (!seen.has(col.id)) {
       result.push(col);
@@ -177,8 +184,21 @@ export function resolveColumns(columnOrderJson: string | undefined): ListColumn[
 }
 
 /**
+ * Create a ListColumn for a dynamic state ID (not in the predefined list).
+ * Uses a titlecased version of the ID as the display label.
+ * No folderName since dynamic states are frontmatter-only.
+ */
+export function makeDynamicColumn(stateId: string): ListColumn {
+  return {
+    id: stateId,
+    label: stateId.charAt(0).toUpperCase() + stateId.slice(1),
+  };
+}
+
+/**
  * Resolve the effective creation columns from a custom setting.
  * The first column in the list is marked as the default.
+ * Accepts both predefined and dynamic column IDs.
  */
 export function resolveCreationColumns(
   creationColumnIdsJson: string | undefined,
@@ -195,6 +215,11 @@ export function resolveCreationColumns(
     const label = labelById.get(id);
     if (label) {
       result.push({ id, label, ...(result.length === 0 ? { default: true } : {}) });
+      seen.add(id);
+    } else {
+      // Dynamic column - use titlecased ID as label
+      const dynLabel = id.charAt(0).toUpperCase() + id.slice(1);
+      result.push({ id, label: dynLabel, ...(result.length === 0 ? { default: true } : {}) });
       seen.add(id);
     }
   }

--- a/src/adapters/task-agent/TaskFileTemplate.ts
+++ b/src/adapters/task-agent/TaskFileTemplate.ts
@@ -1,4 +1,4 @@
-import { slugify } from "../../core/utils";
+import { slugify, yamlQuoteValue } from "../../core/utils";
 import type { KanbanColumn } from "./types";
 
 export interface SplitSource {
@@ -49,13 +49,16 @@ export function generateTaskContent(
       `  cwd: ${yamlQuote(enrichment.cwd)}\n`
     : "";
 
+  const safeState = yamlQuoteValue(state);
+  const safeTagState = yamlQuoteValue(`task/${state}`);
+
   return `---
 id: ${id}
 tags:
   - task
-  - task/${state}
+  - ${safeTagState}
 
-state: ${state}
+state: ${safeState}
 
 title: ${safeTitle}
 

--- a/src/adapters/task-agent/TaskMover.test.ts
+++ b/src/adapters/task-agent/TaskMover.test.ts
@@ -250,4 +250,78 @@ created: 2026-03-26T00:00:00Z
 
     expect(createFolder).toHaveBeenCalledWith("2 - Areas/Tasks/active");
   });
+
+  describe("dynamic/custom state moves", () => {
+    it("updates frontmatter to dynamic state without folder move", async () => {
+      const { app, modify, rename } = createMockApp();
+      const mover = new TaskMover(app, "", defaultSettings);
+      const file = { path: "2 - Areas/Tasks/todo/task.md", name: "task.md" } as TFile;
+
+      const result = await mover.move(file, "review");
+
+      expect(result).toBe(true);
+      const content = modify.mock.calls[0][1] as string;
+      expect(content).toMatch(/^state: review$/m);
+      // No folder rename for dynamic states
+      expect(rename).not.toHaveBeenCalled();
+    });
+
+    it("updates task tag for dynamic state", async () => {
+      const { app, modify } = createMockApp();
+      const mover = new TaskMover(app, "", defaultSettings);
+      const file = { path: "2 - Areas/Tasks/todo/task.md", name: "task.md" } as TFile;
+
+      await mover.move(file, "review");
+
+      const content = modify.mock.calls[0][1] as string;
+      expect(content).toMatch(/- task\/review/);
+    });
+
+    it("appends activity log entry for dynamic state move", async () => {
+      const { app, modify } = createMockApp();
+      const mover = new TaskMover(app, "", defaultSettings);
+      const file = { path: "2 - Areas/Tasks/todo/task.md", name: "task.md" } as TFile;
+
+      await mover.move(file, "blocked-upstream");
+
+      const content = modify.mock.calls[0][1] as string;
+      expect(content).toContain("Moved to blocked-upstream (via kanban board)");
+    });
+
+    it("with resolver: skips applyState for dynamic state (no folder mapping)", async () => {
+      const resolver = {
+        applyState: vi.fn().mockResolvedValue(true),
+        resolveState: vi.fn().mockReturnValue("todo"),
+        getFolderForState: vi.fn().mockReturnValue(null), // No folder for dynamic state
+      };
+      const { app, modify } = createMockApp();
+      const mover = new TaskMover(app, "", defaultSettings, resolver as any);
+      const file = { path: "2 - Areas/Tasks/todo/task.md", name: "task.md" } as TFile;
+
+      const result = await mover.move(file, "amazing");
+
+      expect(result).toBe(true);
+      // Frontmatter updated
+      const content = modify.mock.calls[0][1] as string;
+      expect(content).toMatch(/^state: amazing$/m);
+      // Resolver's applyState NOT called since there's no folder mapping
+      expect(resolver.applyState).not.toHaveBeenCalled();
+    });
+
+    it("with resolver: calls applyState for known state (has folder mapping)", async () => {
+      const resolver = {
+        applyState: vi.fn().mockResolvedValue(true),
+        resolveState: vi.fn().mockReturnValue("todo"),
+        getFolderForState: vi.fn().mockReturnValue("active"),
+      };
+      const { app } = createMockApp();
+      const mover = new TaskMover(app, "", defaultSettings, resolver as any);
+      const file = { path: "2 - Areas/Tasks/todo/task.md", name: "task.md" } as TFile;
+
+      const result = await mover.move(file, "active");
+
+      expect(result).toBe(true);
+      expect(resolver.applyState).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/adapters/task-agent/TaskMover.test.ts
+++ b/src/adapters/task-agent/TaskMover.test.ts
@@ -324,4 +324,61 @@ created: 2026-03-26T00:00:00Z
       expect(resolver.applyState).toHaveBeenCalled();
     });
   });
+
+  describe("YAML quoting of special state values", () => {
+    it("quotes state values that are YAML booleans", async () => {
+      const { app, modify } = createMockApp();
+      const mover = new TaskMover(app, "", defaultSettings);
+      const file = { path: "2 - Areas/Tasks/todo/task.md", name: "task.md" } as TFile;
+
+      await mover.move(file, "yes");
+
+      const content = modify.mock.calls[0][1] as string;
+      expect(content).toMatch(/^state: "yes"$/m);
+    });
+
+    it("quotes state values with hash character", async () => {
+      const { app, modify } = createMockApp();
+      const mover = new TaskMover(app, "", defaultSettings);
+      const file = { path: "2 - Areas/Tasks/todo/task.md", name: "task.md" } as TFile;
+
+      await mover.move(file, "state#1");
+
+      const content = modify.mock.calls[0][1] as string;
+      expect(content).toMatch(/^state: "state#1"$/m);
+    });
+
+    it("quotes state values with colon", async () => {
+      const { app, modify } = createMockApp();
+      const mover = new TaskMover(app, "", defaultSettings);
+      const file = { path: "2 - Areas/Tasks/todo/task.md", name: "task.md" } as TFile;
+
+      await mover.move(file, "blocked: upstream");
+
+      const content = modify.mock.calls[0][1] as string;
+      expect(content).toMatch(/^state: "blocked: upstream"$/m);
+    });
+
+    it("does not quote normal state values", async () => {
+      const { app, modify } = createMockApp();
+      const mover = new TaskMover(app, "", defaultSettings);
+      const file = { path: "2 - Areas/Tasks/todo/task.md", name: "task.md" } as TFile;
+
+      await mover.move(file, "review");
+
+      const content = modify.mock.calls[0][1] as string;
+      expect(content).toMatch(/^state: review$/m);
+    });
+
+    it("quotes tag values with special characters", async () => {
+      const { app, modify } = createMockApp();
+      const mover = new TaskMover(app, "", defaultSettings);
+      const file = { path: "2 - Areas/Tasks/todo/task.md", name: "task.md" } as TFile;
+
+      await mover.move(file, "state#1");
+
+      const content = modify.mock.calls[0][1] as string;
+      expect(content).toMatch(/- "task\/state#1"/);
+    });
+  });
 });

--- a/src/adapters/task-agent/TaskMover.test.ts
+++ b/src/adapters/task-agent/TaskMover.test.ts
@@ -147,14 +147,20 @@ created: 2026-03-26T00:00:00Z
     expect(modify).not.toHaveBeenCalled();
   });
 
-  it("returns false for invalid target column", async () => {
-    const { app } = createMockApp();
+  it("succeeds for dynamic state target - updates frontmatter without folder move", async () => {
+    const { app, modify, rename } = createMockApp();
     const mover = new TaskMover(app, "", defaultSettings);
     const file = { path: "2 - Areas/Tasks/todo/task.md", name: "task.md" } as TFile;
 
-    const result = await mover.move(file, "nonexistent");
+    const result = await mover.move(file, "amazing");
 
-    expect(result).toBe(false);
+    // Dynamic states update frontmatter but skip folder move (no folder mapping)
+    expect(result).toBe(true);
+    expect(modify).toHaveBeenCalled();
+    const written = modify.mock.calls[0][1] as string;
+    expect(written).toMatch(/^state: amazing$/m);
+    // No folder rename since "amazing" has no STATE_FOLDER_MAP entry
+    expect(rename).not.toHaveBeenCalled();
   });
 
   it("returns false when vault operation fails", async () => {

--- a/src/adapters/task-agent/TaskMover.ts
+++ b/src/adapters/task-agent/TaskMover.ts
@@ -17,12 +17,7 @@ export class TaskMover implements WorkItemMover {
   }
 
   async move(file: TFile, targetColumnId: string): Promise<boolean> {
-    const newColumn = targetColumnId as KanbanColumn;
-
-    // Validate target: either the resolver knows it or STATE_FOLDER_MAP does
-    if (!this.stateResolver?.getFolderForState?.(newColumn) && !STATE_FOLDER_MAP[newColumn]) {
-      return false;
-    }
+    const newColumn = targetColumnId;
 
     try {
       const content = await this.app.vault.read(file);
@@ -35,11 +30,28 @@ export class TaskMover implements WorkItemMover {
 
       let updated = content;
 
-      // Update state field
-      updated = updated.replace(/^state:\s*.+$/m, `state: ${newColumn}`);
+      // Update state field (or insert it if missing)
+      if (/^state:\s*.+$/m.test(updated)) {
+        updated = updated.replace(/^state:\s*.+$/m, `state: ${newColumn}`);
+      } else {
+        // Insert state field into frontmatter
+        const fmMatch = updated.match(/^(---\r?\n)([\s\S]*?)(^---(?:\r?\n|$))/m);
+        if (fmMatch) {
+          const [fullMatch, openFence, body, closeFence] = fmMatch;
+          const eol = openFence.endsWith("\r\n") ? "\r\n" : "\n";
+          const trimmedBody = body.endsWith(eol) ? body : body + eol;
+          updated = updated.replace(
+            fullMatch,
+            `${openFence}${trimmedBody}state: ${newColumn}${eol}${closeFence}`,
+          );
+        }
+      }
 
-      // Update task tag
-      const oldTagPattern = new RegExp(`(- task/)(?:priority|todo|active|done|abandoned)`, "m");
+      // Update task tag - match both known and dynamic state values
+      const oldTagPattern = new RegExp(
+        `(- task/)(?:priority|todo|active|done|abandoned|${this.escapeRegex(oldState)})`,
+        "m",
+      );
       updated = updated.replace(oldTagPattern, `$1${newColumn}`);
 
       // Update the updated timestamp (no milliseconds)
@@ -70,21 +82,31 @@ export class TaskMover implements WorkItemMover {
       // Write updated content first (write-then-move pattern)
       await this.app.vault.modify(file, updated);
 
-      // Apply the state transition (file move or other mechanism)
+      // Apply the state transition (file move or other mechanism).
+      // For dynamic states without folder mappings, the resolver's applyState
+      // handles updating frontmatter (already done above) and may skip the
+      // folder move. The FolderStateResolver returns false for unknown states,
+      // which is fine - the frontmatter update above is sufficient.
       if (this.stateResolver) {
-        const stateApplied = await this.stateResolver.applyState(
-          this.app,
-          file,
-          newColumn,
-          oldState,
-          this.basePath,
-        );
-        if (!stateApplied) {
-          return false;
+        // Only attempt applyState if the resolver has a folder mapping for this state.
+        // For dynamic states (no folder mapping), frontmatter is already updated above.
+        const folder = this.stateResolver.getFolderForState?.(newColumn);
+        const hasFolder = folder !== null && folder !== undefined;
+        if (hasFolder) {
+          const stateApplied = await this.stateResolver.applyState(
+            this.app,
+            file,
+            newColumn,
+            oldState,
+            this.basePath,
+          );
+          if (!stateApplied) {
+            return false;
+          }
         }
       } else {
         // Legacy fallback: direct folder move using STATE_FOLDER_MAP
-        const targetFolder = STATE_FOLDER_MAP[newColumn];
+        const targetFolder = STATE_FOLDER_MAP[newColumn as KanbanColumn];
         if (targetFolder) {
           const newFolderPath = `${this.basePath}/${targetFolder}`;
           const newPath = `${newFolderPath}/${file.name}`;
@@ -104,6 +126,10 @@ export class TaskMover implements WorkItemMover {
       console.error("[work-terminal] TaskMover.move failed:", err);
       return false;
     }
+  }
+
+  private escapeRegex(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   }
 
   private formatActivityDate(date: Date): string {

--- a/src/adapters/task-agent/TaskMover.ts
+++ b/src/adapters/task-agent/TaskMover.ts
@@ -1,5 +1,6 @@
 import type { App, TFile } from "obsidian";
 import type { WorkItemMover, StateResolver } from "../../core/interfaces";
+import { yamlQuoteValue } from "../../core/utils";
 import { type KanbanColumn, STATE_FOLDER_MAP } from "./types";
 
 export class TaskMover implements WorkItemMover {
@@ -30,9 +31,12 @@ export class TaskMover implements WorkItemMover {
 
       let updated = content;
 
+      // Quote the state value to handle YAML-sensitive characters
+      const safeState = yamlQuoteValue(newColumn);
+
       // Update state field (or insert it if missing)
       if (/^state:\s*.+$/m.test(updated)) {
-        updated = updated.replace(/^state:\s*.+$/m, `state: ${newColumn}`);
+        updated = updated.replace(/^state:\s*.+$/m, `state: ${safeState}`);
       } else {
         // Insert state field into frontmatter
         const fmMatch = updated.match(/^(---\r?\n)([\s\S]*?)(^---(?:\r?\n|$))/m);
@@ -42,17 +46,21 @@ export class TaskMover implements WorkItemMover {
           const trimmedBody = body.endsWith(eol) ? body : body + eol;
           updated = updated.replace(
             fullMatch,
-            `${openFence}${trimmedBody}state: ${newColumn}${eol}${closeFence}`,
+            `${openFence}${trimmedBody}state: ${safeState}${eol}${closeFence}`,
           );
         }
       }
 
-      // Update task tag - match both known and dynamic state values
+      // Update task tag - match both known and dynamic state values.
+      // Tags are YAML list items where the value follows "task/", so special
+      // characters in the state need the whole tag value quoted.
+      const rawTag = `task/${newColumn}`;
+      const safeTagEntry = yamlQuoteValue(rawTag);
       const oldTagPattern = new RegExp(
-        `(- task/)(?:priority|todo|active|done|abandoned|${this.escapeRegex(oldState)})`,
+        `- (?:task/)(?:priority|todo|active|done|abandoned|${this.escapeRegex(oldState)})`,
         "m",
       );
-      updated = updated.replace(oldTagPattern, `$1${newColumn}`);
+      updated = updated.replace(oldTagPattern, `- ${safeTagEntry}`);
 
       // Update the updated timestamp (no milliseconds)
       const now = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");

--- a/src/adapters/task-agent/TaskParser.ts
+++ b/src/adapters/task-agent/TaskParser.ts
@@ -52,7 +52,7 @@ export class TaskParser implements WorkItemParser {
       this.transientIdsByPath.delete(file.path);
     }
 
-    const state = this.normaliseState(fm.state, fallbackState);
+    const state: string | null = this.normaliseState(fm.state, fallbackState);
     if (!state) return null;
 
     const priority = this.resolvePriority(fm);
@@ -93,10 +93,11 @@ export class TaskParser implements WorkItemParser {
     return filePath;
   }
 
-  private normaliseState(
-    frontmatterState: unknown,
-    fallbackState: TaskState | null,
-  ): TaskState | null {
+  private normaliseState(frontmatterState: unknown, fallbackState: string | null): string | null {
+    // When a state resolver is configured, it has already resolved the state
+    // (possibly a dynamic/custom value). Use its result as the fallback.
+    // Direct frontmatter values are still accepted if they match known states
+    // (backward compat for folder-only mode without resolver).
     if (
       typeof frontmatterState === "string" &&
       VALID_STATES.includes(frontmatterState as TaskState)
@@ -266,18 +267,23 @@ export class TaskParser implements WorkItemParser {
   /**
    * Resolve state for a file using the configured StateResolver if available,
    * falling back to the legacy path-based resolution.
+   *
+   * When a resolver is present, any non-null string it returns is accepted -
+   * including dynamic/custom states not in the predefined VALID_STATES list.
+   * This enables the open state set feature where frontmatter can contain
+   * arbitrary state values that create dynamic kanban columns.
    */
   private resolveStateFromFile(
     path: string,
     frontmatter: Record<string, unknown> | undefined,
-  ): TaskState | null {
+  ): string | null {
     if (this.stateResolver) {
       const resolved = this.stateResolver.resolveState(path, frontmatter);
-      if (resolved !== null && VALID_STATES.includes(resolved as TaskState)) {
-        return resolved as TaskState;
+      if (resolved !== null) {
+        return resolved;
       }
-      // If resolver returned null or an unrecognized state, fall back to the
-      // legacy path-based resolution below.
+      // If resolver returned null, fall back to the legacy path-based
+      // resolution below.
     }
     return this.getStateFromPath(path);
   }
@@ -301,7 +307,7 @@ export class TaskParser implements WorkItemParser {
 
   private createFallbackTaskFile(
     file: TFile,
-    state: TaskState | null,
+    state: string | null,
     transientId?: string,
   ): TaskFile | null {
     if (!state) return null;
@@ -396,11 +402,17 @@ export class TaskParser implements WorkItemParser {
       const column = item.state === "done" ? "done" : item.state;
       if (KANBAN_COLUMNS.includes(column as KanbanColumn)) {
         groups[column].push(item);
+      } else {
+        // Dynamic/custom state - create a group for it
+        if (!groups[column]) {
+          groups[column] = [];
+        }
+        groups[column].push(item);
       }
     }
 
     // Sort each column: score desc, then updated desc
-    for (const col of KANBAN_COLUMNS) {
+    for (const col of Object.keys(groups)) {
       groups[col].sort((a, b) => {
         const aPriority = (a.metadata as any)?.priority || { score: 0 };
         const bPriority = (b.metadata as any)?.priority || { score: 0 };

--- a/src/adapters/task-agent/TaskParserWithResolver.test.ts
+++ b/src/adapters/task-agent/TaskParserWithResolver.test.ts
@@ -147,10 +147,10 @@ describe("TaskParser with StateResolver", () => {
     });
   });
 
-  describe("resolver returns unrecognized state", () => {
-    it("falls back to folder path instead of dropping the task", () => {
-      // A resolver that always returns an unrecognized state
-      const badResolver = {
+  describe("resolver returns dynamic/custom state", () => {
+    it("accepts custom state from resolver (open state set)", () => {
+      // A resolver that returns a custom state not in the predefined list
+      const customResolver = {
         resolveState: () => "custom-unknown-state",
         applyState: async () => false,
       };
@@ -158,12 +158,37 @@ describe("TaskParser with StateResolver", () => {
       const app = mockApp([file], {
         [file.path]: makeFrontmatter({ state: "custom-unknown-state" }),
       });
-      const parser = new TaskParser(app, "", defaultSettings, badResolver as any);
+      const parser = new TaskParser(app, "", defaultSettings, customResolver as any);
       const item = parser.parse(file as unknown as TFile);
 
-      // Should fall back to folder-based resolution, not return null
+      // Custom states are now accepted - they create dynamic columns
       expect(item).not.toBeNull();
-      expect(item!.state).toBe("active");
+      expect(item!.state).toBe("custom-unknown-state");
+    });
+
+    it("groups custom state items into dynamic columns", () => {
+      const customResolver = {
+        resolveState: (_path: string, fm: Record<string, unknown> | undefined) => {
+          return (fm as any)?.state ?? null;
+        },
+        applyState: async () => true,
+      };
+      const file1 = makeFile("2 - Areas/Tasks/active/task1.md");
+      const file2 = makeFile("2 - Areas/Tasks/active/task2.md");
+      const app = mockApp([file1, file2], {
+        [file1.path]: makeFrontmatter({ state: "amazing" }),
+        [file2.path]: makeFrontmatter({ state: "active" }),
+      });
+      const parser = new TaskParser(app, "", defaultSettings, customResolver as any);
+      const item1 = parser.parse(file1 as unknown as TFile);
+      const item2 = parser.parse(file2 as unknown as TFile);
+
+      expect(item1!.state).toBe("amazing");
+      expect(item2!.state).toBe("active");
+
+      const groups = parser.groupByColumn([item1!, item2!]);
+      expect(groups["amazing"]).toHaveLength(1);
+      expect(groups["active"]).toHaveLength(1);
     });
   });
 

--- a/src/adapters/task-agent/stateResolverFactory.test.ts
+++ b/src/adapters/task-agent/stateResolverFactory.test.ts
@@ -60,5 +60,32 @@ describe("stateResolverFactory", () => {
       expect(resolver.getFolderForState!("done")).toBe("archive");
       expect(resolver.getFolderForState!("active")).toBe("active");
     });
+
+    it("composite resolver accepts dynamic frontmatter states", () => {
+      const resolver = createStateResolver("composite", "Tasks");
+      // Custom state in frontmatter is returned as-is (open state set)
+      expect(resolver.resolveState("Tasks/active/task.md", { state: "amazing" })).toBe("amazing");
+      expect(resolver.resolveState("Tasks/todo/task.md", { state: "review" })).toBe("review");
+    });
+
+    it("composite resolver returns null folder for dynamic states", () => {
+      const resolver = createStateResolver("composite", "Tasks");
+      expect(resolver.getFolderForState!("amazing")).toBeNull();
+      expect(resolver.getFolderForState!("review")).toBeNull();
+    });
+
+    it("frontmatter resolver accepts dynamic states", () => {
+      const resolver = createStateResolver("frontmatter", "Tasks");
+      expect(resolver.resolveState("any.md", { state: "waiting-on-review" })).toBe(
+        "waiting-on-review",
+      );
+      expect(resolver.resolveState("any.md", { state: "testing" })).toBe("testing");
+    });
+
+    it("folder resolver does not accept dynamic states", () => {
+      const resolver = createStateResolver("folder", "Tasks");
+      // Folder resolver only knows about states that map to folders
+      expect(resolver.resolveState("Tasks/amazing/task.md", undefined)).toBeNull();
+    });
   });
 });

--- a/src/adapters/task-agent/stateResolverFactory.test.ts
+++ b/src/adapters/task-agent/stateResolverFactory.test.ts
@@ -35,13 +35,14 @@ describe("stateResolverFactory", () => {
       expect(resolver.resolveState("Tasks/todo/task.md", undefined)).toBe("todo");
     });
 
-    it("frontmatter resolver validates against task states", () => {
+    it("frontmatter resolver accepts any string state (open state set)", () => {
       const resolver = createStateResolver("frontmatter", "Tasks");
       expect(resolver.resolveState("any.md", { state: "active" })).toBe("active");
       expect(resolver.resolveState("any.md", { state: "done" })).toBe("done");
       expect(resolver.resolveState("any.md", { state: "abandoned" })).toBe("abandoned");
-      // Invalid state
-      expect(resolver.resolveState("any.md", { state: "invalid" })).toBeNull();
+      // Dynamic/custom states are accepted - no validation against a fixed list
+      expect(resolver.resolveState("any.md", { state: "amazing" })).toBe("amazing");
+      expect(resolver.resolveState("any.md", { state: "custom-state" })).toBe("custom-state");
     });
 
     it("composite resolver checks frontmatter first, then folder", () => {

--- a/src/adapters/task-agent/stateResolverFactory.ts
+++ b/src/adapters/task-agent/stateResolverFactory.ts
@@ -7,8 +7,6 @@ import { STATE_FOLDER_MAP } from "./types";
 /** State resolution strategy identifier. */
 export type StateStrategy = "folder" | "frontmatter" | "composite";
 
-const VALID_TASK_STATES = ["priority", "todo", "active", "done", "abandoned"];
-
 /**
  * Create the default state resolver for the task-agent adapter.
  * Defaults to folder-based resolution for backward compatibility: state is
@@ -22,6 +20,11 @@ export function createDefaultStateResolver(basePath: string): StateResolver {
 
 /**
  * Create a state resolver for the given strategy.
+ *
+ * For frontmatter and composite modes, the FrontmatterStateResolver accepts
+ * any string value (open state set). This means users can write arbitrary
+ * states like `state: amazing` and they will be passed through as-is,
+ * creating dynamic columns in the kanban board.
  */
 export function createStateResolver(strategy: StateStrategy, basePath: string): StateResolver {
   switch (strategy) {
@@ -29,11 +32,14 @@ export function createStateResolver(strategy: StateStrategy, basePath: string): 
       return new FolderStateResolver(STATE_FOLDER_MAP, basePath);
 
     case "frontmatter":
-      return new FrontmatterStateResolver("state", VALID_TASK_STATES);
+      // No valid-state restriction: any frontmatter value is a valid state
+      return new FrontmatterStateResolver("state");
 
     case "composite":
+      // No valid-state restriction on frontmatter: any value is accepted.
+      // Folder resolver still provides fallback for files without frontmatter state.
       return new CompositeStateResolver([
-        new FrontmatterStateResolver("state", VALID_TASK_STATES),
+        new FrontmatterStateResolver("state"),
         new FolderStateResolver(STATE_FOLDER_MAP, basePath),
       ]);
 

--- a/src/adapters/task-agent/types.ts
+++ b/src/adapters/task-agent/types.ts
@@ -15,13 +15,15 @@ export interface TaskPriority {
 
 export type TaskState = "priority" | "todo" | "active" | "done" | "abandoned";
 
+/** Known kanban column IDs. Dynamic columns use arbitrary string IDs. */
 export type KanbanColumn = "priority" | "todo" | "active" | "done";
 
 export interface TaskFile {
   id: string;
   path: string;
   filename: string;
-  state: TaskState;
+  /** Task state - either a known TaskState or a dynamic/custom state string. */
+  state: string;
   title: string;
   tags: string[];
   source: TaskSource;

--- a/src/core/resolvers/FrontmatterStateResolver.ts
+++ b/src/core/resolvers/FrontmatterStateResolver.ts
@@ -1,5 +1,6 @@
 import type { App, TFile } from "obsidian";
 import type { StateResolver } from "../interfaces";
+import { yamlQuoteValue } from "../utils";
 
 /**
  * Resolves state from a frontmatter field. Applies state changes by
@@ -58,15 +59,16 @@ export class FrontmatterStateResolver implements StateResolver {
     const [fullMatch, openFence, body, closeFence] = fmMatch;
     const eol = openFence.endsWith("\r\n") ? "\r\n" : "\n";
     const fieldPattern = new RegExp(`^${escapeRegex(this.fieldName)}:\\s*.*$`, "m");
+    const safeState = yamlQuoteValue(newState);
 
     let updatedBody: string;
     if (fieldPattern.test(body)) {
       // Field exists (even if blank like `state:`) - replace it
-      updatedBody = body.replace(fieldPattern, `${this.fieldName}: ${newState}`);
+      updatedBody = body.replace(fieldPattern, `${this.fieldName}: ${safeState}`);
     } else {
       // Field missing - append before closing fence
       const trimmedBody = body.endsWith(eol) ? body : body + eol;
-      updatedBody = `${trimmedBody}${this.fieldName}: ${newState}${eol}`;
+      updatedBody = `${trimmedBody}${this.fieldName}: ${safeState}${eol}`;
     }
 
     return content.replace(fullMatch, `${openFence}${updatedBody}${closeFence}`);

--- a/src/core/utils.test.ts
+++ b/src/core/utils.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { expandTilde, normalizeObsidianDisplayText, stripAnsi, slugify } from "./utils";
+import {
+  expandTilde,
+  normalizeObsidianDisplayText,
+  stripAnsi,
+  slugify,
+  titleCase,
+  yamlQuoteValue,
+} from "./utils";
 
 describe("expandTilde", () => {
   const originalHome = process.env.HOME;
@@ -103,6 +110,91 @@ describe("slugify", () => {
 
   it("collapses consecutive special characters", () => {
     expect(slugify("hello!!!...world")).toBe("hello-world");
+  });
+});
+
+describe("titleCase", () => {
+  it("capitalizes a single word", () => {
+    expect(titleCase("review")).toBe("Review");
+  });
+
+  it("splits and capitalizes hyphenated words", () => {
+    expect(titleCase("blocked-upstream")).toBe("Blocked Upstream");
+  });
+
+  it("splits and capitalizes underscored words", () => {
+    expect(titleCase("my_custom_state")).toBe("My Custom State");
+  });
+
+  it("handles mixed separators", () => {
+    expect(titleCase("in-progress_now")).toBe("In Progress Now");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(titleCase("")).toBe("");
+  });
+
+  it("handles single character", () => {
+    expect(titleCase("x")).toBe("X");
+  });
+
+  it("preserves already capitalized words", () => {
+    expect(titleCase("API-ready")).toBe("API Ready");
+  });
+});
+
+describe("yamlQuoteValue", () => {
+  it("does not quote simple values", () => {
+    expect(yamlQuoteValue("active")).toBe("active");
+    expect(yamlQuoteValue("review")).toBe("review");
+    expect(yamlQuoteValue("blocked-upstream")).toBe("blocked-upstream");
+  });
+
+  it("quotes YAML boolean literals", () => {
+    expect(yamlQuoteValue("yes")).toBe('"yes"');
+    expect(yamlQuoteValue("true")).toBe('"true"');
+    expect(yamlQuoteValue("on")).toBe('"on"');
+    expect(yamlQuoteValue("no")).toBe('"no"');
+    expect(yamlQuoteValue("false")).toBe('"false"');
+    expect(yamlQuoteValue("off")).toBe('"off"');
+  });
+
+  it("quotes case-insensitive booleans", () => {
+    expect(yamlQuoteValue("Yes")).toBe('"Yes"');
+    expect(yamlQuoteValue("TRUE")).toBe('"TRUE"');
+    expect(yamlQuoteValue("On")).toBe('"On"');
+  });
+
+  it("quotes values with hash character", () => {
+    expect(yamlQuoteValue("state#1")).toBe('"state#1"');
+  });
+
+  it("quotes values with colon", () => {
+    expect(yamlQuoteValue("key: value")).toBe('"key: value"');
+  });
+
+  it("quotes values with leading whitespace", () => {
+    expect(yamlQuoteValue(" leading")).toBe('" leading"');
+  });
+
+  it("quotes values with trailing whitespace", () => {
+    expect(yamlQuoteValue("trailing ")).toBe('"trailing "');
+  });
+
+  it("escapes embedded double quotes", () => {
+    expect(yamlQuoteValue('say "hi"')).toBe('"say \\"hi\\""');
+  });
+
+  it("escapes embedded newlines", () => {
+    expect(yamlQuoteValue("line1\nline2")).toBe('"line1\\nline2"');
+  });
+
+  it("quotes null keyword", () => {
+    expect(yamlQuoteValue("null")).toBe('"null"');
+  });
+
+  it("quotes empty string", () => {
+    expect(yamlQuoteValue("")).toBe('""');
   });
 });
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -45,6 +45,43 @@ declare global {
 }
 
 /**
+ * Title-case a kebab-case or snake_case identifier.
+ * Splits on `-` and `_`, capitalizes each word, joins with spaces.
+ * e.g. "blocked-upstream" -> "Blocked Upstream", "my_custom_state" -> "My Custom State"
+ */
+export function titleCase(text: string): string {
+  if (!text) return "";
+  return text
+    .split(/[-_]/)
+    .map((word) => (word.length > 0 ? word.charAt(0).toUpperCase() + word.slice(1) : ""))
+    .join(" ");
+}
+
+/**
+ * Quote a value for safe embedding in YAML frontmatter.
+ * Wraps in double quotes when the value contains characters that would
+ * break YAML parsing: `#`, `: `, leading/trailing whitespace, or
+ * values that match YAML boolean literals (yes/no/on/off/true/false).
+ * Always escapes embedded backslashes, double quotes, and newlines.
+ */
+export function yamlQuoteValue(value: string): string {
+  const needsQuoting =
+    /[#:{}[\]|>&*!,'"%@`\n\r\\]/.test(value) ||
+    /^\s|\s$/.test(value) ||
+    /^(true|false|yes|no|on|off|null|~)$/i.test(value) ||
+    value.length === 0;
+
+  if (!needsQuoting) return value;
+
+  const escaped = value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r");
+  return `"${escaped}"`;
+}
+
+/**
  * Convert text to a URL/filename-safe kebab-case slug.
  * Max 40 characters, no leading/trailing hyphens.
  */

--- a/src/framework/ListPanel.test.ts
+++ b/src/framework/ListPanel.test.ts
@@ -808,4 +808,67 @@ describe("ListPanel", () => {
     expect(sections.length).toBe(1);
     expect(sections[0].getAttribute("data-column")).toBe("todo");
   });
+
+  describe("dynamic columns", () => {
+    it("skips empty dynamic columns persisted in config", () => {
+      // Dynamic columns (no folderName) with zero items should not render
+      const { panel } = createListPanel({
+        columns: [
+          { id: "todo", label: "To Do", folderName: "todo" },
+          { id: "review", label: "Review", folderName: undefined as any },
+        ],
+      });
+
+      panel.render({ todo: [makeItem("task-1")] }, {});
+
+      const sections = Array.from(document.querySelectorAll(".wt-section"));
+      expect(sections.length).toBe(1);
+      expect(sections[0].getAttribute("data-column")).toBe("todo");
+    });
+
+    it("renders dynamic columns that have items", () => {
+      const { panel } = createListPanel({
+        columns: [
+          { id: "todo", label: "To Do", folderName: "todo" },
+          { id: "review", label: "Review", folderName: undefined as any },
+        ],
+      });
+
+      const reviewItem = { ...makeItem("task-2"), state: "review" };
+      panel.render({ todo: [makeItem("task-1")], review: [reviewItem] }, {});
+
+      const sections = Array.from(document.querySelectorAll(".wt-section"));
+      expect(sections.length).toBe(2);
+      expect(sections[1].getAttribute("data-column")).toBe("review");
+    });
+
+    it("always renders built-in columns even when empty", () => {
+      const { panel } = createListPanel({
+        columns: [
+          { id: "todo", label: "To Do", folderName: "todo" },
+          { id: "active", label: "Active", folderName: "active" },
+        ],
+      });
+
+      panel.render({ todo: [makeItem("task-1")] }, {});
+
+      const sections = Array.from(document.querySelectorAll(".wt-section"));
+      expect(sections.length).toBe(2);
+      expect(sections[0].getAttribute("data-column")).toBe("todo");
+      expect(sections[1].getAttribute("data-column")).toBe("active");
+    });
+
+    it("sanitizes column IDs in CSS class names", () => {
+      const { panel } = createListPanel({
+        columns: [{ id: "blocked upstream", label: "Blocked Upstream", folderName: "todo" }],
+      });
+
+      panel.render({ "blocked upstream": [makeItem("task-1")] }, {});
+
+      const header = document.querySelector(".wt-section-header");
+      expect(header?.classList.contains("wt-section-header-blocked-upstream")).toBe(true);
+      // Should not contain the raw unsanitized class
+      expect(header?.classList.contains("wt-section-header-blocked upstream")).toBe(false);
+    });
+  });
 });

--- a/src/framework/ListPanel.ts
+++ b/src/framework/ListPanel.ts
@@ -17,6 +17,7 @@ import type { PersistedSession } from "../core/session/types";
 import type { TerminalPanelView } from "./TerminalPanelView";
 import type { PinStore } from "../core/PinStore";
 import { DangerConfirm } from "./DangerConfirm";
+import { slugify, titleCase } from "../core/utils";
 
 /** Virtual column ID for the pinned section. Not a real adapter column. */
 const PINNED_COLUMN_ID = "__pinned__";
@@ -160,10 +161,14 @@ export class ListPanel {
       }
     }
 
-    // Render regular columns, excluding pinned items
+    // Render regular columns, excluding pinned items.
+    // Dynamic columns (no folderName) that were persisted via column ordering
+    // are skipped when they have zero items to avoid cluttering the board.
     const configuredColumnIds = new Set(this.adapter.config.columns.map((c) => c.id));
     for (const col of this.adapter.config.columns) {
       const colItems = (groups[col.id] || []).filter((item) => !pinnedSet.has(item.id));
+      const isDynamic = !col.folderName;
+      if (isDynamic && colItems.length === 0) continue;
       const sortedItems = this.sortItems(colItems, col.id);
 
       this.renderSection(col.id, col.label, sortedItems, false);
@@ -178,7 +183,7 @@ export class ListPanel {
       const colItems = (groups[id] || []).filter((item) => !pinnedSet.has(item.id));
       if (colItems.length === 0) continue;
       const sortedItems = this.sortItems(colItems, id);
-      const label = id.charAt(0).toUpperCase() + id.slice(1);
+      const label = titleCase(id);
       this.renderSection(id, label, sortedItems, false);
     }
 
@@ -215,7 +220,8 @@ export class ListPanel {
 
     // Section header
     const headerEl = sectionEl.createDiv({ cls: "wt-section-header" });
-    headerEl.addClass(`wt-section-header-${columnId}`);
+    const safeColumnSlug = slugify(columnId);
+    if (safeColumnSlug) headerEl.addClass(`wt-section-header-${safeColumnSlug}`);
 
     const collapseIcon = headerEl.createSpan({ cls: "wt-collapse-icon" });
     collapseIcon.textContent = this.collapsedSections.has(columnId) ? "\u25b6" : "\u25bc";
@@ -257,10 +263,10 @@ export class ListPanel {
       if (isPinnedSection) {
         cardEl.addClass("wt-card-pinned");
         const realColumn = this.adapter.config.columns.find((c) => c.id === item.state);
-        const stateLabel =
-          realColumn?.label ?? item.state.charAt(0).toUpperCase() + item.state.slice(1);
+        const stateLabel = realColumn?.label ?? titleCase(item.state);
         const stateBadge = document.createElement("span");
-        stateBadge.addClass("wt-card-state-badge", `wt-state-badge-${item.state}`);
+        const stateSlug = slugify(item.state);
+        stateBadge.addClass("wt-card-state-badge", `wt-state-badge-${stateSlug}`);
         stateBadge.textContent = stateLabel;
         stateBadge.title = `Real state: ${stateLabel}`;
         // Insert badge into the meta row if available, otherwise into the card

--- a/src/framework/ListPanel.ts
+++ b/src/framework/ListPanel.ts
@@ -161,11 +161,25 @@ export class ListPanel {
     }
 
     // Render regular columns, excluding pinned items
+    const configuredColumnIds = new Set(this.adapter.config.columns.map((c) => c.id));
     for (const col of this.adapter.config.columns) {
       const colItems = (groups[col.id] || []).filter((item) => !pinnedSet.has(item.id));
       const sortedItems = this.sortItems(colItems, col.id);
 
       this.renderSection(col.id, col.label, sortedItems, false);
+    }
+
+    // Render dynamic columns: states present in items but not in configured columns.
+    // These appear after the configured columns, sorted alphabetically.
+    const dynamicIds = Object.keys(groups)
+      .filter((id) => !configuredColumnIds.has(id))
+      .sort();
+    for (const id of dynamicIds) {
+      const colItems = (groups[id] || []).filter((item) => !pinnedSet.has(item.id));
+      if (colItems.length === 0) continue;
+      const sortedItems = this.sortItems(colItems, id);
+      const label = id.charAt(0).toUpperCase() + id.slice(1);
+      this.renderSection(id, label, sortedItems, false);
     }
 
     // Auto-resolve placeholders whose real cards have now rendered
@@ -243,18 +257,18 @@ export class ListPanel {
       if (isPinnedSection) {
         cardEl.addClass("wt-card-pinned");
         const realColumn = this.adapter.config.columns.find((c) => c.id === item.state);
-        if (realColumn) {
-          const stateBadge = document.createElement("span");
-          stateBadge.addClass("wt-card-state-badge", `wt-state-badge-${item.state}`);
-          stateBadge.textContent = realColumn.label;
-          stateBadge.title = `Real state: ${realColumn.label}`;
-          // Insert badge into the meta row if available, otherwise into the card
-          const metaRow = cardEl.querySelector(".wt-card-meta");
-          if (metaRow) {
-            metaRow.insertBefore(stateBadge, metaRow.firstChild);
-          } else {
-            cardEl.appendChild(stateBadge);
-          }
+        const stateLabel =
+          realColumn?.label ?? item.state.charAt(0).toUpperCase() + item.state.slice(1);
+        const stateBadge = document.createElement("span");
+        stateBadge.addClass("wt-card-state-badge", `wt-state-badge-${item.state}`);
+        stateBadge.textContent = stateLabel;
+        stateBadge.title = `Real state: ${stateLabel}`;
+        // Insert badge into the meta row if available, otherwise into the card
+        const metaRow = cardEl.querySelector(".wt-card-meta");
+        if (metaRow) {
+          metaRow.insertBefore(stateBadge, metaRow.firstChild);
+        } else {
+          cardEl.appendChild(stateBadge);
         }
       }
 

--- a/src/framework/MainView.test.ts
+++ b/src/framework/MainView.test.ts
@@ -271,6 +271,9 @@ describe("MainView selection ID backfill", () => {
     (view as any).listPanel = listPanel;
     (view as any).parser = parser;
     (view as any).terminalPanel = terminalPanel;
+    (view as any).adapter = {
+      config: { columns: [{ id: "todo", label: "To Do" }] },
+    };
 
     (view as any).handleRename("2 - Areas/Tasks/todo/task-renamed.md", "stale-path");
     await (view as any).refreshList();

--- a/src/framework/MainView.ts
+++ b/src/framework/MainView.ts
@@ -22,6 +22,7 @@ import { SessionStore } from "../core/session/SessionStore";
 import { mergeAndSavePluginData } from "../core/PluginDataStore";
 import { PinStore } from "../core/PinStore";
 import { extractYamlFrontmatterString } from "../core/frontmatter";
+import { titleCase } from "../core/utils";
 import { GuidedTourController, shouldAutoStartGuidedTour } from "./GuidedTour";
 import type { AgentProfileManager } from "../core/agents/AgentProfileManager";
 
@@ -605,7 +606,7 @@ export class MainView extends ItemView {
     if (dynamicIds.length > 0) {
       const dynamicColumns = dynamicIds.map((id) => ({
         id,
-        label: id.charAt(0).toUpperCase() + id.slice(1),
+        label: titleCase(id),
       }));
       // Merge without duplicates - re-add configured columns then dynamic
       this.adapter.config.columns = [

--- a/src/framework/MainView.ts
+++ b/src/framework/MainView.ts
@@ -594,6 +594,26 @@ export class MainView extends ItemView {
     if (!this.listPanel || !this.parser) return [];
     const items = await this.parser.loadAll();
     const groups = this.parser.groupByColumn(items);
+
+    // Discover dynamic columns (states in items not in configured columns)
+    // and update the adapter config so the SettingsTab column ordering UI
+    // includes them. Dynamic columns appear after configured columns.
+    const configuredIds = new Set(this.adapter.config.columns.map((c) => c.id));
+    const dynamicIds = Object.keys(groups)
+      .filter((id) => !configuredIds.has(id) && (groups[id]?.length ?? 0) > 0)
+      .sort();
+    if (dynamicIds.length > 0) {
+      const dynamicColumns = dynamicIds.map((id) => ({
+        id,
+        label: id.charAt(0).toUpperCase() + id.slice(1),
+      }));
+      // Merge without duplicates - re-add configured columns then dynamic
+      this.adapter.config.columns = [
+        ...this.adapter.config.columns,
+        ...dynamicColumns.filter((dc) => !configuredIds.has(dc.id)),
+      ];
+    }
+
     const data = (await this.pluginRef.loadData()) || {};
     const customOrder = this.pendingCustomOrderOverride || data.customOrder || {};
     this.listPanel.render(groups, customOrder);

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -368,10 +368,13 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
     // Resolve effective column order (current config reflects it)
     const columns = this.adapter.config.columns;
 
+    const hasDynamic = columns.some((c) => !c.folderName);
     const desc = new Setting(containerEl)
       .setName("Column display order")
       .setDesc(
-        "Use arrow buttons to reorder kanban board columns. Changes take effect immediately.",
+        hasDynamic
+          ? "Use arrow buttons to reorder kanban board columns. Dynamic columns (from custom frontmatter states) are shown with a star. Changes take effect immediately."
+          : "Use arrow buttons to reorder kanban board columns. Changes take effect immediately.",
       );
 
     // Reset button
@@ -390,8 +393,10 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
       const col = columns[i];
       const rowEl = listEl.createDiv({ cls: "wt-column-order-row" });
 
-      // Column label
-      rowEl.createSpan({ text: col.label, cls: "wt-column-order-label" });
+      // Column label (with dynamic indicator for custom frontmatter states)
+      const isDynamic = !col.folderName;
+      const labelText = isDynamic ? `${col.label} *` : col.label;
+      rowEl.createSpan({ text: labelText, cls: "wt-column-order-label" });
 
       // Up button
       const upBtn = rowEl.createEl("button", {


### PR DESCRIPTION
## Summary

- Any frontmatter state value is now a valid state - unknown states create dynamic columns in the kanban board
- Composite/frontmatter resolvers pass through raw frontmatter values even if not in predefined column list
- ListPanel discovers all unique states across items and creates ad-hoc sections for unmapped states (appended after configured columns)
- TaskMover updates frontmatter state when moving to dynamic columns without attempting folder moves for unmapped states
- Column ordering settings incorporate dynamically discovered states

This implements "option 2" (open state set) from the discussion on PR #399 - frontmatter is the source of truth, the column list adapts.

Fixes #398

## Test plan

- [x] Unit tests for dynamic column discovery and rendering
- [x] Tests for TaskMover handling unmapped states
- [x] Tests for composite resolver passing through unknown states
- [x] All existing tests pass
- [ ] Manual: set `state: amazing` in frontmatter, verify new column appears
- [ ] Manual: drag task to dynamic column, verify frontmatter updates
- [ ] Manual: reorder dynamic columns in settings, verify persistence

Generated with [Claude Code](https://claude.com/claude-code)