### PR TITLE
feat: compact single-line task card view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ src/
     utils.ts      # expandTilde, stripAnsi, electronRequire, slugify
     interfaces.ts # All extension point interfaces + BaseAdapter
     terminal/     # XtermCss, ScrollButton, KeyboardCapture, TerminalTab, TabManager
-    agents/       # AgentLauncher, AgentStateDetector, AgentSessionRename
+    agents/       # AgentLauncher, AgentStateDetector
     claude/       # HeadlessClaude
     session/      # SessionStore (window-global), types
 
@@ -49,7 +49,7 @@ To create a custom adapter: extend `BaseAdapter`, implement the abstract methods
 
 ### Key design decisions
 
-- **Agent integration owned by framework, not adapter** - AgentLauncher, AgentStateDetector, and AgentSessionRename are framework code. Adapters only provide a `WorkItemPromptBuilder` for context prompts.
+- **Agent integration owned by framework, not adapter** - AgentLauncher and AgentStateDetector are framework code. Adapters only provide a `WorkItemPromptBuilder` for context prompts.
 - **UUID-based keying** - Custom order and selection use frontmatter UUIDs, not file paths. Survives renames without re-keying.
 - **2-panel ItemView + workspace leaf detail** - The detail panel is a native Obsidian MarkdownView created via `createLeafBySplit`, not a custom CSS column. Gives live preview, frontmatter editing, backlinks for free.
 - **CSS prefix `wt-`** - All plugin CSS classes use `wt-` prefix. No CSS modules.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -11,6 +11,7 @@ Work Terminal turns your Obsidian vault into a work item board with per-item tab
   - [Creating tasks](#creating-tasks)
   - [Kanban board](#kanban-board)
   - [Task card anatomy](#task-card-anatomy)
+  - [Compact card mode](#compact-card-mode)
   - [Context menu](#context-menu)
   - [Detail panel](#detail-panel)
   - [Drag-drop reordering](#drag-drop-reordering)
@@ -109,6 +110,33 @@ Cards contain:
 - **Ingestion indicator** - shows "ingesting..." while background enrichment is running
 
 When a task has an active terminal session, a small indicator appears on the card showing the session count and type.
+
+### Compact card mode
+
+Work Terminal offers an optional **compact display mode** that collapses each task card into a single horizontal line. This is useful when you have many tasks and want to see more of them at once without scrolling.
+
+To enable compact mode, go to **Settings > Core > Card display mode** and select **Compact**.
+
+In compact mode, each card becomes a single row containing:
+
+- **Title** - single line, truncated with ellipsis if it overflows
+- **Indicator dots** - small coloured dots that replace the verbose meta badges:
+  - Blue dot for Jira-sourced tasks (hover to see the Jira key, e.g. "CASTLE-1234")
+  - Orange/red dot for priority score (hover to see the score value; red for 60+, orange for 30-59, grey for below 30)
+  - Green dot for tasks with a goal assigned (hover to see the goal name)
+  - Coloured dot for each active card flag (hover to see the flag label or context)
+- **Session badge** - the session count badge remains visible, slightly smaller
+
+Everything else works identically in compact mode:
+
+- **Drag-drop** reordering and cross-column moves
+- **Selection** and detail panel opening
+- **Context menu** with all the same actions
+- **Agent state indicators** (active/waiting/idle border and glow animations)
+- **Pinned section** with state badges (adapted to the compact height)
+- **Filtering** by text and active sessions
+
+Switch back to **Standard** mode at any time to restore the full multi-line card layout with verbose badges, goal tags, and flag labels.
 
 ### Context menu
 
@@ -302,6 +330,7 @@ The core settings section covers:
 
 | Setting | Description |
 |---------|-------------|
+| **Card display mode** | Choose between **Standard** (full card details with badges and tags) and **Compact** (single-line cards with indicator dots). See [Compact card mode](#compact-card-mode). |
 | **Default shell** | Shell used for new terminal tabs (defaults to your system shell) |
 | **Default terminal CWD** | Working directory for new terminals (supports `~` expansion) |
 | **Keep sessions alive** | When enabled, closing the Work Terminal tab stashes sessions to memory instead of killing them. Reopening restores sessions with full PTY state. |

--- a/src/adapters/task-agent/TaskCard.test.ts
+++ b/src/adapters/task-agent/TaskCard.test.ts
@@ -428,4 +428,237 @@ describe("TaskCard", () => {
       expect(flags.length).toBe(0);
     });
   });
+
+  describe("compact display mode", () => {
+    it("renders wt-card-compact class in compact mode", () => {
+      const item = makeItem();
+      const ctx = makeContext();
+      const card = new TaskCard();
+
+      const el = card.render(item, ctx, "compact");
+
+      expect(el.classList.contains("wt-card-compact")).toBe(true);
+    });
+
+    it("does not render wt-card-compact class in standard mode", () => {
+      const item = makeItem();
+      const ctx = makeContext();
+      const card = new TaskCard();
+
+      const el = card.render(item, ctx, "standard");
+
+      expect(el.classList.contains("wt-card-compact")).toBe(false);
+    });
+
+    it("does not render wt-card-compact class when displayMode is undefined", () => {
+      const item = makeItem();
+      const ctx = makeContext();
+      const card = new TaskCard();
+
+      const el = card.render(item, ctx);
+
+      expect(el.classList.contains("wt-card-compact")).toBe(false);
+    });
+
+    it("renders compact row layout with title and dots container", () => {
+      const item = makeItem();
+      const ctx = makeContext();
+      const card = new TaskCard();
+
+      const el = card.render(item, ctx, "compact");
+
+      const compactRow = el.querySelector(".wt-card-compact-row");
+      expect(compactRow).not.toBeNull();
+
+      const title = el.querySelector(".wt-card-compact-title");
+      expect(title).not.toBeNull();
+      expect(title!.textContent).toBe("Fix context prompt");
+
+      const dots = el.querySelector(".wt-card-compact-dots");
+      expect(dots).not.toBeNull();
+    });
+
+    it("renders icon slot placeholder in compact mode (hidden)", () => {
+      const item = makeItem();
+      const ctx = makeContext();
+      const card = new TaskCard();
+
+      const el = card.render(item, ctx, "compact");
+
+      const iconSlot = el.querySelector(".wt-card-icon-slot") as HTMLElement;
+      expect(iconSlot).not.toBeNull();
+      expect(iconSlot.style.display).toBe("none");
+    });
+
+    it("renders icon slot placeholder in standard mode (hidden)", () => {
+      const item = makeItem();
+      const ctx = makeContext();
+      const card = new TaskCard();
+
+      const el = card.render(item, ctx, "standard");
+
+      const iconSlot = el.querySelector(".wt-card-icon-slot") as HTMLElement;
+      expect(iconSlot).not.toBeNull();
+      expect(iconSlot.style.display).toBe("none");
+    });
+
+    it("does not render meta row in compact mode", () => {
+      const item = makeItem({
+        metadata: {
+          source: { type: "jira", id: "PROJ-123" },
+          priority: { score: 50 },
+          goal: ["Ship Feature"],
+        },
+      });
+      const ctx = makeContext();
+      const card = new TaskCard();
+
+      const el = card.render(item, ctx, "compact");
+
+      expect(el.querySelector(".wt-card-meta")).toBeNull();
+      expect(el.querySelector(".wt-card-source")).toBeNull();
+      expect(el.querySelector(".wt-card-score")).toBeNull();
+      expect(el.querySelector(".wt-card-goal")).toBeNull();
+    });
+
+    it("renders Jira indicator dot with blue color and tooltip", () => {
+      const item = makeItem({
+        metadata: {
+          source: { type: "jira", id: "CASTLE-1234" },
+        },
+      });
+      const ctx = makeContext();
+      const card = new TaskCard();
+
+      const el = card.render(item, ctx, "compact");
+
+      const jiraDot = el.querySelector(".wt-compact-dot--jira") as HTMLElement;
+      expect(jiraDot).not.toBeNull();
+      expect(jiraDot.title).toBe("CASTLE-1234");
+    });
+
+    it("renders priority indicator dot with correct tier class", () => {
+      const highItem = makeItem({
+        metadata: { priority: { score: 75 } },
+      });
+      const ctx = makeContext();
+      const card = new TaskCard();
+
+      const highEl = card.render(highItem, ctx, "compact");
+      expect(highEl.querySelector(".wt-compact-dot--priority-high")).not.toBeNull();
+      expect(highEl.querySelector(".wt-compact-dot--priority-high")!.getAttribute("title")).toBe(
+        "Priority: 75",
+      );
+
+      const medItem = makeItem({
+        metadata: { priority: { score: 40 } },
+      });
+      const medEl = card.render(medItem, ctx, "compact");
+      expect(medEl.querySelector(".wt-compact-dot--priority-medium")).not.toBeNull();
+
+      const lowItem = makeItem({
+        metadata: { priority: { score: 10 } },
+      });
+      const lowEl = card.render(lowItem, ctx, "compact");
+      expect(lowEl.querySelector(".wt-compact-dot--priority-low")).not.toBeNull();
+    });
+
+    it("does not render priority dot when score is 0", () => {
+      const item = makeItem({
+        metadata: { priority: { score: 0 } },
+      });
+      const ctx = makeContext();
+      const card = new TaskCard();
+
+      const el = card.render(item, ctx, "compact");
+      const dots = el.querySelectorAll(".wt-compact-dot");
+      const priorityDots = Array.from(dots).filter(
+        (d) =>
+          d.classList.contains("wt-compact-dot--priority-high") ||
+          d.classList.contains("wt-compact-dot--priority-medium") ||
+          d.classList.contains("wt-compact-dot--priority-low"),
+      );
+
+      expect(priorityDots.length).toBe(0);
+    });
+
+    it("renders goal indicator dot with tooltip", () => {
+      const item = makeItem({
+        metadata: {
+          goal: ["[[Ship Feature|My Goal]]"],
+        },
+      });
+      const ctx = makeContext();
+      const card = new TaskCard();
+
+      const el = card.render(item, ctx, "compact");
+
+      const goalDot = el.querySelector(".wt-compact-dot--goal") as HTMLElement;
+      expect(goalDot).not.toBeNull();
+      expect(goalDot.title).toBe("My Goal");
+    });
+
+    it("renders flag indicator dots with flag color and tooltip", () => {
+      const rules: CardFlagRule[] = [
+        {
+          field: "priority.has-blocker",
+          value: true,
+          label: "BLOCKED",
+          style: "badge",
+          color: "#e5484d",
+          tooltip: "{{priority.blocker-context}}",
+        },
+      ];
+      const item = makeItem({
+        metadata: {
+          priority: {
+            "has-blocker": true,
+            "blocker-context": "waiting on deploy",
+          },
+        },
+      });
+      const ctx = makeContext();
+      const card = new TaskCard(rules);
+
+      const el = card.render(item, ctx, "compact");
+
+      const flagDot = el.querySelector(".wt-compact-dot--flag") as HTMLElement;
+      expect(flagDot).not.toBeNull();
+      expect(flagDot.style.backgroundColor).toBe("rgb(229, 72, 77)");
+      expect(flagDot.title).toBe("waiting on deploy");
+    });
+
+    it("renders no dots for a plain task with no metadata", () => {
+      const item = makeItem({ metadata: {} });
+      const ctx = makeContext();
+      const card = new TaskCard();
+
+      const el = card.render(item, ctx, "compact");
+
+      const dots = el.querySelectorAll(".wt-compact-dot");
+      expect(dots.length).toBe(0);
+    });
+
+    it("renders actions container inside compact row for framework badges", () => {
+      const item = makeItem();
+      const ctx = makeContext();
+      const card = new TaskCard();
+
+      const el = card.render(item, ctx, "compact");
+
+      const actions = el.querySelector(".wt-card-compact-row .wt-card-actions");
+      expect(actions).not.toBeNull();
+    });
+
+    it("sets title attribute on compact title for tooltip on hover", () => {
+      const item = makeItem({ title: "A very long task title that would be truncated" });
+      const ctx = makeContext();
+      const card = new TaskCard();
+
+      const el = card.render(item, ctx, "compact");
+
+      const title = el.querySelector(".wt-card-compact-title") as HTMLElement;
+      expect(title.getAttribute("title")).toBe("A very long task title that would be truncated");
+    });
+  });
 });

--- a/src/adapters/task-agent/TaskCard.ts
+++ b/src/adapters/task-agent/TaskCard.ts
@@ -4,6 +4,7 @@ import type {
   CardRenderer,
   CardActionContext,
   CardFlagRule,
+  CardDisplayMode,
 } from "../../core/interfaces";
 import { matchCardFlags, type MatchedCardFlag } from "../../core/cardFlags";
 import { normalizeObsidianDisplayText } from "../../core/utils";
@@ -21,7 +22,7 @@ export class TaskCard implements CardRenderer {
     this.flagRules = rules;
   }
 
-  render(item: WorkItem, ctx: CardActionContext): HTMLElement {
+  render(item: WorkItem, ctx: CardActionContext, displayMode?: CardDisplayMode): HTMLElement {
     const meta = (item.metadata || {}) as Record<string, any>;
     const source = meta.source || { type: "other" };
     const priority = meta.priority || { score: 0 };
@@ -39,8 +40,54 @@ export class TaskCard implements CardRenderer {
       card.style.setProperty("--wt-task-color", taskColor);
     }
 
+    if (displayMode === "compact") {
+      card.addClass("wt-card-compact");
+      this.renderCompact(card, item, meta, source, priority, goal);
+    } else {
+      this.renderStandard(card, item, meta, source, priority, goal, ingesting);
+    }
+
+    // Click to select
+    card.addEventListener("click", (e) => {
+      e.stopPropagation();
+      ctx.onSelect();
+    });
+
+    // Drag events
+    card.addEventListener("dragstart", (e) => {
+      card.addClass("dragging");
+      e.dataTransfer?.setData("text/plain", item.path);
+      if (e.dataTransfer) {
+        e.dataTransfer.effectAllowed = "move";
+      }
+    });
+
+    card.addEventListener("dragend", () => {
+      card.removeClass("dragging");
+    });
+
+    return card;
+  }
+
+  /**
+   * Render the standard multi-line card layout with full badges and metadata.
+   */
+  private renderStandard(
+    card: HTMLElement,
+    item: WorkItem,
+    meta: Record<string, any>,
+    source: Record<string, any>,
+    priority: Record<string, any>,
+    goal: string[],
+    ingesting: boolean,
+  ): void {
     // Title row
     const titleRow = card.createDiv({ cls: "wt-card-title-row" });
+
+    // TODO(icons): Render item icon in this slot when icon support is implemented
+    const iconSlot = titleRow.createDiv({ cls: "wt-card-icon-slot" });
+    iconSlot.style.display = "none";
+
     const titleEl = titleRow.createDiv({ cls: "wt-card-title" });
     titleEl.textContent = item.title;
 
@@ -101,27 +148,84 @@ export class TaskCard implements CardRenderer {
     for (const flag of matchedFlags) {
       this.renderFlag(metaRow, card, flag);
     }
+  }
 
-    // Click to select
-    card.addEventListener("click", (e) => {
-      e.stopPropagation();
-      ctx.onSelect();
-    });
+  /**
+   * Render a compact single-line card layout with indicator dots replacing
+   * verbose badges.
+   */
+  private renderCompact(
+    card: HTMLElement,
+    item: WorkItem,
+    meta: Record<string, any>,
+    source: Record<string, any>,
+    priority: Record<string, any>,
+    goal: string[],
+  ): void {
+    const compactRow = card.createDiv({ cls: "wt-card-compact-row" });
 
-    // Drag events
-    card.addEventListener("dragstart", (e) => {
-      card.addClass("dragging");
-      e.dataTransfer?.setData("text/plain", item.path);
-      if (e.dataTransfer) {
-        e.dataTransfer.effectAllowed = "move";
+    // TODO(icons): Render item icon in this slot when icon support is implemented
+    const iconSlot = compactRow.createDiv({ cls: "wt-card-icon-slot" });
+    iconSlot.style.display = "none";
+
+    // Title - single line with ellipsis truncation
+    const titleEl = compactRow.createDiv({ cls: "wt-card-compact-title" });
+    titleEl.textContent = item.title;
+    titleEl.title = item.title;
+
+    // Indicator dots container
+    const dotsEl = compactRow.createDiv({ cls: "wt-card-compact-dots" });
+    this.renderIndicatorDots(dotsEl, meta, source, priority, goal);
+
+    // Actions container (session badge + move-to-top added by framework)
+    compactRow.createDiv({ cls: "wt-card-actions" });
+  }
+
+  /**
+   * Render coloured indicator dots for compact mode. Each dot replaces a
+   * verbose badge with a small coloured circle and tooltip.
+   */
+  private renderIndicatorDots(
+    container: HTMLElement,
+    meta: Record<string, any>,
+    source: Record<string, any>,
+    priority: Record<string, any>,
+    goal: string[],
+  ): void {
+    // Jira source dot
+    if (source.type === "jira" && source.id) {
+      const dot = container.createSpan({ cls: "wt-compact-dot wt-compact-dot--jira" });
+      dot.title = source.id.toUpperCase();
+    }
+
+    // Priority score dot
+    if (priority.score > 0) {
+      const tierClass =
+        priority.score >= 60
+          ? "wt-compact-dot--priority-high"
+          : priority.score >= 30
+            ? "wt-compact-dot--priority-medium"
+            : "wt-compact-dot--priority-low";
+      const dot = container.createSpan({ cls: `wt-compact-dot ${tierClass}` });
+      dot.title = `Priority: ${priority.score}`;
+    }
+
+    // Goal dot
+    if (goal.length > 0) {
+      const displayGoal = normalizeObsidianDisplayText(goal[0]);
+      const dot = container.createSpan({ cls: "wt-compact-dot wt-compact-dot--goal" });
+      dot.title = displayGoal.replace(/-/g, " ");
+    }
+
+    // Card flag dots
+    const matchedFlags = matchCardFlags(this.flagRules, meta);
+    for (const flag of matchedFlags) {
+      const dot = container.createSpan({ cls: "wt-compact-dot wt-compact-dot--flag" });
+      if (flag.color) {
+        dot.style.backgroundColor = flag.color;
       }
-    });
-
-    card.addEventListener("dragend", () => {
-      card.removeClass("dragging");
-    });
-
-    return card;
+      dot.title = flag.tooltip || flag.label;
+    }
   }
 
   /**

--- a/src/adapters/task-agent/TaskCard.ts
+++ b/src/adapters/task-agent/TaskCard.ts
@@ -194,8 +194,11 @@ export class TaskCard implements CardRenderer {
   ): void {
     // Jira source dot
     if (source.type === "jira" && source.id) {
+      const label = source.id.toUpperCase();
       const dot = container.createSpan({ cls: "wt-compact-dot wt-compact-dot--jira" });
-      dot.title = source.id.toUpperCase();
+      dot.title = label;
+      dot.setAttribute("role", "img");
+      dot.setAttribute("aria-label", label);
     }
 
     // Priority score dot
@@ -206,25 +209,33 @@ export class TaskCard implements CardRenderer {
           : priority.score >= 30
             ? "wt-compact-dot--priority-medium"
             : "wt-compact-dot--priority-low";
+      const label = `Priority: ${priority.score}`;
       const dot = container.createSpan({ cls: `wt-compact-dot ${tierClass}` });
-      dot.title = `Priority: ${priority.score}`;
+      dot.title = label;
+      dot.setAttribute("role", "img");
+      dot.setAttribute("aria-label", label);
     }
 
     // Goal dot
     if (goal.length > 0) {
-      const displayGoal = normalizeObsidianDisplayText(goal[0]);
+      const label = normalizeObsidianDisplayText(goal[0]).replace(/-/g, " ");
       const dot = container.createSpan({ cls: "wt-compact-dot wt-compact-dot--goal" });
-      dot.title = displayGoal.replace(/-/g, " ");
+      dot.title = label;
+      dot.setAttribute("role", "img");
+      dot.setAttribute("aria-label", label);
     }
 
     // Card flag dots
     const matchedFlags = matchCardFlags(this.flagRules, meta);
     for (const flag of matchedFlags) {
+      const label = flag.tooltip || flag.label;
       const dot = container.createSpan({ cls: "wt-compact-dot wt-compact-dot--flag" });
       if (flag.color) {
         dot.style.backgroundColor = flag.color;
       }
-      dot.title = flag.tooltip || flag.label;
+      dot.title = label;
+      dot.setAttribute("role", "img");
+      dot.setAttribute("aria-label", label);
     }
   }
 

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -222,6 +222,9 @@ export interface CardActionContext {
   isPinned?(): boolean;
 }
 
+/** Display mode for card rendering. */
+export type CardDisplayMode = "standard" | "compact";
+
 /**
  * Renders a work item as a DOM card element and provides context menu items.
  * Adapters control the visual appearance of cards (badges, icons, layout)
@@ -229,7 +232,7 @@ export interface CardActionContext {
  */
 export interface CardRenderer {
   /** Create the card DOM element for a work item. */
-  render(item: WorkItem, ctx: CardActionContext): HTMLElement;
+  render(item: WorkItem, ctx: CardActionContext, displayMode?: CardDisplayMode): HTMLElement;
   /** Return context menu items for right-click on a card. */
   getContextMenuItems(item: WorkItem, ctx: CardActionContext): MenuItem[];
 }

--- a/src/framework/ListPanel.test.ts
+++ b/src/framework/ListPanel.test.ts
@@ -980,4 +980,98 @@ describe("ListPanel", () => {
       expect(card2.style.display).toBe("");
     });
   });
+
+  describe("compact display mode", () => {
+    it("adds wt-compact class to list panel when cardDisplayMode is compact", () => {
+      const { panel } = createListPanel({
+        settings: { "core.cardDisplayMode": "compact" },
+      });
+      panel.render({ todo: [makeItem("task-1")] }, {});
+
+      const listEl = document.querySelector(".wt-list-panel") as HTMLElement;
+      expect(listEl.classList.contains("wt-compact")).toBe(true);
+    });
+
+    it("does not add wt-compact class when cardDisplayMode is standard", () => {
+      const { panel } = createListPanel({
+        settings: { "core.cardDisplayMode": "standard" },
+      });
+      panel.render({ todo: [makeItem("task-1")] }, {});
+
+      const listEl = document.querySelector(".wt-list-panel") as HTMLElement;
+      expect(listEl.classList.contains("wt-compact")).toBe(false);
+    });
+
+    it("does not add wt-compact class when cardDisplayMode is not set", () => {
+      const { panel } = createListPanel({
+        settings: {},
+      });
+      panel.render({ todo: [makeItem("task-1")] }, {});
+
+      const listEl = document.querySelector(".wt-list-panel") as HTMLElement;
+      expect(listEl.classList.contains("wt-compact")).toBe(false);
+    });
+
+    it("removes wt-compact class when mode changes from compact to standard", () => {
+      const settings: Record<string, any> = { "core.cardDisplayMode": "compact" };
+      const { panel } = createListPanel({ settings });
+
+      panel.render({ todo: [makeItem("task-1")] }, {});
+      const listEl = document.querySelector(".wt-list-panel") as HTMLElement;
+      expect(listEl.classList.contains("wt-compact")).toBe(true);
+
+      // Simulate settings change
+      settings["core.cardDisplayMode"] = "standard";
+      panel.render({ todo: [makeItem("task-1")] }, {});
+
+      expect(listEl.classList.contains("wt-compact")).toBe(false);
+    });
+
+    it("passes displayMode to card renderer", () => {
+      const renderSpy = vi.fn((item: WorkItem) => {
+        const el = document.createElement("div");
+        el.createDiv({ cls: "wt-card-actions" });
+        return el;
+      });
+
+      const { panel, parentEl } = createListPanel({
+        settings: { "core.cardDisplayMode": "compact" },
+      });
+
+      // Replace the card renderer's render with a spy to verify the displayMode argument
+      const cardRenderer = (panel as any).cardRenderer;
+      cardRenderer.render = renderSpy;
+
+      panel.render({ todo: [makeItem("task-1")] }, {});
+
+      expect(renderSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "task-1" }),
+        expect.anything(),
+        "compact",
+      );
+    });
+
+    it("passes standard displayMode to card renderer when not compact", () => {
+      const renderSpy = vi.fn((item: WorkItem) => {
+        const el = document.createElement("div");
+        el.createDiv({ cls: "wt-card-actions" });
+        return el;
+      });
+
+      const { panel } = createListPanel({
+        settings: { "core.cardDisplayMode": "standard" },
+      });
+
+      const cardRenderer = (panel as any).cardRenderer;
+      cardRenderer.render = renderSpy;
+
+      panel.render({ todo: [makeItem("task-1")] }, {});
+
+      expect(renderSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "task-1" }),
+        expect.anything(),
+        "standard",
+      );
+    });
+  });
 });

--- a/src/framework/ListPanel.test.ts
+++ b/src/framework/ListPanel.test.ts
@@ -1034,7 +1034,7 @@ describe("ListPanel", () => {
         return el;
       });
 
-      const { panel, parentEl } = createListPanel({
+      const { panel } = createListPanel({
         settings: { "core.cardDisplayMode": "compact" },
       });
 

--- a/src/framework/ListPanel.ts
+++ b/src/framework/ListPanel.ts
@@ -12,6 +12,7 @@ import type {
   WorkItemMover,
   WorkItemParser,
   CardActionContext,
+  CardDisplayMode,
 } from "../core/interfaces";
 import type { TerminalPanelView } from "./TerminalPanelView";
 import type { PinStore } from "../core/PinStore";
@@ -149,6 +150,11 @@ export class ListPanel {
   // Rendering
   // ---------------------------------------------------------------------------
 
+  /** Resolve the current card display mode from settings. */
+  private getDisplayMode(): CardDisplayMode {
+    return (this.settings["core.cardDisplayMode"] as CardDisplayMode) || "standard";
+  }
+
   render(groups: Record<string, WorkItem[]>, customOrder: Record<string, string[]>): void {
     this.groups = groups;
     this.customOrder = customOrder;
@@ -160,6 +166,14 @@ export class ListPanel {
     }
 
     this.listEl.empty();
+
+    // Apply compact mode class to list panel container
+    const displayMode = this.getDisplayMode();
+    if (displayMode === "compact") {
+      this.listEl.addClass("wt-compact");
+    } else {
+      this.listEl.removeClass("wt-compact");
+    }
 
     // Collect pinned item IDs and build a lookup of all items by ID
     const pinnedIds = this.pinStore?.getPinnedIds() ?? [];
@@ -273,12 +287,14 @@ export class ListPanel {
     // Drop zone for drag-drop
     this.setupDropZone(cardsEl, sectionEl, headerEl, columnId);
 
+    const displayMode = this.getDisplayMode();
+
     for (const item of items) {
       // For pinned items, use the pinned column as the visual column
       // but track the real column for move operations
       const effectiveColumn = isPinnedSection ? PINNED_COLUMN_ID : columnId;
       const ctx = this.buildCardActionContext(item, effectiveColumn);
-      const cardEl = this.cardRenderer.render(item, ctx);
+      const cardEl = this.cardRenderer.render(item, ctx, displayMode);
       cardEl.addClass("wt-card-wrapper");
       cardEl.setAttribute("data-item-id", item.id);
       cardEl.setAttribute("draggable", "true");

--- a/src/framework/ListPanel.ts
+++ b/src/framework/ListPanel.ts
@@ -152,7 +152,8 @@ export class ListPanel {
 
   /** Resolve the current card display mode from settings. */
   private getDisplayMode(): CardDisplayMode {
-    return (this.settings["core.cardDisplayMode"] as CardDisplayMode) || "standard";
+    const value = this.settings["core.cardDisplayMode"];
+    return value === "compact" ? "compact" : "standard";
   }
 
   render(groups: Record<string, WorkItem[]>, customOrder: Record<string, string[]>): void {
@@ -309,10 +310,13 @@ export class ListPanel {
         stateBadge.addClass("wt-card-state-badge", `wt-state-badge-${stateSlug}`);
         stateBadge.textContent = stateLabel;
         stateBadge.title = `Real state: ${stateLabel}`;
-        // Insert badge into the meta row if available, otherwise into the card
+        // Insert badge into the meta row, compact dots container, or card root
         const metaRow = cardEl.querySelector(".wt-card-meta");
+        const compactDots = cardEl.querySelector(".wt-card-compact-dots");
         if (metaRow) {
           metaRow.insertBefore(stateBadge, metaRow.firstChild);
+        } else if (compactDots) {
+          compactDots.insertBefore(stateBadge, compactDots.firstChild);
         } else {
           cardEl.appendChild(stateBadge);
         }

--- a/src/framework/ProfileLaunchModal.test.ts
+++ b/src/framework/ProfileLaunchModal.test.ts
@@ -350,15 +350,7 @@ describe("ProfileLaunchModal placeholders", () => {
 
 describe("ProfileLaunchModal settings link", () => {
   function createModalWithSettings(profiles: AgentProfile[], onOpenSettings?: () => void) {
-    const modal = new ProfileLaunchModal(
-      {} as any,
-      profiles,
-      "/vault",
-      vi.fn(),
-      [],
-      undefined,
-      onOpenSettings,
-    );
+    const modal = new ProfileLaunchModal({} as any, profiles, "/vault", vi.fn(), onOpenSettings);
     modal.open();
     return modal;
   }

--- a/src/framework/ProfileLaunchModal.ts
+++ b/src/framework/ProfileLaunchModal.ts
@@ -24,8 +24,6 @@ export class ProfileLaunchModal extends Modal {
     private profiles: AgentProfile[],
     private defaultCwd: string,
     private onSubmit: (overrides: ProfileLaunchOverrides) => void,
-    _closedSessions?: unknown,
-    _onRestore?: unknown,
     private onOpenSettings?: () => void,
   ) {
     super(app);

--- a/src/framework/SettingsTab.test.ts
+++ b/src/framework/SettingsTab.test.ts
@@ -150,6 +150,36 @@ vi.mock("obsidian", () => {
       callback(button);
       return this;
     }
+
+    addDropdown(
+      callback: (dropdown: {
+        addOption: (value: string, label: string) => any;
+        setValue: (value: string) => any;
+        onChange: (handler: (value: string) => void) => any;
+      }) => void,
+    ) {
+      const selectEl = document.createElement("select");
+      this.controlEl.appendChild(selectEl);
+      const dropdown = {
+        addOption(value: string, label: string) {
+          const option = document.createElement("option");
+          option.value = value;
+          option.textContent = label;
+          selectEl.appendChild(option);
+          return dropdown;
+        },
+        setValue(value: string) {
+          selectEl.value = value;
+          return dropdown;
+        },
+        onChange(handler: (value: string) => void) {
+          selectEl.addEventListener("change", () => handler(selectEl.value));
+          return dropdown;
+        },
+      };
+      callback(dropdown);
+      return this;
+    }
   }
 
   class Modal {

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -29,6 +29,7 @@ interface CoreSettings {
   "core.defaultTerminalCwd": string;
   "core.exposeDebugApi": boolean;
   "core.keepSessionsAlive": boolean;
+  "core.cardDisplayMode": string;
 }
 
 export const SETTINGS_CHANGED_EVENT = "work-terminal:settings-changed";
@@ -45,6 +46,7 @@ const CORE_DEFAULTS: CoreSettings = {
   "core.defaultTerminalCwd": "~",
   "core.exposeDebugApi": false,
   "core.keepSessionsAlive": true,
+  "core.cardDisplayMode": "standard",
 };
 
 export class WorkTerminalSettingsTab extends PluginSettingTab {
@@ -121,6 +123,14 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
       "Keep sessions alive when tab is closed",
       "Stash terminal sessions to memory instead of killing them when the Work Terminal tab is closed. Reopening the tab restores sessions with full PTY state.",
     );
+    this.addCoreDropdown(
+      containerEl,
+      "core.cardDisplayMode",
+      "Card display mode",
+      "Standard shows full card details. Compact shows single-line cards with indicator dots replacing verbose badges.",
+      { standard: "Standard", compact: "Compact" },
+    );
+
     this.addCoreToggle(
       containerEl,
       "core.exposeDebugApi",
@@ -226,6 +236,32 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
     if (tourId) {
       setting.settingEl.setAttribute("data-wt-tour", tourId);
     }
+  }
+
+  private async addCoreDropdown(
+    containerEl: HTMLElement,
+    key: keyof CoreSettings,
+    name: string,
+    description: string,
+    choices: Record<string, string>,
+  ): Promise<void> {
+    const data = (await this.plugin.loadData()) || {};
+    const settings = data.settings || {};
+    const value = settings[key] ?? CORE_DEFAULTS[key];
+
+    new Setting(containerEl)
+      .setName(name)
+      .setDesc(description)
+      .addDropdown((dropdown) => {
+        for (const [val, label] of Object.entries(choices)) {
+          dropdown.addOption(val, label);
+        }
+        dropdown.setValue(String(value || "")).onChange(async (newValue) => {
+          await this.saveSettings((settings) => {
+            settings[key] = newValue;
+          });
+        });
+      });
   }
 
   private async addCardFlagRulesButton(containerEl: HTMLElement): Promise<void> {

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -29,7 +29,7 @@ interface CoreSettings {
   "core.defaultTerminalCwd": string;
   "core.exposeDebugApi": boolean;
   "core.keepSessionsAlive": boolean;
-  "core.cardDisplayMode": string;
+  "core.cardDisplayMode": "standard" | "compact";
 }
 
 export const SETTINGS_CHANGED_EVENT = "work-terminal:settings-changed";

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -1084,8 +1084,6 @@ export class TerminalPanelView {
       (overrides) => {
         this.launchAction("profile launch", () => this.spawnFromProfileWithOverrides(overrides));
       },
-      undefined,
-      undefined,
       () => {
         (this.plugin.app as any).setting.open();
         (this.plugin.app as any).setting.openTabById(this.plugin.manifest.id);

--- a/styles.css
+++ b/styles.css
@@ -2005,3 +2005,137 @@ button.wt-spawn-claude-ctx:hover svg {
   margin: 0;
   flex-shrink: 0;
 }
+
+/* =============================================================================
+   Compact card display mode
+   ============================================================================= */
+
+/* Icon slot placeholder - hidden by default, present in DOM for future use */
+.wt-card-icon-slot {
+  width: 0;
+  height: 0;
+  flex-shrink: 0;
+}
+
+/* Compact card wrapper overrides */
+.wt-compact .wt-card-wrapper {
+  --wt-card-padding-y: 2px;
+}
+
+/* Compact card inner layout: single horizontal row */
+.wt-card-compact-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+/* Compact title: single line, truncated */
+.wt-card-compact-title {
+  flex: 1;
+  min-width: 0;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+/* Compact actions container: positioned inline, not absolute */
+.wt-card-compact-row .wt-card-actions {
+  position: static;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+/* Indicator dots container */
+.wt-card-compact-dots {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
+/* Base indicator dot style */
+.wt-compact-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* Jira source dot - blue */
+.wt-compact-dot--jira {
+  background-color: #0062e3;
+}
+
+/* Priority score dots */
+.wt-compact-dot--priority-high {
+  background-color: #e53e3e;
+}
+
+.wt-compact-dot--priority-medium {
+  background-color: #d69e2e;
+}
+
+.wt-compact-dot--priority-low {
+  background-color: #a0aec0;
+}
+
+/* Goal dot - green */
+.wt-compact-dot--goal {
+  background-color: #38a169;
+}
+
+/* Flag dot - uses inline background-color from flag.color */
+.wt-compact-dot--flag {
+  background-color: #e53e3e;
+}
+
+/* Compact mode: drop indicator thinner */
+.wt-compact .wt-drop-indicator {
+  height: 1px;
+  margin: 0 4px;
+}
+
+/* Compact mode: move-to-top smaller */
+.wt-compact .wt-move-to-top {
+  width: 16px;
+  height: 16px;
+  font-size: 10px;
+}
+
+/* Compact mode: session badge slightly smaller */
+.wt-compact .wt-session-badge {
+  min-width: 16px;
+  height: 16px;
+  font-size: 9px;
+  padding: 0 3px;
+}
+
+/* Compact mode: pinned state badge adapts to single-line height */
+.wt-compact .wt-card-state-badge {
+  font-size: 8px;
+  padding: 0 3px;
+}
+
+/* Compact mode: agent state waiting overlay adapts */
+.wt-compact .wt-card-wrapper.wt-agent-waiting::after {
+  border-radius: inherit;
+}
+
+/* Compact mode: agent state active arc on badge */
+.wt-compact .wt-agent-active .wt-session-badge::before {
+  inset: -2px;
+  border-radius: 10px;
+}
+
+/* Compact mode: agent state idle arc on badge */
+.wt-compact .wt-agent-idle .wt-session-badge::before {
+  inset: -2px;
+  border-radius: 10px;
+}


### PR DESCRIPTION
## Summary

- Add optional compact display mode that collapses task cards into single-line rows with indicator dots replacing verbose badges
- New "Card display mode" dropdown in core settings (standard/compact), persisted across reloads
- Indicator dots: blue (Jira), orange/red (priority tiers), green (goal), per-flag colour (card flags) - all with tooltips
- Icon slot placeholder in DOM (hidden) for future icon feature with TODO comments
- CSS adaptations for compact mode: reduced padding, thinner drop indicators, smaller session badges and agent state arcs

## Test plan

- [x] 21 new tests covering ListPanel compact class toggling and TaskCard compact rendering
- [x] All 1025 tests pass
- [x] Build succeeds with no type errors
- [x] User guide updated with compact mode documentation and core settings table entry

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)