### PR TITLE
fix: re-initialise view on hot reload to prevent blank pane

### DIFF
--- a/src/framework/PluginBase.test.ts
+++ b/src/framework/PluginBase.test.ts
@@ -259,12 +259,12 @@ describe("PluginBase", () => {
   describe("hotReload", () => {
     it("stashes terminal sessions before reloading", async () => {
       const stashAll = vi.fn();
-      const fakeLeaf = { view: { terminalPanel: { stashAll } } };
+      const fakeLeaf = {
+        view: { terminalPanel: { stashAll } },
+        setViewState: vi.fn(() => Promise.resolve()),
+      };
       const app = makeApp();
       (app.workspace.getLeavesOfType as any).mockReturnValue([fakeLeaf]);
-      app.plugins.plugins["work-terminal"] = {
-        activateView: vi.fn(() => Promise.resolve()),
-      };
       const plugin = new TestPlugin(app, makeManifest(), makeAdapter());
       await plugin.hotReload();
       expect(stashAll).toHaveBeenCalledTimes(1);
@@ -281,9 +281,24 @@ describe("PluginBase", () => {
       expect(app.plugins.enablePlugin).toHaveBeenCalledWith("work-terminal");
     });
 
-    it("calls activateView on the new plugin instance after reload", async () => {
+    it("re-initialises existing leaf via setViewState instead of activateView", async () => {
+      const setViewState = vi.fn(() => Promise.resolve());
+      const fakeLeaf = { view: {}, setViewState };
       const newActivateView = vi.fn(() => Promise.resolve());
       const app = makeApp();
+      (app.workspace.getLeavesOfType as any).mockReturnValue([fakeLeaf]);
+      app.plugins.plugins["work-terminal"] = { activateView: newActivateView };
+      const plugin = new TestPlugin(app, makeManifest(), makeAdapter());
+      await plugin.hotReload();
+      expect(setViewState).toHaveBeenCalledWith({ type: VIEW_TYPE, active: true });
+      expect(app.workspace.revealLeaf).toHaveBeenCalledWith(fakeLeaf);
+      expect(newActivateView).not.toHaveBeenCalled();
+    });
+
+    it("falls back to activateView when no existing leaf is found", async () => {
+      const newActivateView = vi.fn(() => Promise.resolve());
+      const app = makeApp();
+      (app.workspace.getLeavesOfType as any).mockReturnValue([]);
       app.plugins.plugins["work-terminal"] = { activateView: newActivateView };
       const plugin = new TestPlugin(app, makeManifest(), makeAdapter());
       await plugin.hotReload();
@@ -291,7 +306,7 @@ describe("PluginBase", () => {
     });
 
     it("tolerates missing terminalPanel gracefully", async () => {
-      const fakeLeaf = { view: {} };
+      const fakeLeaf = { view: {}, setViewState: vi.fn(() => Promise.resolve()) };
       const app = makeApp();
       (app.workspace.getLeavesOfType as any).mockReturnValue([fakeLeaf]);
       app.plugins.plugins["work-terminal"] = { activateView: vi.fn(() => Promise.resolve()) };

--- a/src/framework/PluginBase.test.ts
+++ b/src/framework/PluginBase.test.ts
@@ -305,6 +305,23 @@ describe("PluginBase", () => {
       expect(newActivateView).toHaveBeenCalledTimes(1);
     });
 
+    it("re-initialises all existing leaves when multiple are open", async () => {
+      const setViewStateA = vi.fn(() => Promise.resolve());
+      const setViewStateB = vi.fn(() => Promise.resolve());
+      const leafA = { view: {}, setViewState: setViewStateA };
+      const leafB = { view: {}, setViewState: setViewStateB };
+      const newActivateView = vi.fn(() => Promise.resolve());
+      const app = makeApp();
+      (app.workspace.getLeavesOfType as any).mockReturnValue([leafA, leafB]);
+      app.plugins.plugins["work-terminal"] = { activateView: newActivateView };
+      const plugin = new TestPlugin(app, makeManifest(), makeAdapter());
+      await plugin.hotReload();
+      expect(setViewStateA).toHaveBeenCalledWith({ type: VIEW_TYPE, active: true });
+      expect(setViewStateB).toHaveBeenCalledWith({ type: VIEW_TYPE, active: true });
+      expect(app.workspace.revealLeaf).toHaveBeenCalledWith(leafA);
+      expect(newActivateView).not.toHaveBeenCalled();
+    });
+
     it("tolerates missing terminalPanel gracefully", async () => {
       const fakeLeaf = { view: {}, setViewState: vi.fn(() => Promise.resolve()) };
       const app = makeApp();

--- a/src/framework/PluginBase.ts
+++ b/src/framework/PluginBase.ts
@@ -91,11 +91,20 @@ export abstract class PluginBase extends Plugin {
     await plugins.disablePlugin("work-terminal");
     await plugins.enablePlugin("work-terminal");
 
-    // The new plugin instance re-registered the view type. Open the view
-    // so onOpen() fires and picks up stashed sessions from window store.
-    const newPlugin = plugins.plugins["work-terminal"];
-    if (newPlugin && typeof newPlugin.activateView === "function") {
-      await newPlugin.activateView();
+    // The new plugin instance re-registered the view type. Force the
+    // existing leaf to re-create its view so onOpen() fires and picks
+    // up stashed sessions from window store. A plain activateView()
+    // would find the stale leaf via getLeavesOfType and just reveal it
+    // without re-initialising the view, leaving a blank pane.
+    const existingLeaf = appRef.workspace.getLeavesOfType(VIEW_TYPE)[0];
+    if (existingLeaf) {
+      await existingLeaf.setViewState({ type: VIEW_TYPE, active: true });
+      appRef.workspace.revealLeaf(existingLeaf);
+    } else {
+      const newPlugin = plugins.plugins["work-terminal"];
+      if (newPlugin && typeof newPlugin.activateView === "function") {
+        await newPlugin.activateView();
+      }
     }
     console.log("[work-terminal] Hot reload complete");
   }

--- a/src/framework/PluginBase.ts
+++ b/src/framework/PluginBase.ts
@@ -96,10 +96,12 @@ export abstract class PluginBase extends Plugin {
     // up stashed sessions from window store. A plain activateView()
     // would find the stale leaf via getLeavesOfType and just reveal it
     // without re-initialising the view, leaving a blank pane.
-    const existingLeaf = appRef.workspace.getLeavesOfType(VIEW_TYPE)[0];
-    if (existingLeaf) {
-      await existingLeaf.setViewState({ type: VIEW_TYPE, active: true });
-      appRef.workspace.revealLeaf(existingLeaf);
+    const existingLeaves = appRef.workspace.getLeavesOfType(VIEW_TYPE);
+    if (existingLeaves.length > 0) {
+      for (const existingLeaf of existingLeaves) {
+        await existingLeaf.setViewState({ type: VIEW_TYPE, active: true });
+      }
+      appRef.workspace.revealLeaf(existingLeaves[0]);
     } else {
       const newPlugin = plugins.plugins["work-terminal"];
       if (newPlugin && typeof newPlugin.activateView === "function") {


### PR DESCRIPTION
## Summary

- Fixes the blank view after "Reload Plugin (preserve terminals)" by forcing the existing leaf to re-create its view via `setViewState`, rather than just revealing the stale leaf
- After `disablePlugin`/`enablePlugin`, the leaf remains in the workspace but its view (DOM) was destroyed during `onClose()`. `activateView()` found this leaf via `getLeavesOfType` and called `revealLeaf` without triggering the view factory, leaving a blank pane.
- Falls back to `activateView` on the new plugin instance when no existing leaf is found (e.g. if the tab was closed before reload)

## Test plan

- [x] Unit tests updated: existing "calls activateView" test replaced with "re-initialises existing leaf via setViewState" and "falls back to activateView when no existing leaf is found"
- [x] All 1026 tests pass
- [x] Build succeeds
- [ ] Manual: open Work Terminal, run "Reload Plugin (preserve terminals)" from command palette, verify view re-renders with terminals preserved

Fixes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)