### PR TITLE
fix: prevent hover layout shift on compact/comfortable task cards

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2116,6 +2116,20 @@ button.wt-spawn-claude-ctx:hover svg {
   flex-shrink: 0;
 }
 
+/* In compact/comfortable modes the actions container is in-flow, so toggling
+   the move-to-top button between display:none and display:flex causes layout
+   shift (the title truncates shorter and adjacent cards jump). Use
+   visibility:hidden/visible instead to reserve space permanently. */
+.wt-card-compact-row .wt-move-to-top {
+  display: flex;
+  visibility: hidden;
+}
+
+.wt-card-compact-row:hover .wt-move-to-top,
+.wt-card-wrapper:hover .wt-card-compact-row .wt-move-to-top {
+  visibility: visible;
+}
+
 /* Indicator dots container */
 .wt-card-compact-dots {
   display: flex;


### PR DESCRIPTION
## Summary

- Fixes hover layout shift on task cards in compact and comfortable display modes
- The `.wt-move-to-top` button toggled between `display:none` and `display:flex` on hover, but in compact/comfortable modes `.wt-card-actions` is `position:static` (inline flow), so the button appearing pushed the title narrower and shifted adjacent cards
- Replaced `display` toggling with `visibility:hidden/visible` in the compact row context so the button reserves its space permanently but remains invisible until hover

## Test plan

- [x] All 1105 tests pass (`pnpm exec vitest run`)
- [x] Build succeeds (`pnpm run build`)
- [ ] Manual: hover over cards in compact mode - title should not truncate shorter and adjacent cards should not shift
- [ ] Manual: hover over cards in comfortable mode - same stable layout
- [ ] Manual: hover over cards in standard mode - button still appears correctly (absolute positioning, unaffected by this change)

Fixes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)