### PR TITLE
fix: drop inaccurate 'covers all fields' claim in AgentProfileModal header

### DIFF
--- a/src/framework/AgentProfileModal.ts
+++ b/src/framework/AgentProfileModal.ts
@@ -1,7 +1,7 @@
 /**
  * AgentProfileModal - modal for editing a single agent profile.
- * Covers all profile fields: name, agent type, command, CWD, arguments,
- * context prompt, and button configuration.
+ * Exposes launch settings (agent type, command, CWD, arguments, login shell),
+ * context prompt options, and tab bar button styling.
  */
 import { App, Modal, Notice, Setting } from "obsidian";
 import type {


### PR DESCRIPTION
## Summary

- Rewrites the header comment in `AgentProfileModal.ts` to accurately describe what the modal exposes (launch settings, context prompt options, button styling) without claiming completeness over the `AgentProfile` interface.
- Prevents the comment from going stale when new fields are added to `AgentProfile`.

## Test plan

- [x] All 1105 tests pass (`pnpm exec vitest run`)
- [x] Build succeeds (`pnpm run build`)
- Comment-only change - no runtime behaviour affected

Fixes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)