### PR TITLE
feat: add comfortable card display mode

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -11,7 +11,7 @@ Work Terminal turns your Obsidian vault into a work item board with per-item tab
   - [Creating tasks](#creating-tasks)
   - [Kanban board](#kanban-board)
   - [Task card anatomy](#task-card-anatomy)
-  - [Compact card mode](#compact-card-mode)
+  - [Card display modes](#card-display-modes)
   - [Context menu](#context-menu)
   - [Detail panel](#detail-panel)
   - [Drag-drop reordering](#drag-drop-reordering)
@@ -111,13 +111,19 @@ Cards contain:
 
 When a task has an active terminal session, a small indicator appears on the card showing the session count and type.
 
-### Compact card mode
+### Card display modes
 
-Work Terminal offers an optional **compact display mode** that collapses each task card into a single horizontal line. This is useful when you have many tasks and want to see more of them at once without scrolling.
+Work Terminal offers three card display modes, configurable under **Settings > Core > Card display mode**:
 
-To enable compact mode, go to **Settings > Core > Card display mode** and select **Compact**.
+| Mode | Description |
+|------|-------------|
+| **Standard** | The default multi-line card layout with full badges, goal tags, and flag labels. |
+| **Comfortable** | Same layout as Standard but with more padding within cards, larger gaps between cards, and more visual breathing room overall. Useful when you prefer a less dense board that is easier to scan visually. |
+| **Compact** | Collapses each card into a single horizontal line with indicator dots replacing verbose badges. Useful when you have many tasks and want to see more at once without scrolling. |
 
-In compact mode, each card becomes a single row containing:
+**Comfortable mode** uses the same card structure as Standard - title, source badges, priority scores, goal tags, and card flags all remain visible. The difference is purely spacing: cards have more internal padding, larger margins between them, slightly larger text, and more gap between meta badges. Section headers and the cards container also get extra breathing room.
+
+**Compact mode** replaces the full card layout with a single row containing:
 
 - **Title** - single line, truncated with ellipsis if it overflows
 - **Indicator dots** - small coloured dots that replace the verbose meta badges:
@@ -127,16 +133,16 @@ In compact mode, each card becomes a single row containing:
   - Coloured dot for each active card flag (hover to see the flag label or context)
 - **Session badge** - the session count badge remains visible, slightly smaller
 
-Everything else works identically in compact mode:
+All three modes share the same interactive behaviour:
 
 - **Drag-drop** reordering and cross-column moves
 - **Selection** and detail panel opening
 - **Context menu** with all the same actions
 - **Agent state indicators** (active/waiting/idle border and glow animations)
-- **Pinned section** with state badges (adapted to the compact height)
+- **Pinned section** with state badges
 - **Filtering** by text and active sessions
 
-Switch back to **Standard** mode at any time to restore the full multi-line card layout with verbose badges, goal tags, and flag labels.
+Switch between modes at any time from the settings dropdown.
 
 ### Context menu
 
@@ -330,7 +336,7 @@ The core settings section covers:
 
 | Setting | Description |
 |---------|-------------|
-| **Card display mode** | Choose between **Standard** (full card details with badges and tags) and **Compact** (single-line cards with indicator dots). See [Compact card mode](#compact-card-mode). |
+| **Card display mode** | Choose between **Standard** (full card details), **Comfortable** (spacious layout with more padding and gaps), and **Compact** (single-line cards with indicator dots). See [Card display modes](#card-display-modes). |
 | **Default shell** | Shell used for new terminal tabs (defaults to your system shell) |
 | **Default terminal CWD** | Working directory for new terminals (supports `~` expansion) |
 | **Keep sessions alive** | When enabled, closing the Work Terminal tab stashes sessions to memory instead of killing them. Reopening restores sessions with full PTY state. |

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -223,7 +223,7 @@ export interface CardActionContext {
 }
 
 /** Display mode for card rendering. */
-export type CardDisplayMode = "standard" | "compact";
+export type CardDisplayMode = "standard" | "compact" | "comfortable";
 
 /**
  * Renders a work item as a DOM card element and provides context menu items.

--- a/src/framework/ListPanel.test.ts
+++ b/src/framework/ListPanel.test.ts
@@ -981,6 +981,76 @@ describe("ListPanel", () => {
     });
   });
 
+  describe("comfortable display mode", () => {
+    it("adds wt-comfortable class to list panel when cardDisplayMode is comfortable", () => {
+      const { panel } = createListPanel({
+        settings: { "core.cardDisplayMode": "comfortable" },
+      });
+      panel.render({ todo: [makeItem("task-1")] }, {});
+
+      const listEl = document.querySelector(".wt-list-panel") as HTMLElement;
+      expect(listEl.classList.contains("wt-comfortable")).toBe(true);
+    });
+
+    it("does not add wt-comfortable class when cardDisplayMode is standard", () => {
+      const { panel } = createListPanel({
+        settings: { "core.cardDisplayMode": "standard" },
+      });
+      panel.render({ todo: [makeItem("task-1")] }, {});
+
+      const listEl = document.querySelector(".wt-list-panel") as HTMLElement;
+      expect(listEl.classList.contains("wt-comfortable")).toBe(false);
+    });
+
+    it("does not add wt-comfortable class when cardDisplayMode is not set", () => {
+      const { panel } = createListPanel({
+        settings: {},
+      });
+      panel.render({ todo: [makeItem("task-1")] }, {});
+
+      const listEl = document.querySelector(".wt-list-panel") as HTMLElement;
+      expect(listEl.classList.contains("wt-comfortable")).toBe(false);
+    });
+
+    it("removes wt-comfortable class when mode changes from comfortable to standard", () => {
+      const settings: Record<string, any> = { "core.cardDisplayMode": "comfortable" };
+      const { panel } = createListPanel({ settings });
+
+      panel.render({ todo: [makeItem("task-1")] }, {});
+      const listEl = document.querySelector(".wt-list-panel") as HTMLElement;
+      expect(listEl.classList.contains("wt-comfortable")).toBe(true);
+
+      // Simulate settings change
+      settings["core.cardDisplayMode"] = "standard";
+      panel.render({ todo: [makeItem("task-1")] }, {});
+
+      expect(listEl.classList.contains("wt-comfortable")).toBe(false);
+    });
+
+    it("passes comfortable displayMode to card renderer", () => {
+      const renderSpy = vi.fn((item: WorkItem) => {
+        const el = document.createElement("div");
+        el.createDiv({ cls: "wt-card-actions" });
+        return el;
+      });
+
+      const { panel } = createListPanel({
+        settings: { "core.cardDisplayMode": "comfortable" },
+      });
+
+      const cardRenderer = (panel as any).cardRenderer;
+      cardRenderer.render = renderSpy;
+
+      panel.render({ todo: [makeItem("task-1")] }, {});
+
+      expect(renderSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "task-1" }),
+        expect.anything(),
+        "comfortable",
+      );
+    });
+  });
+
   describe("compact display mode", () => {
     it("adds wt-compact class to list panel when cardDisplayMode is compact", () => {
       const { panel } = createListPanel({

--- a/src/framework/ListPanel.ts
+++ b/src/framework/ListPanel.ts
@@ -153,7 +153,9 @@ export class ListPanel {
   /** Resolve the current card display mode from settings. */
   private getDisplayMode(): CardDisplayMode {
     const value = this.settings["core.cardDisplayMode"];
-    return value === "compact" ? "compact" : "standard";
+    if (value === "compact") return "compact";
+    if (value === "comfortable") return "comfortable";
+    return "standard";
   }
 
   render(groups: Record<string, WorkItem[]>, customOrder: Record<string, string[]>): void {
@@ -168,12 +170,13 @@ export class ListPanel {
 
     this.listEl.empty();
 
-    // Apply compact mode class to list panel container
+    // Apply display mode class to list panel container
     const displayMode = this.getDisplayMode();
+    this.listEl.removeClass("wt-compact", "wt-comfortable");
     if (displayMode === "compact") {
       this.listEl.addClass("wt-compact");
-    } else {
-      this.listEl.removeClass("wt-compact");
+    } else if (displayMode === "comfortable") {
+      this.listEl.addClass("wt-comfortable");
     }
 
     // Collect pinned item IDs and build a lookup of all items by ID

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -9,7 +9,12 @@
  */
 import { App, Notice, PluginSettingTab, Setting } from "obsidian";
 import type { Plugin } from "obsidian";
-import type { AdapterBundle, CardFlagRule, SettingField } from "../core/interfaces";
+import type {
+  AdapterBundle,
+  CardDisplayMode,
+  CardFlagRule,
+  SettingField,
+} from "../core/interfaces";
 import { mergeAndSavePluginData } from "../core/PluginDataStore";
 import { resetGuidedTourStatus } from "./GuidedTour";
 import type { AgentProfileManager } from "../core/agents/AgentProfileManager";
@@ -29,7 +34,7 @@ interface CoreSettings {
   "core.defaultTerminalCwd": string;
   "core.exposeDebugApi": boolean;
   "core.keepSessionsAlive": boolean;
-  "core.cardDisplayMode": "standard" | "compact" | "comfortable";
+  "core.cardDisplayMode": CardDisplayMode;
 }
 
 export const SETTINGS_CHANGED_EVENT = "work-terminal:settings-changed";

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -29,7 +29,7 @@ interface CoreSettings {
   "core.defaultTerminalCwd": string;
   "core.exposeDebugApi": boolean;
   "core.keepSessionsAlive": boolean;
-  "core.cardDisplayMode": "standard" | "compact";
+  "core.cardDisplayMode": "standard" | "compact" | "comfortable";
 }
 
 export const SETTINGS_CHANGED_EVENT = "work-terminal:settings-changed";
@@ -127,8 +127,8 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
       containerEl,
       "core.cardDisplayMode",
       "Card display mode",
-      "Standard shows full card details. Compact shows single-line cards with indicator dots replacing verbose badges.",
-      { standard: "Standard", compact: "Compact" },
+      "Standard shows full card details. Comfortable adds extra padding and spacing for easier scanning. Compact shows single-line cards with indicator dots replacing verbose badges.",
+      { standard: "Standard", comfortable: "Comfortable", compact: "Compact" },
     );
 
     this.addCoreToggle(

--- a/styles.css
+++ b/styles.css
@@ -2139,3 +2139,50 @@ button.wt-spawn-claude-ctx:hover svg {
   inset: -2px;
   border-radius: 10px;
 }
+
+/* =============================================================================
+   Comfortable card display mode
+   ============================================================================= */
+
+/* Comfortable sections: more breathing room between columns */
+.wt-comfortable .wt-section {
+  margin-bottom: 8px;
+}
+
+/* Comfortable section headers: taller with more padding */
+.wt-comfortable .wt-section-header {
+  padding: 10px 12px;
+  font-size: 12px;
+}
+
+/* Comfortable cards container: more horizontal padding */
+.wt-comfortable .wt-section-cards {
+  padding: 2px 6px 8px;
+}
+
+/* Comfortable card wrapper: more padding and larger gaps */
+.wt-comfortable .wt-card-wrapper {
+  --wt-card-padding-x: 14px;
+  --wt-card-padding-y: 12px;
+  margin: 6px 0;
+  border-radius: 6px;
+}
+
+/* Comfortable title: slightly larger with more bottom margin */
+.wt-comfortable .wt-card-title {
+  font-size: 14px;
+  margin-bottom: 6px;
+}
+
+/* Comfortable meta row: more gap between badges */
+.wt-comfortable .wt-card-meta {
+  gap: 8px;
+  font-size: 12px;
+  margin-top: 2px;
+}
+
+/* Comfortable drop indicator: thicker with more margin */
+.wt-comfortable .wt-drop-indicator {
+  height: 3px;
+  margin: 3px 6px;
+}

--- a/styles.css
+++ b/styles.css
@@ -2144,7 +2144,7 @@ button.wt-spawn-claude-ctx:hover svg {
    Comfortable card display mode
    ============================================================================= */
 
-/* Comfortable sections: more breathing room between columns */
+/* Comfortable sections: more breathing room between sections */
 .wt-comfortable .wt-section {
   margin-bottom: 8px;
 }


### PR DESCRIPTION
## Summary

- Adds a new **Comfortable** card display mode that provides more padding within cards, larger gaps between cards, and more visual breathing room - addressing #415
- The comfortable mode uses the same standard card layout (title, source badges, priority scores, goal tags, flags) with purely CSS-driven spacing increases
- Updates the settings dropdown to offer three modes: Standard, Comfortable, Compact

## Changes

- `src/core/interfaces.ts` - Extended `CardDisplayMode` type with `"comfortable"`
- `src/framework/SettingsTab.ts` - Added Comfortable option to the card display mode dropdown
- `src/framework/ListPanel.ts` - Handle `"comfortable"` display mode, apply `wt-comfortable` CSS class
- `styles.css` - New `.wt-comfortable` CSS rules: increased card padding (14px/12px vs 10px/8px), larger card margins (6px vs 3px), bigger section headers, wider meta row gaps, larger border radius, thicker drop indicators
- `docs/user-guide.md` - Consolidated "Compact card mode" section into "Card display modes" covering all three modes

## Test plan

- [x] All 1025 tests pass (`pnpm exec vitest run`)
- [x] Build succeeds (`pnpm run build`)
- [ ] Open Settings > Core > Card display mode and verify all three options appear
- [ ] Select Comfortable and confirm cards have visibly more padding and spacing
- [ ] Switch between Standard/Comfortable/Compact to verify each renders correctly
- [ ] Verify drag-drop, selection, context menu, and agent state indicators work in Comfortable mode

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)