### PR TITLE
Fix card style setting not triggering re-render

### DIFF
--- a/src/framework/ListPanel.test.ts
+++ b/src/framework/ListPanel.test.ts
@@ -97,7 +97,7 @@ function createListPanel(
     cardClasses?: string[];
     includeMetaRow?: boolean;
     itemName?: string;
-    settings?: Record<string, any>;
+    settings?: Record<string, unknown>;
   } = {},
 ) {
   const parentEl = document.createElement("div") as HTMLElement & {
@@ -1013,7 +1013,7 @@ describe("ListPanel", () => {
     });
 
     it("removes wt-compact class when mode changes from compact to standard", () => {
-      const settings: Record<string, any> = { "core.cardDisplayMode": "compact" };
+      const settings: Record<string, unknown> = { "core.cardDisplayMode": "compact" };
       const { panel } = createListPanel({ settings });
 
       panel.render({ todo: [makeItem("task-1")] }, {});
@@ -1049,6 +1049,28 @@ describe("ListPanel", () => {
         expect.anything(),
         "compact",
       );
+    });
+
+    it("picks up a new settings object via updateSettings on the next render", () => {
+      const { panel } = createListPanel({
+        settings: { "core.cardDisplayMode": "standard" },
+      });
+      panel.render({ todo: [makeItem("task-1")] }, {});
+
+      const listEl = document.querySelector(".wt-list-panel") as HTMLElement;
+      expect(listEl.classList.contains("wt-compact")).toBe(false);
+
+      // MainView replaces the settings object on change
+      panel.updateSettings({ "core.cardDisplayMode": "compact" });
+      panel.render({ todo: [makeItem("task-1")] }, {});
+
+      expect(listEl.classList.contains("wt-compact")).toBe(true);
+
+      // Switch back to standard
+      panel.updateSettings({ "core.cardDisplayMode": "standard" });
+      panel.render({ todo: [makeItem("task-1")] }, {});
+
+      expect(listEl.classList.contains("wt-compact")).toBe(false);
     });
 
     it("passes standard displayMode to card renderer when not compact", () => {

--- a/src/framework/ListPanel.ts
+++ b/src/framework/ListPanel.ts
@@ -137,6 +137,11 @@ export class ListPanel {
     }
   }
 
+  /** Update cached settings (called by MainView when settings change). */
+  updateSettings(settings: Record<string, any>): void {
+    this.settings = settings;
+  }
+
   getParser(): WorkItemParser | null {
     return null; // Parser is owned by MainView, not ListPanel
   }

--- a/src/framework/ListPanel.ts
+++ b/src/framework/ListPanel.ts
@@ -33,7 +33,7 @@ export class ListPanel {
   private plugin: Plugin;
   private terminalPanel: TerminalPanelView;
 
-  private settings: Record<string, any>;
+  private settings: Record<string, unknown>;
   private onSelect: (item: WorkItem | null) => void;
   private onCustomOrderChange: (order: Record<string, string[]>) => void;
   private onSessionFilterChange: (active: boolean) => void;
@@ -73,7 +73,7 @@ export class ListPanel {
     mover: WorkItemMover,
     plugin: Plugin,
     terminalPanel: TerminalPanelView,
-    settings: Record<string, any>,
+    settings: Record<string, unknown>,
     onSelect: (item: WorkItem | null) => void,
     onCustomOrderChange: (order: Record<string, string[]>) => void,
     onSessionFilterChange?: (active: boolean) => void,
@@ -138,7 +138,7 @@ export class ListPanel {
   }
 
   /** Update cached settings (called by MainView when settings change). */
-  updateSettings(settings: Record<string, any>): void {
+  updateSettings(settings: Record<string, unknown>): void {
     this.settings = settings;
   }
 

--- a/src/framework/MainView.ts
+++ b/src/framework/MainView.ts
@@ -79,6 +79,8 @@ export class MainView extends ItemView {
     this.settings = { ...(event as CustomEvent<Record<string, any>>).detail };
     // Notify adapter so it can update internal state (e.g. card flag rules, column order)
     this.adapter.onSettingsChanged?.(this.settings);
+    // Keep ListPanel's cached settings in sync so card display mode etc. take effect
+    this.listPanel?.updateSettings(this.settings);
     // Only rebuild PromptBox creation columns when they actually changed
     const newCreationColumnIds = this.adapter.config.creationColumns;
     if (prevCreationColumnIds !== newCreationColumnIds) {


### PR DESCRIPTION
## Summary

- **Root cause**: `ListPanel` cached its settings at construction time, but `MainView._handleSettingsChanged` never propagated updated settings back to it. When the card display mode was changed in Settings, `ListPanel.getDisplayMode()` still read the stale value, so cards kept the old style until a full plugin reload.
- **Fix**: Added `ListPanel.updateSettings()` method and call it from `MainView._handleSettingsChanged` before scheduling the refresh. This ensures the list panel reads the new card display mode on the next render.

Fixes #417

## Test plan

- [ ] Open Work Terminal with tasks visible
- [ ] Go to Settings > Work Terminal > change Card display mode from Standard to Compact
- [ ] Return to Work Terminal view - cards should immediately show compact style
- [ ] Change back to Standard - cards should immediately revert
- [ ] Verify `pnpm exec vitest run` passes (1025 tests)
- [ ] Verify `pnpm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)