### PR TITLE
fix: hide state label on pinned cards in compact/comfortable modes

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -172,7 +172,7 @@ All three modes share the same interactive behaviour:
 - **Selection** and detail panel opening
 - **Context menu** with all the same actions
 - **Agent state indicators** (active/waiting/idle border and glow animations)
-- **Pinned section** with state badges
+- **Pinned section** with state badges (standard mode only - hidden in compact/comfortable to save space)
 - **Filtering** by text and active sessions
 
 Switch between modes at any time from the settings dropdown.
@@ -450,6 +450,8 @@ The core settings section covers:
 Pin important tasks to keep them visible at the top of the board regardless of their column. Pinned tasks appear in a dedicated **Pinned** section above the regular columns.
 
 To pin a task, use the pin action from the task's context area. Pinned tasks can be reordered within the pinned section using drag-drop. Unpin a task to return it to its normal column position.
+
+In **standard mode**, pinned cards show a state label badge (e.g. "Active", "To Do") so you can see each task's real column at a glance. In **compact** and **comfortable** modes, the state label is hidden to conserve horizontal space - the dedicated Pinned section heading already provides sufficient context.
 
 Pinned state is persisted across sessions using the task's UUID, so it survives file renames and moves.
 

--- a/styles.css
+++ b/styles.css
@@ -2183,10 +2183,12 @@ button.wt-spawn-claude-ctx:hover svg {
   padding: 0 3px;
 }
 
-/* Compact mode: pinned state badge adapts to single-line height */
-.wt-compact .wt-card-state-badge {
-  font-size: 8px;
-  padding: 0 3px;
+/* Compact/comfortable mode: hide state badge on pinned cards.
+   The Pinned section already communicates that items are pinned,
+   so the state label is redundant and wastes horizontal space. */
+.wt-compact .wt-card-state-badge,
+.wt-comfortable .wt-card-state-badge {
+  display: none;
 }
 
 /* Compact mode: agent state waiting overlay adapts */


### PR DESCRIPTION
## Summary

- Hide the state label badge (e.g. "ACTIVE", "TO DO") on pinned task cards in compact and comfortable display modes via CSS `display: none`
- The Pinned section heading already communicates that items are pinned, making the per-card state badge redundant - especially in space-constrained compact/comfortable layouts
- Standard mode retains the state badge for users who want full detail

Fixes #442

## Test plan

- [ ] Open Work Terminal in compact mode with pinned tasks - verify state badge is not visible on pinned cards
- [ ] Switch to comfortable mode - verify state badge is also hidden
- [ ] Switch to standard mode - verify state badge still appears on pinned cards
- [ ] Verify other pinned card elements (indicator dots, session badges, title) are unaffected
- [ ] Verify non-pinned cards are unaffected in all three modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)