### PR TITLE
feat: session filter toggle for kanban board

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -151,6 +151,8 @@ You can also drag a task between columns to change its state. Dropping a task fr
 
 The filter input at the top of the kanban board provides instant text filtering across all task titles. Type to narrow the visible cards to only those matching your search text. Clear the filter to show all tasks again.
 
+Below the text filter is an **Active sessions only** checkbox. When enabled, only tasks that have open terminal tabs or agent sessions are shown. This is useful when working with many tasks and you want to focus on just the ones you are actively working on. The toggle combines with the text filter - both conditions must match for a card to be visible. The filter state persists across plugin reloads.
+
 ---
 
 ## Terminal and agent sessions

--- a/src/framework/ListPanel.test.ts
+++ b/src/framework/ListPanel.test.ts
@@ -93,9 +93,11 @@ function createListPanel(
     creationColumns?: { id: string; label: string; default?: boolean }[];
     mover?: { move: ReturnType<typeof vi.fn> };
     onCustomOrderChange?: ReturnType<typeof vi.fn>;
+    onSessionFilterChange?: ReturnType<typeof vi.fn>;
     cardClasses?: string[];
     includeMetaRow?: boolean;
     itemName?: string;
+    settings?: Record<string, any>;
   } = {},
 ) {
   const parentEl = document.createElement("div") as HTMLElement & {
@@ -149,6 +151,7 @@ function createListPanel(
     closeAllSessions: vi.fn(),
     getAgentContextPrompt: vi.fn(),
     getSessionCounts: vi.fn(() => ({ shells: 0, agents: 0 })),
+    getSessionItemIds: vi.fn(() => [] as string[]),
     hasResumableAgentSessions: vi.fn(() => false),
     getPersistedSessions: vi.fn(() => []),
     getIdleSince: vi.fn(() => null),
@@ -166,6 +169,9 @@ function createListPanel(
     },
   };
 
+  const onSessionFilterChange = options.onSessionFilterChange ?? vi.fn();
+  const settings = options.settings ?? {};
+
   const panel = new ListPanel(
     parentEl,
     adapter as any,
@@ -173,12 +179,21 @@ function createListPanel(
     mover as any,
     plugin as any,
     terminalPanel as any,
-    {},
+    settings,
     vi.fn(),
     onCustomOrderChange,
+    onSessionFilterChange,
   );
 
-  return { panel, parentEl, mover, onCustomOrderChange, plugin, terminalPanel };
+  return {
+    panel,
+    parentEl,
+    mover,
+    onCustomOrderChange,
+    onSessionFilterChange,
+    plugin,
+    terminalPanel,
+  };
 }
 
 describe("ListPanel", () => {
@@ -869,6 +884,170 @@ describe("ListPanel", () => {
       expect(header?.classList.contains("wt-section-header-blocked-upstream")).toBe(true);
       // Should not contain the raw unsanitized class
       expect(header?.classList.contains("wt-section-header-blocked upstream")).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Session filter toggle
+  // ---------------------------------------------------------------------------
+
+  describe("session filter", () => {
+    it("renders the session filter checkbox in the filter container", () => {
+      createListPanel();
+
+      const checkbox = document.querySelector(".wt-session-filter-checkbox") as HTMLInputElement;
+      expect(checkbox).not.toBeNull();
+      expect(checkbox.type).toBe("checkbox");
+      expect(checkbox.checked).toBe(false);
+
+      const label = document.querySelector(".wt-session-filter-label");
+      expect(label).not.toBeNull();
+      expect(label?.textContent).toBe("Active sessions only");
+    });
+
+    it("hides cards without active sessions when the toggle is checked", () => {
+      const { panel, terminalPanel } = createListPanel();
+      terminalPanel.getSessionItemIds.mockReturnValue(["task-1"]);
+
+      panel.render({ todo: [makeItem("task-1"), makeItem("task-2")] }, {});
+
+      const checkbox = document.querySelector(".wt-session-filter-checkbox") as HTMLInputElement;
+      checkbox.checked = true;
+      checkbox.dispatchEvent(new dom.window.Event("change", { bubbles: true }));
+
+      const card1 = document.querySelector('[data-item-id="task-1"]') as HTMLElement;
+      const card2 = document.querySelector('[data-item-id="task-2"]') as HTMLElement;
+      expect(card1.style.display).toBe("");
+      expect(card2.style.display).toBe("none");
+    });
+
+    it("shows all cards when the toggle is unchecked", () => {
+      const { panel, terminalPanel } = createListPanel();
+      terminalPanel.getSessionItemIds.mockReturnValue(["task-1"]);
+
+      panel.render({ todo: [makeItem("task-1"), makeItem("task-2")] }, {});
+
+      const checkbox = document.querySelector(".wt-session-filter-checkbox") as HTMLInputElement;
+
+      // Enable filter
+      checkbox.checked = true;
+      checkbox.dispatchEvent(new dom.window.Event("change", { bubbles: true }));
+
+      // Disable filter
+      checkbox.checked = false;
+      checkbox.dispatchEvent(new dom.window.Event("change", { bubbles: true }));
+
+      const card1 = document.querySelector('[data-item-id="task-1"]') as HTMLElement;
+      const card2 = document.querySelector('[data-item-id="task-2"]') as HTMLElement;
+      expect(card1.style.display).toBe("");
+      expect(card2.style.display).toBe("");
+    });
+
+    it("combines session filter with text filter", () => {
+      const { panel, terminalPanel } = createListPanel();
+      terminalPanel.getSessionItemIds.mockReturnValue(["task-1", "task-2"]);
+
+      panel.render(
+        {
+          todo: [
+            makeItem("task-1", "Alpha"),
+            makeItem("task-2", "Beta"),
+            makeItem("task-3", "Alpha Clone"),
+          ],
+        },
+        {},
+      );
+
+      // Enable session filter
+      const checkbox = document.querySelector(".wt-session-filter-checkbox") as HTMLInputElement;
+      checkbox.checked = true;
+      checkbox.dispatchEvent(new dom.window.Event("change", { bubbles: true }));
+
+      // Also apply text filter for "Alpha"
+      const filterEl = document.querySelector(".wt-filter-input") as HTMLInputElement;
+      filterEl.value = "alpha";
+      filterEl.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+      vi.advanceTimersByTime(100);
+
+      // task-1 matches both filters (has session + matches "alpha")
+      const card1 = document.querySelector('[data-item-id="task-1"]') as HTMLElement;
+      expect(card1.style.display).toBe("");
+
+      // task-2 has session but does not match "alpha"
+      const card2 = document.querySelector('[data-item-id="task-2"]') as HTMLElement;
+      expect(card2.style.display).toBe("none");
+
+      // task-3 matches "alpha" but has no session
+      const card3 = document.querySelector('[data-item-id="task-3"]') as HTMLElement;
+      expect(card3.style.display).toBe("none");
+    });
+
+    it("hides sections with no visible cards when session filter is active", () => {
+      const { panel, terminalPanel } = createListPanel({
+        columns: [
+          { id: "todo", label: "To Do", folderName: "todo" },
+          { id: "active", label: "Active", folderName: "active" },
+        ],
+      });
+      terminalPanel.getSessionItemIds.mockReturnValue(["task-2"]);
+
+      const activeItem = { ...makeItem("task-2"), state: "active" };
+      panel.render({ todo: [makeItem("task-1")], active: [activeItem] }, {});
+
+      const checkbox = document.querySelector(".wt-session-filter-checkbox") as HTMLInputElement;
+      checkbox.checked = true;
+      checkbox.dispatchEvent(new dom.window.Event("change", { bubbles: true }));
+
+      const todoSection = document.querySelector('[data-column="todo"]') as HTMLElement;
+      const activeSection = document.querySelector('[data-column="active"]') as HTMLElement;
+      expect(todoSection.style.display).toBe("none");
+      expect(activeSection.style.display).toBe("");
+    });
+
+    it("calls onSessionFilterChange when the toggle is clicked", () => {
+      const onSessionFilterChange = vi.fn();
+      createListPanel({ onSessionFilterChange });
+
+      const checkbox = document.querySelector(".wt-session-filter-checkbox") as HTMLInputElement;
+      checkbox.checked = true;
+      checkbox.dispatchEvent(new dom.window.Event("change", { bubbles: true }));
+
+      expect(onSessionFilterChange).toHaveBeenCalledWith(true);
+
+      checkbox.checked = false;
+      checkbox.dispatchEvent(new dom.window.Event("change", { bubbles: true }));
+
+      expect(onSessionFilterChange).toHaveBeenCalledWith(false);
+    });
+
+    it("restores session filter state from settings", () => {
+      createListPanel({
+        settings: { "core.sessionFilterActive": true },
+      });
+
+      const checkbox = document.querySelector(".wt-session-filter-checkbox") as HTMLInputElement;
+      expect(checkbox.checked).toBe(true);
+    });
+
+    it("re-applies session filter when session badges update", () => {
+      const { panel, terminalPanel } = createListPanel();
+
+      panel.render({ todo: [makeItem("task-1"), makeItem("task-2")] }, {});
+
+      // Enable session filter with task-1 having a session
+      terminalPanel.getSessionItemIds.mockReturnValue(["task-1"]);
+      const checkbox = document.querySelector(".wt-session-filter-checkbox") as HTMLInputElement;
+      checkbox.checked = true;
+      checkbox.dispatchEvent(new dom.window.Event("change", { bubbles: true }));
+
+      const card2 = document.querySelector('[data-item-id="task-2"]') as HTMLElement;
+      expect(card2.style.display).toBe("none");
+
+      // Now task-2 also gets a session - updateSessionBadges should re-apply filter
+      terminalPanel.getSessionItemIds.mockReturnValue(["task-1", "task-2"]);
+      panel.updateSessionBadges();
+
+      expect(card2.style.display).toBe("");
     });
   });
 });

--- a/src/framework/ListPanel.ts
+++ b/src/framework/ListPanel.ts
@@ -105,18 +105,17 @@ export class ListPanel {
       }, 100);
     });
 
-    // Session filter toggle
+    // Session filter toggle (input wrapped in label to avoid duplicate DOM IDs)
     const sessionFilterContainer = filterContainer.createDiv({ cls: "wt-session-filter" });
-    this.sessionFilterEl = sessionFilterContainer.createEl("input", {
+    const sessionFilterLabel = sessionFilterContainer.createEl("label", {
+      cls: "wt-session-filter-label",
+    });
+    this.sessionFilterEl = sessionFilterLabel.createEl("input", {
       cls: "wt-session-filter-checkbox",
-      attr: { type: "checkbox", id: "wt-session-filter-toggle" },
+      attr: { type: "checkbox" },
     });
     this.sessionFilterEl.checked = this.sessionFilterActive;
-    sessionFilterContainer.createEl("label", {
-      text: "Active sessions only",
-      cls: "wt-session-filter-label",
-      attr: { for: "wt-session-filter-toggle" },
-    });
+    sessionFilterLabel.createSpan({ text: "Active sessions only" });
     this.sessionFilterEl.addEventListener("change", () => {
       this.sessionFilterActive = this.sessionFilterEl.checked;
       this.onSessionFilterChange(this.sessionFilterActive);

--- a/src/framework/ListPanel.ts
+++ b/src/framework/ListPanel.ts
@@ -26,6 +26,7 @@ export class ListPanel {
   private containerEl: HTMLElement;
   private listEl: HTMLElement;
   private filterEl: HTMLInputElement;
+  private sessionFilterEl: HTMLInputElement;
   private adapter: AdapterBundle;
   private cardRenderer: CardRenderer;
   private mover: WorkItemMover;
@@ -35,12 +36,14 @@ export class ListPanel {
   private settings: Record<string, any>;
   private onSelect: (item: WorkItem | null) => void;
   private onCustomOrderChange: (order: Record<string, string[]>) => void;
+  private onSessionFilterChange: (active: boolean) => void;
   private pinStore: PinStore | null = null;
 
   // State
   private selectedId: string | null = null;
   private collapsedSections: Set<string> = new Set();
   private filterTerm = "";
+  private sessionFilterActive = false;
   private filterDebounce: ReturnType<typeof setTimeout> | null = null;
   private items: WorkItem[] = [];
   private groups: Record<string, WorkItem[]> = {};
@@ -73,6 +76,7 @@ export class ListPanel {
     settings: Record<string, any>,
     onSelect: (item: WorkItem | null) => void,
     onCustomOrderChange: (order: Record<string, string[]>) => void,
+    onSessionFilterChange?: (active: boolean) => void,
   ) {
     this.adapter = adapter;
     this.cardRenderer = cardRenderer;
@@ -82,6 +86,10 @@ export class ListPanel {
     this.settings = settings;
     this.onSelect = onSelect;
     this.onCustomOrderChange = onCustomOrderChange;
+    this.onSessionFilterChange = onSessionFilterChange ?? (() => {});
+
+    // Restore session filter state from settings
+    this.sessionFilterActive = !!settings["core.sessionFilterActive"];
 
     // Filter input
     const filterContainer = parentEl.createDiv({ cls: "wt-filter-container" });
@@ -95,6 +103,24 @@ export class ListPanel {
         this.filterTerm = this.filterEl.value.toLowerCase();
         this.applyFilter();
       }, 100);
+    });
+
+    // Session filter toggle
+    const sessionFilterContainer = filterContainer.createDiv({ cls: "wt-session-filter" });
+    this.sessionFilterEl = sessionFilterContainer.createEl("input", {
+      cls: "wt-session-filter-checkbox",
+      attr: { type: "checkbox", id: "wt-session-filter-toggle" },
+    });
+    this.sessionFilterEl.checked = this.sessionFilterActive;
+    sessionFilterContainer.createEl("label", {
+      text: "Active sessions only",
+      cls: "wt-session-filter-label",
+      attr: { for: "wt-session-filter-toggle" },
+    });
+    this.sessionFilterEl.addEventListener("change", () => {
+      this.sessionFilterActive = this.sessionFilterEl.checked;
+      this.onSessionFilterChange(this.sessionFilterActive);
+      this.applyFilter();
     });
 
     // List container
@@ -873,20 +899,29 @@ export class ListPanel {
   // ---------------------------------------------------------------------------
 
   private applyFilter(): void {
+    // Build a set of item IDs with active sessions when session filter is on
+    const sessionItemIds = this.sessionFilterActive
+      ? new Set(this.terminalPanel.getSessionItemIds())
+      : null;
+    const hasAnyFilter = !!this.filterTerm || this.sessionFilterActive;
+
     const sections = this.listEl.querySelectorAll(".wt-section");
     for (const section of Array.from(sections)) {
       const cards = section.querySelectorAll(".wt-card-wrapper");
       let visibleCount = 0;
 
       for (const card of Array.from(cards)) {
-        const text = card.textContent?.toLowerCase() || "";
-        const match = !this.filterTerm || text.includes(this.filterTerm);
+        const textMatch =
+          !this.filterTerm || (card.textContent?.toLowerCase() || "").includes(this.filterTerm);
+        const sessionMatch =
+          !sessionItemIds || sessionItemIds.has(card.getAttribute("data-item-id") || "");
+        const match = textMatch && sessionMatch;
         (card as HTMLElement).style.display = match ? "" : "none";
         if (match) visibleCount++;
       }
 
       // Hide section if all cards filtered out
-      (section as HTMLElement).style.display = visibleCount > 0 || !this.filterTerm ? "" : "none";
+      (section as HTMLElement).style.display = visibleCount > 0 || !hasAnyFilter ? "" : "none";
     }
   }
 
@@ -1090,6 +1125,11 @@ export class ListPanel {
       this.renderSessionBadges(actionsEl, item);
       this.renderResumeBadge(actionsEl, item);
       if (moveBtn) actionsEl.appendChild(moveBtn); // re-append to keep it last
+    }
+
+    // Re-apply filter so session-only toggle reflects current session state
+    if (this.sessionFilterActive) {
+      this.applyFilter();
     }
   }
 

--- a/src/framework/MainView.ts
+++ b/src/framework/MainView.ts
@@ -386,6 +386,13 @@ export class MainView extends ItemView {
       async (order: Record<string, string[]>) => {
         await this.persistCustomOrder(order);
       },
+      // onSessionFilterChange callback - persist toggle state
+      async (active: boolean) => {
+        await mergeAndSavePluginData(this.pluginRef, async (data) => {
+          if (!data.settings) data.settings = {};
+          data.settings["core.sessionFilterActive"] = active;
+        });
+      },
     );
 
     // Initialize PinStore and inject into ListPanel

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -2496,6 +2496,11 @@ export class TerminalPanelView {
     return this.tabManager.getSessionItemIds().length > 0;
   }
 
+  /** Return item IDs that have active terminal sessions. */
+  getSessionItemIds(): string[] {
+    return this.tabManager.getSessionItemIds();
+  }
+
   getSessionCounts(itemId: string): { shells: number; agents: number } {
     return this.tabManager.getSessionCounts(itemId);
   }

--- a/styles.css
+++ b/styles.css
@@ -73,6 +73,25 @@
   border-color: var(--interactive-accent);
 }
 
+.wt-session-filter {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.wt-session-filter-checkbox {
+  margin: 0;
+  cursor: pointer;
+}
+
+.wt-session-filter-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  cursor: pointer;
+  user-select: none;
+}
+
 /* =============================================================================
    List panel & sections
    ============================================================================= */


### PR DESCRIPTION
## Summary

- Adds an **Active sessions only** checkbox below the text filter input on the kanban board
- When enabled, only tasks with open terminal tabs or agent sessions are shown
- Filter combines with text search (both conditions must match) and persists across plugin reloads
- Filter automatically re-evaluates when sessions are opened or closed

## Changes

- `TerminalPanelView`: expose `getSessionItemIds()` for querying which items have active sessions
- `ListPanel`: add session filter toggle UI, `sessionFilterActive` state, updated `applyFilter()` logic
- `MainView`: wire persistence callback via `mergeAndSavePluginData` to `core.sessionFilterActive`
- `styles.css`: new `wt-session-filter-*` classes for the toggle row
- `ListPanel.test.ts`: 7 new tests covering toggle rendering, filtering, combined filters, section hiding, callback, persistence, and live session updates
- `docs/user-guide.md`: document the new filter in the Filtering section

## Test plan

- [x] All 1197 tests pass (`pnpm exec vitest run`)
- [x] Production build succeeds (`pnpm run build`)
- [ ] Manual: open kanban with multiple tasks, enable toggle, verify only tasks with sessions visible
- [ ] Manual: combine text filter + session filter, verify intersection behavior
- [ ] Manual: close plugin and reopen, verify toggle state persists

Closes #401