### PR TITLE
fix: remove dead persistSessions calls left by #410

### DIFF
--- a/src/framework/MainView.test.ts
+++ b/src/framework/MainView.test.ts
@@ -99,7 +99,10 @@ describe("MainView selection ID backfill", () => {
       getCustomOrder: vi.fn(() => ({ active: [updatedItem.id] })),
       selectById: vi.fn(),
     };
-    const terminalPanel: Pick<TerminalPanelView, 'getActiveItemId' | 'rekeyItem' | 'setActiveItem' | 'setTitle'> = {
+    const terminalPanel: Pick<
+      TerminalPanelView,
+      "getActiveItemId" | "rekeyItem" | "setActiveItem" | "setTitle"
+    > = {
       getActiveItemId: vi.fn(() => item.id),
       rekeyItem: vi.fn(),
       setActiveItem: vi.fn(),
@@ -135,7 +138,10 @@ describe("MainView selection ID backfill", () => {
       rekeyCustomOrder: vi.fn(() => false),
       selectById: vi.fn(),
     };
-    const terminalPanel: Pick<TerminalPanelView, 'getActiveItemId' | 'rekeyItem' | 'setActiveItem' | 'setTitle'> = {
+    const terminalPanel: Pick<
+      TerminalPanelView,
+      "getActiveItemId" | "rekeyItem" | "setActiveItem" | "setTitle"
+    > = {
       getActiveItemId: vi.fn(() => "different-item"),
       rekeyItem: vi.fn(),
       setActiveItem: vi.fn(),
@@ -168,7 +174,7 @@ describe("MainView selection ID backfill", () => {
       rekeyCustomOrder: vi.fn(() => true),
       getCustomOrder: vi.fn(() => ({ active: ["uuid-123"] })),
     };
-    const terminalPanel: Pick<TerminalPanelView, 'rekeyItem'> = {
+    const terminalPanel: Pick<TerminalPanelView, "rekeyItem"> = {
       rekeyItem: vi.fn(),
     };
 
@@ -209,7 +215,7 @@ describe("MainView selection ID backfill", () => {
       rekeyCustomOrder: vi.fn(() => true),
       getCustomOrder: vi.fn(() => ({ todo: ["uuid-123"] })),
     };
-    const terminalPanel: Pick<TerminalPanelView, 'rekeyItem'> = {
+    const terminalPanel: Pick<TerminalPanelView, "rekeyItem"> = {
       rekeyItem: vi.fn(),
     };
 
@@ -257,7 +263,7 @@ describe("MainView selection ID backfill", () => {
       loadAll: vi.fn().mockResolvedValue([]),
       groupByColumn: vi.fn(() => ({ todo: [] })),
     };
-    const terminalPanel: Pick<TerminalPanelView, 'rekeyItem' | 'setItems'> = {
+    const terminalPanel: Pick<TerminalPanelView, "rekeyItem" | "setItems"> = {
       rekeyItem: vi.fn(),
       setItems: vi.fn(),
     };
@@ -301,7 +307,10 @@ describe("MainView stash-on-close (keepSessionsAlive)", () => {
     return view;
   }
 
-  function makeTerminalPanel(): Pick<TerminalPanelView, 'stashAll' | 'disposeAll' | 'hasAnySessions'> {
+  function makeTerminalPanel(): Pick<
+    TerminalPanelView,
+    "stashAll" | "disposeAll" | "hasAnySessions"
+  > {
     return {
       stashAll: vi.fn(),
       disposeAll: vi.fn(),

--- a/src/framework/MainView.test.ts
+++ b/src/framework/MainView.test.ts
@@ -3,6 +3,7 @@ import { JSDOM } from "jsdom";
 import { TFile } from "obsidian";
 import type { WorkItem } from "../core/interfaces";
 import { mergeAndSavePluginData } from "../core/PluginDataStore";
+import type { TerminalPanelView } from "./TerminalPanelView";
 
 vi.mock("obsidian", () => ({
   ItemView: class {
@@ -98,10 +99,9 @@ describe("MainView selection ID backfill", () => {
       getCustomOrder: vi.fn(() => ({ active: [updatedItem.id] })),
       selectById: vi.fn(),
     };
-    const terminalPanel = {
+    const terminalPanel: Pick<TerminalPanelView, 'getActiveItemId' | 'rekeyItem' | 'setActiveItem' | 'setTitle'> = {
       getActiveItemId: vi.fn(() => item.id),
       rekeyItem: vi.fn(),
-      persistSessions: vi.fn().mockResolvedValue(undefined),
       setActiveItem: vi.fn(),
       setTitle: vi.fn(),
     };
@@ -118,7 +118,6 @@ describe("MainView selection ID backfill", () => {
     expect(mergeAndSavePluginData).toHaveBeenCalledTimes(1);
     expect(mergeAndSavePluginData).toHaveBeenCalledWith(expect.anything(), expect.any(Function));
     expect(refreshSpy).toHaveBeenCalled();
-    expect(terminalPanel.persistSessions).toHaveBeenCalled();
     expect(listPanel.selectById).toHaveBeenCalledWith(updatedItem.id);
     expect(terminalPanel.setActiveItem).not.toHaveBeenCalled();
     expect(terminalPanel.setTitle).not.toHaveBeenCalled();
@@ -136,10 +135,9 @@ describe("MainView selection ID backfill", () => {
       rekeyCustomOrder: vi.fn(() => false),
       selectById: vi.fn(),
     };
-    const terminalPanel = {
+    const terminalPanel: Pick<TerminalPanelView, 'getActiveItemId' | 'rekeyItem' | 'setActiveItem' | 'setTitle'> = {
       getActiveItemId: vi.fn(() => "different-item"),
       rekeyItem: vi.fn(),
-      persistSessions: vi.fn().mockResolvedValue(undefined),
       setActiveItem: vi.fn(),
       setTitle: vi.fn(),
     };
@@ -154,7 +152,6 @@ describe("MainView selection ID backfill", () => {
     expect(listPanel.rekeyCustomOrder).toHaveBeenCalledWith(item.id, updatedItem.id);
     expect(mergeAndSavePluginData).not.toHaveBeenCalled();
     expect(refreshSpy).toHaveBeenCalled();
-    expect(terminalPanel.persistSessions).toHaveBeenCalled();
     expect(listPanel.selectById).not.toHaveBeenCalled();
     expect(terminalPanel.setActiveItem).not.toHaveBeenCalled();
     expect(terminalPanel.setTitle).not.toHaveBeenCalled();
@@ -171,9 +168,8 @@ describe("MainView selection ID backfill", () => {
       rekeyCustomOrder: vi.fn(() => true),
       getCustomOrder: vi.fn(() => ({ active: ["uuid-123"] })),
     };
-    const terminalPanel = {
+    const terminalPanel: Pick<TerminalPanelView, 'rekeyItem'> = {
       rekeyItem: vi.fn(),
-      persistSessions: vi.fn(),
     };
 
     (view as any).listPanel = listPanel;
@@ -213,9 +209,8 @@ describe("MainView selection ID backfill", () => {
       rekeyCustomOrder: vi.fn(() => true),
       getCustomOrder: vi.fn(() => ({ todo: ["uuid-123"] })),
     };
-    const terminalPanel = {
+    const terminalPanel: Pick<TerminalPanelView, 'rekeyItem'> = {
       rekeyItem: vi.fn(),
-      persistSessions: vi.fn(),
     };
 
     (view as any).listPanel = listPanel;
@@ -262,8 +257,7 @@ describe("MainView selection ID backfill", () => {
       loadAll: vi.fn().mockResolvedValue([]),
       groupByColumn: vi.fn(() => ({ todo: [] })),
     };
-    const terminalPanel = {
-      persistSessions: vi.fn(),
+    const terminalPanel: Pick<TerminalPanelView, 'rekeyItem' | 'setItems'> = {
       rekeyItem: vi.fn(),
       setItems: vi.fn(),
     };
@@ -307,9 +301,8 @@ describe("MainView stash-on-close (keepSessionsAlive)", () => {
     return view;
   }
 
-  function makeTerminalPanel() {
+  function makeTerminalPanel(): Pick<TerminalPanelView, 'stashAll' | 'disposeAll' | 'hasAnySessions'> {
     return {
-      persistSessions: vi.fn().mockResolvedValue(undefined),
       stashAll: vi.fn(),
       disposeAll: vi.fn(),
       hasAnySessions: vi.fn(() => true),
@@ -327,7 +320,6 @@ describe("MainView stash-on-close (keepSessionsAlive)", () => {
 
     await view.onClose();
 
-    expect(terminalPanel.persistSessions).toHaveBeenCalled();
     expect(terminalPanel.stashAll).toHaveBeenCalled();
     expect(terminalPanel.disposeAll).not.toHaveBeenCalled();
   });
@@ -343,7 +335,6 @@ describe("MainView stash-on-close (keepSessionsAlive)", () => {
 
     await view.onClose();
 
-    expect(terminalPanel.persistSessions).toHaveBeenCalled();
     expect(terminalPanel.disposeAll).toHaveBeenCalled();
     expect(terminalPanel.stashAll).not.toHaveBeenCalled();
   });
@@ -378,7 +369,6 @@ describe("MainView stash-on-close (keepSessionsAlive)", () => {
     await view.onClose();
 
     expect(terminalPanel.stashAll).not.toHaveBeenCalled();
-    expect(terminalPanel.persistSessions).toHaveBeenCalled();
   });
 
   it("skips close guard confirmation when keepSessionsAlive is enabled", () => {

--- a/src/framework/MainView.ts
+++ b/src/framework/MainView.ts
@@ -355,8 +355,6 @@ export class MainView extends ItemView {
       // onSessionChange callback
       () => {
         this.listPanel?.updateSessionBadges();
-        // Persist sessions to disk
-        this.terminalPanel?.persistSessions();
       },
       // profileManager
       this.profileManager,
@@ -502,8 +500,6 @@ export class MainView extends ItemView {
     if (this.listPanel?.rekeyCustomOrder(oldPath, newPath)) {
       void this.persistCustomOrder();
     }
-    // Persist updated session paths to disk so they survive a full reload
-    this.terminalPanel?.persistSessions();
   }
 
   private completeRename(oldPath: string, newPath: string): void {
@@ -517,8 +513,6 @@ export class MainView extends ItemView {
       void this.persistCustomOrder();
     }
     this.adapter.rekeyDetailPath?.(oldPath, newPath);
-    // Persist updated session paths to disk so they survive a full reload
-    this.terminalPanel?.persistSessions();
   }
 
   private scheduleRefresh(): void {
@@ -563,7 +557,6 @@ export class MainView extends ItemView {
       await this.persistCustomOrder();
     }
     await this.refreshList();
-    await this.terminalPanel?.persistSessions();
 
     if (!shouldReselect) {
       return;
@@ -656,16 +649,11 @@ export class MainView extends ItemView {
     if (this.pluginRef.isReloading || keepAlive) {
       // Stash sessions to window-global store so PTY processes survive
       // and can be restored when the view is reopened.
-      // Always persist to disk as a fallback (e.g. if Obsidian quits
-      // before the tab is reopened, the window-global stash is lost).
-      await this.terminalPanel?.persistSessions();
       // Only stash if not already stashed (hotReload pre-stashes explicitly)
       if (!SessionStore.isReload()) {
         this.terminalPanel?.stashAll();
       }
     } else {
-      // Persist sessions to disk before disposing so they can be resumed
-      await this.terminalPanel?.persistSessions();
       this.terminalPanel?.disposeAll();
     }
 


### PR DESCRIPTION
## Summary

- Remove 6 dead `persistSessions()` calls in `MainView.ts` left behind by #410
- Fix agent spawn error: `this.terminalPanel?.persistSessions is not a function`
- Fix tab retention on view close/reopen (`stashAll()` was blocked by the error)
- Type test mocks with `Pick<TerminalPanelView, ...>` so non-existent method mocks are compile errors

## Test plan

- [ ] Spawn a Claude+ctx agent session - no error notice
- [ ] Close and reopen the plugin view - tabs retained
- [ ] `pnpm exec vitest run` passes (1025 tests)
- [ ] `pnpm run build` clean

Fixes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)