### PR TITLE
fix(task-agent): use nested YAML in TaskFileTemplate frontmatter

### DIFF
--- a/src/adapters/task-agent/TaskFileTemplate.test.ts
+++ b/src/adapters/task-agent/TaskFileTemplate.test.ts
@@ -60,29 +60,38 @@ describe("generateTaskContent", () => {
     expect(content).toContain("agent-actionable: false");
     expect(content).toContain("goal: []");
     expect(content).toContain("related: []");
-    expect(content).toContain("priority.score: 0");
-    expect(content).toContain("priority.has-blocker: false");
+    expect(content).toMatch(/^priority:\n\s+score: 0$/m);
+    expect(content).toMatch(/^priority:[\s\S]*?has-blocker: false$/m);
   });
 
-  it("uses flat dot-notation keys for source fields", () => {
+  it("uses nested YAML for source fields", () => {
     const content = generateTaskContent("Test", "todo");
-    expect(content).toMatch(/^source\.type: prompt$/m);
-    expect(content).toMatch(/^source\.id:/m);
-    expect(content).toMatch(/^source\.url:/m);
-    expect(content).toMatch(/^source\.captured:/m);
-    // Must NOT contain nested source block
-    expect(content).not.toMatch(/^source:\n\s+type:/m);
+    expect(content).toMatch(/^source:\n\s+type: prompt$/m);
+    expect(content).toMatch(/^source:[\s\S]*?\s+id:/m);
+    expect(content).toMatch(/^source:[\s\S]*?\s+url:/m);
+    expect(content).toMatch(/^source:[\s\S]*?\s+captured:/m);
+    // Must NOT contain dot-notation source keys
+    expect(content).not.toMatch(/^source\./m);
   });
 
-  it("uses flat dot-notation keys for priority fields", () => {
+  it("uses nested YAML for priority fields", () => {
     const content = generateTaskContent("Test", "todo");
-    expect(content).toMatch(/^priority\.score: 0$/m);
-    expect(content).toMatch(/^priority\.deadline: ""$/m);
-    expect(content).toMatch(/^priority\.impact: medium$/m);
-    expect(content).toMatch(/^priority\.has-blocker: false$/m);
-    expect(content).toMatch(/^priority\.blocker-context: ""$/m);
-    // Must NOT contain nested priority block
-    expect(content).not.toMatch(/^priority:\n\s+score:/m);
+    expect(content).toMatch(/^priority:\n\s+score: 0$/m);
+    expect(content).toMatch(/^priority:[\s\S]*?\s+deadline: ""$/m);
+    expect(content).toMatch(/^priority:[\s\S]*?\s+impact: medium$/m);
+    expect(content).toMatch(/^priority:[\s\S]*?\s+has-blocker: false$/m);
+    expect(content).toMatch(/^priority:[\s\S]*?\s+blocker-context: ""$/m);
+    // Must NOT contain dot-notation priority keys
+    expect(content).not.toMatch(/^priority\./m);
+  });
+
+  it("has no blank lines within frontmatter fences", () => {
+    const content = generateTaskContent("Test", "todo");
+    const frontmatter = content.split("---")[1];
+    // Every line within the frontmatter block should be non-empty
+    const lines = frontmatter.split("\n").slice(1, -1); // trim leading/trailing from split
+    const blankLines = lines.filter((line) => line.trim() === "");
+    expect(blankLines).toHaveLength(0);
   });
 
   it("uses block list syntax for split task related links", () => {

--- a/src/adapters/task-agent/TaskFileTemplate.test.ts
+++ b/src/adapters/task-agent/TaskFileTemplate.test.ts
@@ -87,9 +87,11 @@ describe("generateTaskContent", () => {
 
   it("has no blank lines within frontmatter fences", () => {
     const content = generateTaskContent("Test", "todo");
-    const frontmatter = content.split("---")[1];
+    const fmMatch = content.match(/^---\n([\s\S]*?)\n---\n/);
+    expect(fmMatch).not.toBeNull();
+    const frontmatter = fmMatch![1];
     // Every line within the frontmatter block should be non-empty
-    const lines = frontmatter.split("\n").slice(1, -1); // trim leading/trailing from split
+    const lines = frontmatter.split("\n");
     const blankLines = lines.filter((line) => line.trim() === "");
     expect(blankLines).toHaveLength(0);
   });

--- a/src/adapters/task-agent/TaskFileTemplate.ts
+++ b/src/adapters/task-agent/TaskFileTemplate.ts
@@ -73,7 +73,7 @@ priority:
 agent-actionable: false
 goal: []
 ${relatedField}
-${enrichmentSection}created: ${now}
+${enrichmentSection ? enrichmentSection + (enrichmentSection.endsWith("\n") ? "" : "\n") : ""}created: ${now}
 updated: ${now}
 ---
 # ${title}

--- a/src/adapters/task-agent/TaskFileTemplate.ts
+++ b/src/adapters/task-agent/TaskFileTemplate.ts
@@ -40,8 +40,11 @@ export function generateTaskContent(
   const yamlQuote = (s: string): string =>
     `"${s.replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/"/g, '\\"')}"`;
 
-  const enrichmentBlock = enrichment
-    ? `\nenrichment:\n` +
+  const safeState = yamlQuoteValue(state);
+  const safeTagState = yamlQuoteValue(`task/${state}`);
+
+  const enrichmentSection = enrichment
+    ? `enrichment:\n` +
       `  profile: ${yamlQuote(enrichment.profile ?? "")}\n` +
       `  command: ${yamlQuote(enrichment.command)}\n` +
       `  args: ${yamlQuote(enrichment.args)}\n` +
@@ -49,37 +52,28 @@ export function generateTaskContent(
       `  cwd: ${yamlQuote(enrichment.cwd)}\n`
     : "";
 
-  const safeState = yamlQuoteValue(state);
-  const safeTagState = yamlQuoteValue(`task/${state}`);
-
   return `---
 id: ${id}
 tags:
   - task
   - ${safeTagState}
-
 state: ${safeState}
-
 title: ${safeTitle}
-
-source.type: prompt
-source.id: "${splitFrom ? `split-${now.replace(/[:.]/g, "")}` : ""}"
-source.url: ""
-source.captured: ${now}
-
-priority.score: 0
-priority.deadline: ""
-priority.impact: medium
-priority.has-blocker: false
-priority.blocker-context: ""
-
+source:
+  type: prompt
+  id: "${splitFrom ? `split-${now.replace(/[:.]/g, "")}` : ""}"
+  url: ""
+  captured: ${now}
+priority:
+  score: 0
+  deadline: ""
+  impact: medium
+  has-blocker: false
+  blocker-context: ""
 agent-actionable: false
-
 goal: []
-
 ${relatedField}
-${enrichmentBlock}
-created: ${now}
+${enrichmentSection}created: ${now}
 updated: ${now}
 ---
 # ${title}


### PR DESCRIPTION
## Summary

- Replace dot-notation keys (`source.type`, `priority.score`, etc.) with properly nested YAML structure in `generateTaskContent()`
- Remove all blank lines within the `---` frontmatter fences so Obsidian does not prematurely end the frontmatter block
- Update tests to assert nested YAML format and add a new test verifying no blank lines exist within frontmatter

Fixes #404

## Test plan

- [x] All 1198 existing tests pass (`pnpm exec vitest run`)
- [x] Build succeeds with no type errors (`pnpm run build`)
- [ ] Manually create a task in Obsidian and verify all frontmatter fields render as properties (not body text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)