### PR TITLE
Auto-clean empty custom state columns; add pinning and pre-creation

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -408,9 +408,23 @@ Dynamic columns:
 - **Can be reordered** using the column display order controls in settings, just like built-in columns. Once reordered, the dynamic column's position is persisted.
 - **Are shown with a star** (\*) in the settings column ordering UI to distinguish them from built-in columns
 - **Do not have folder mappings** - dragging a task into a dynamic column updates its frontmatter `state` field but does not move the file to a different folder
-- **Disappear** when no tasks have that state (they are not shown as empty columns)
+- **Auto-cleanup** - empty dynamic columns are automatically removed from the board and column order settings when no tasks remain in them, unless they are pinned (see below)
 
 This is useful for workflows that need temporary or project-specific states like "review", "waiting", "testing", or any other status that makes sense for your work.
+
+#### Pinning custom states
+
+Dynamic columns can be **pinned** to keep them visible on the board even when they have no tasks. This is useful for permanent workflow stages that should always appear regardless of whether tasks currently occupy them.
+
+To pin a dynamic column, go to **Settings > Column Order & Creation** and click the **Pin** button next to the dynamic column's entry in the column order list. Pinned columns show "(pinned)" next to their label. Click **Unpin** to allow the column to auto-clean when empty.
+
+Resetting the column order to defaults also clears all pinned custom states.
+
+#### Creating custom states from settings
+
+You can pre-create a custom state column without needing to first create a task with that state. In **Settings > Column Order & Creation**, use the **Create custom state** input at the bottom of the column order section.
+
+Type a lowercase identifier with hyphens (e.g. `review`, `blocked-upstream`, `testing`) and press Enter. The new column is added to the column order and pinned by default so it stays visible even with zero tasks. You can then drag tasks into the new column or set the `state` frontmatter field to match the column ID.
 
 ### Background enrichment
 

--- a/src/adapters/task-agent/TaskAgentConfig.test.ts
+++ b/src/adapters/task-agent/TaskAgentConfig.test.ts
@@ -4,6 +4,8 @@ import {
   resolveColumns,
   resolveCreationColumns,
   makeDynamicColumn,
+  parsePinnedCustomStates,
+  isCustomStatePinned,
   DEFAULT_COLUMNS,
   DEFAULT_CREATION_COLUMNS,
   TASK_AGENT_CONFIG,
@@ -190,16 +192,54 @@ describe("TaskAgentConfig column helpers", () => {
     });
   });
 
-  describe("TASK_AGENT_CONFIG defaults", () => {
-    it("has columnOrder and creationColumnIds in defaultSettings", () => {
-      expect(TASK_AGENT_CONFIG.defaultSettings).toHaveProperty("columnOrder", "");
-      expect(TASK_AGENT_CONFIG.defaultSettings).toHaveProperty("creationColumnIds", "");
+  describe("parsePinnedCustomStates", () => {
+    it("returns empty array for undefined input", () => {
+      expect(parsePinnedCustomStates(undefined)).toEqual([]);
     });
 
-    it("does not expose columnOrder or creationColumnIds in settingsSchema", () => {
+    it("returns empty array for empty string", () => {
+      expect(parsePinnedCustomStates("")).toEqual([]);
+    });
+
+    it("parses valid JSON array of strings", () => {
+      expect(parsePinnedCustomStates('["review", "blocked"]')).toEqual(["review", "blocked"]);
+    });
+
+    it("returns empty array for invalid JSON", () => {
+      expect(parsePinnedCustomStates("not json")).toEqual([]);
+    });
+  });
+
+  describe("isCustomStatePinned", () => {
+    it("returns true for a pinned state", () => {
+      expect(isCustomStatePinned('["review", "blocked"]', "review")).toBe(true);
+    });
+
+    it("returns false for an unpinned state", () => {
+      expect(isCustomStatePinned('["review", "blocked"]', "testing")).toBe(false);
+    });
+
+    it("returns false for undefined input", () => {
+      expect(isCustomStatePinned(undefined, "review")).toBe(false);
+    });
+
+    it("returns false for empty array", () => {
+      expect(isCustomStatePinned("[]", "review")).toBe(false);
+    });
+  });
+
+  describe("TASK_AGENT_CONFIG defaults", () => {
+    it("has columnOrder, creationColumnIds, and pinnedCustomStates in defaultSettings", () => {
+      expect(TASK_AGENT_CONFIG.defaultSettings).toHaveProperty("columnOrder", "");
+      expect(TASK_AGENT_CONFIG.defaultSettings).toHaveProperty("creationColumnIds", "");
+      expect(TASK_AGENT_CONFIG.defaultSettings).toHaveProperty("pinnedCustomStates", "[]");
+    });
+
+    it("does not expose columnOrder, creationColumnIds, or pinnedCustomStates in settingsSchema", () => {
       const schemaKeys = TASK_AGENT_CONFIG.settingsSchema.map((f) => f.key);
       expect(schemaKeys).not.toContain("columnOrder");
       expect(schemaKeys).not.toContain("creationColumnIds");
+      expect(schemaKeys).not.toContain("pinnedCustomStates");
     });
 
     it("default columns match KANBAN_COLUMNS order", () => {

--- a/src/adapters/task-agent/TaskAgentConfig.ts
+++ b/src/adapters/task-agent/TaskAgentConfig.ts
@@ -132,6 +132,7 @@ export const TASK_AGENT_CONFIG: PluginConfig = {
     stateStrategy: "folder",
     columnOrder: "",
     creationColumnIds: "",
+    pinnedCustomStates: "[]",
     jiraBaseUrl: "",
     enrichmentEnabled: true,
     enrichmentPrompt: "",
@@ -227,6 +228,21 @@ export function makeDynamicColumn(stateId: string): ListColumn {
     id: stateId,
     label: titleCase(stateId),
   };
+}
+
+/**
+ * Parse a JSON string containing an array of pinned custom state IDs.
+ * Returns an empty array on invalid/empty input.
+ */
+export function parsePinnedCustomStates(json: string | undefined): string[] {
+  return parseColumnOrderJson(json);
+}
+
+/**
+ * Check whether a custom state ID is pinned.
+ */
+export function isCustomStatePinned(pinnedJson: string | undefined, stateId: string): boolean {
+  return parsePinnedCustomStates(pinnedJson).includes(stateId);
 }
 
 /**

--- a/src/framework/ListPanel.ts
+++ b/src/framework/ListPanel.ts
@@ -47,6 +47,7 @@ export class ListPanel {
   private onSessionFilterChange: (active: boolean) => void;
   private pinStore: PinStore | null = null;
   private activityTracker: ActivityTracker | null = null;
+  private pinnedCustomStates: Set<string> = new Set();
 
   // State
   private selectedId: string | null = null;
@@ -168,6 +169,11 @@ export class ListPanel {
     this.activityTracker = tracker;
   }
 
+  /** Update the set of pinned custom state IDs (columns kept visible when empty). */
+  setPinnedCustomStates(pinnedIds: string[]): void {
+    this.pinnedCustomStates = new Set(pinnedIds);
+  }
+
   // ---------------------------------------------------------------------------
   // Rendering
   // ---------------------------------------------------------------------------
@@ -275,7 +281,7 @@ export class ListPanel {
     for (const col of this.adapter.config.columns) {
       const colItems = (groups[col.id] || []).filter((item) => !pinnedSet.has(item.id));
       const isDynamic = !col.folderName;
-      if (isDynamic && colItems.length === 0) continue;
+      if (isDynamic && colItems.length === 0 && !this.pinnedCustomStates.has(col.id)) continue;
       const sortedItems = this.sortItems(colItems, col.id);
 
       this.renderSection(col.id, col.label, sortedItems, false);

--- a/src/framework/MainView.test.ts
+++ b/src/framework/MainView.test.ts
@@ -258,6 +258,7 @@ describe("MainView selection ID backfill", () => {
       getCustomOrder: vi.fn(() => ({ todo: ["uuid-123"] })),
       rekeyCustomOrder: vi.fn(() => true),
       render: vi.fn(),
+      setPinnedCustomStates: vi.fn(),
     };
     const parser = {
       loadAll: vi.fn().mockResolvedValue([]),
@@ -272,7 +273,7 @@ describe("MainView selection ID backfill", () => {
     (view as any).parser = parser;
     (view as any).terminalPanel = terminalPanel;
     (view as any).adapter = {
-      config: { columns: [{ id: "todo", label: "To Do" }] },
+      config: { columns: [{ id: "todo", label: "To Do", folderName: "todo" }] },
     };
 
     (view as any).handleRename("2 - Areas/Tasks/todo/task-renamed.md", "stale-path");
@@ -507,6 +508,190 @@ describe("MainView writeLastActive", () => {
     // Should insert into frontmatter and leave body unchanged
     expect(written).toBe(
       "---\nid: uuid-123\nlast-active: 2026-04-16T10:00:00Z\n---\nSome content\nlast-active: 2026-01-01T00:00:00Z\nMore content",
+    );
+  });
+});
+
+describe("MainView dynamic column cleanup", () => {
+  let dom: JSDOM;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dom = new JSDOM("<!doctype html><html><body></body></html>");
+    vi.stubGlobal("window", dom.window);
+    vi.stubGlobal("document", dom.window.document);
+    vi.stubGlobal("HTMLElement", dom.window.HTMLElement);
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    dom.window.close();
+  });
+
+  function makeRefreshView(opts: {
+    columnOrder: string;
+    pinnedCustomStates?: string;
+    groups: Record<string, WorkItem[]>;
+    columns: { id: string; label: string; folderName?: string }[];
+  }) {
+    const savedData: Record<string, any> = {
+      settings: {
+        "adapter.columnOrder": opts.columnOrder,
+        "adapter.pinnedCustomStates": opts.pinnedCustomStates || "[]",
+      },
+      customOrder: {},
+    };
+    const pluginRef = {
+      loadData: vi.fn(async () => savedData),
+      saveData: vi.fn(async (data: Record<string, any>) => {
+        Object.assign(savedData, data);
+      }),
+    };
+    // Override the mergeAndSavePluginData mock to actually run the update
+    vi.mocked(mergeAndSavePluginData).mockImplementation(async (plugin, update) => {
+      const data = (await (plugin as any).loadData()) || {};
+      await update(data);
+      await (plugin as any).saveData(data);
+    });
+    const view = new MainView({} as any, {} as any, pluginRef as any);
+
+    const listPanel = {
+      render: vi.fn(),
+      setPinnedCustomStates: vi.fn(),
+    };
+    const parser = {
+      loadAll: vi.fn(async () => {
+        const items: WorkItem[] = [];
+        for (const group of Object.values(opts.groups)) {
+          items.push(...group);
+        }
+        return items;
+      }),
+      groupByColumn: vi.fn(() => opts.groups),
+    };
+    const terminalPanel = {
+      setItems: vi.fn(),
+    };
+
+    (view as any).listPanel = listPanel;
+    (view as any).parser = parser;
+    (view as any).terminalPanel = terminalPanel;
+    (view as any).settings = savedData.settings;
+    (view as any).adapter = {
+      config: { columns: [...opts.columns] },
+    };
+
+    return { view, listPanel, savedData };
+  }
+
+  it("removes empty unpinned dynamic columns from column order", async () => {
+    const { view, savedData } = makeRefreshView({
+      columnOrder: '["priority", "review", "active", "todo", "done"]',
+      columns: [
+        { id: "priority", label: "Priority", folderName: "priority" },
+        { id: "review", label: "Review" },
+        { id: "active", label: "Active", folderName: "active" },
+        { id: "todo", label: "To Do", folderName: "todo" },
+        { id: "done", label: "Done", folderName: "archive" },
+      ],
+      groups: {
+        priority: [],
+        active: [makeItem({ id: "t1", state: "active" })],
+        todo: [],
+        done: [],
+        // "review" has zero tasks - should be removed
+      },
+    });
+
+    await (view as any).refreshList();
+
+    // The column order should have "review" removed
+    expect(savedData.settings["adapter.columnOrder"]).toBe('["priority","active","todo","done"]');
+  });
+
+  it("preserves pinned dynamic columns even when empty", async () => {
+    const { view, savedData, listPanel } = makeRefreshView({
+      columnOrder: '["priority", "review", "active", "todo", "done"]',
+      pinnedCustomStates: '["review"]',
+      columns: [
+        { id: "priority", label: "Priority", folderName: "priority" },
+        { id: "review", label: "Review" },
+        { id: "active", label: "Active", folderName: "active" },
+        { id: "todo", label: "To Do", folderName: "todo" },
+        { id: "done", label: "Done", folderName: "archive" },
+      ],
+      groups: {
+        priority: [],
+        active: [],
+        todo: [],
+        done: [],
+        // "review" has zero tasks but is pinned - should be preserved
+      },
+    });
+
+    await (view as any).refreshList();
+
+    // Column order should NOT have been changed (review is pinned)
+    expect(savedData.settings["adapter.columnOrder"]).toBe(
+      '["priority", "review", "active", "todo", "done"]',
+    );
+
+    // ListPanel should be told about pinned custom states
+    expect(listPanel.setPinnedCustomStates).toHaveBeenCalledWith(["review"]);
+  });
+
+  it("never removes predefined columns even when empty", async () => {
+    const { view, savedData } = makeRefreshView({
+      columnOrder: '["priority", "active", "todo", "done"]',
+      columns: [
+        { id: "priority", label: "Priority", folderName: "priority" },
+        { id: "active", label: "Active", folderName: "active" },
+        { id: "todo", label: "To Do", folderName: "todo" },
+        { id: "done", label: "Done", folderName: "archive" },
+      ],
+      groups: {
+        // All columns empty
+        priority: [],
+        active: [],
+        todo: [],
+        done: [],
+      },
+    });
+
+    await (view as any).refreshList();
+
+    // Predefined columns are always kept
+    expect(savedData.settings["adapter.columnOrder"]).toBe(
+      '["priority", "active", "todo", "done"]',
+    );
+  });
+
+  it("keeps dynamic columns that still have tasks", async () => {
+    const { view, savedData } = makeRefreshView({
+      columnOrder: '["priority", "review", "active", "todo", "done"]',
+      columns: [
+        { id: "priority", label: "Priority", folderName: "priority" },
+        { id: "review", label: "Review" },
+        { id: "active", label: "Active", folderName: "active" },
+        { id: "todo", label: "To Do", folderName: "todo" },
+        { id: "done", label: "Done", folderName: "archive" },
+      ],
+      groups: {
+        priority: [],
+        review: [makeItem({ id: "t1", state: "review" })],
+        active: [],
+        todo: [],
+        done: [],
+      },
+    });
+
+    await (view as any).refreshList();
+
+    // "review" has tasks so should be kept
+    expect(savedData.settings["adapter.columnOrder"]).toBe(
+      '["priority", "review", "active", "todo", "done"]',
     );
   });
 });

--- a/src/framework/MainView.ts
+++ b/src/framework/MainView.ts
@@ -677,6 +677,22 @@ export class MainView extends ItemView {
       }
     }
 
+    // Parse pinned custom states from settings
+    const pinnedJson = (this.settings["adapter.pinnedCustomStates"] as string) || "[]";
+    let pinnedCustomStates: string[] = [];
+    try {
+      const parsed = JSON.parse(pinnedJson);
+      if (Array.isArray(parsed)) pinnedCustomStates = parsed;
+    } catch {
+      /* empty */
+    }
+    const pinnedSet = new Set(pinnedCustomStates);
+
+    // Determine which columns are predefined (have a folderName)
+    const predefinedIds = new Set(
+      this.adapter.config.columns.filter((c) => c.folderName).map((c) => c.id),
+    );
+
     // Discover dynamic columns (states in items not in configured columns)
     // and update the adapter config so the SettingsTab column ordering UI
     // includes them. Dynamic columns appear after configured columns.
@@ -695,6 +711,59 @@ export class MainView extends ItemView {
         ...dynamicColumns.filter((dc) => !configuredIds.has(dc.id)),
       ];
     }
+
+    // Auto-cleanup: remove empty, unpinned dynamic columns from the column
+    // order settings. Only affects dynamic columns (no folderName) - never
+    // predefined ones. Pinned columns are preserved regardless of task count.
+    const columnOrderJson = (this.settings["adapter.columnOrder"] as string) || "";
+    if (columnOrderJson) {
+      let orderIds: string[] = [];
+      try {
+        const parsed = JSON.parse(columnOrderJson);
+        if (Array.isArray(parsed)) orderIds = parsed;
+      } catch {
+        /* empty */
+      }
+
+      const cleanedIds = orderIds.filter((id) => {
+        // Keep predefined columns always
+        if (predefinedIds.has(id)) return true;
+        // Keep pinned dynamic columns even if empty
+        if (pinnedSet.has(id)) return true;
+        // Keep dynamic columns that have tasks
+        if ((groups[id]?.length ?? 0) > 0) return true;
+        // Remove empty unpinned dynamic columns
+        return false;
+      });
+
+      if (cleanedIds.length !== orderIds.length) {
+        // Remove cleaned-out columns from the adapter config too
+        this.adapter.config.columns = this.adapter.config.columns.filter(
+          (c) => c.folderName || pinnedSet.has(c.id) || (groups[c.id]?.length ?? 0) > 0,
+        );
+        // Persist the cleaned column order
+        const newOrderJson = JSON.stringify(cleanedIds);
+        this.settings["adapter.columnOrder"] = newOrderJson;
+        await mergeAndSavePluginData(this.pluginRef, async (data) => {
+          if (!data.settings) data.settings = {};
+          data.settings["adapter.columnOrder"] = newOrderJson;
+        });
+      }
+    }
+
+    // Ensure pinned custom state columns appear in the adapter config even
+    // when they have zero tasks, so they render as empty columns on the board.
+    for (const pinnedId of pinnedCustomStates) {
+      if (!this.adapter.config.columns.some((c) => c.id === pinnedId)) {
+        this.adapter.config.columns.push({
+          id: pinnedId,
+          label: titleCase(pinnedId),
+        });
+      }
+    }
+
+    // Pass pinned custom states to ListPanel so it renders empty pinned columns
+    this.listPanel.setPinnedCustomStates(pinnedCustomStates);
 
     const data = (await this.pluginRef.loadData()) || {};
     const customOrder = this.pendingCustomOrderOverride || data.customOrder || {};

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -328,18 +328,31 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
 
   /**
    * Render column display order controls: a list of columns with up/down
-   * buttons and a reset-to-default action.
+   * buttons, pin toggles for dynamic columns, and a reset-to-default action.
    */
   private async renderColumnOrderControls(containerEl: HTMLElement): Promise<void> {
     // Resolve effective column order (current config reflects it)
     const columns = this.adapter.config.columns;
+
+    // Load pinned custom states
+    const data = (await this.plugin.loadData()) || {};
+    const settings = data.settings || {};
+    const pinnedJson = (settings["adapter.pinnedCustomStates"] as string) || "[]";
+    let pinnedStates: string[] = [];
+    try {
+      const parsed = JSON.parse(pinnedJson);
+      if (Array.isArray(parsed)) pinnedStates = parsed;
+    } catch {
+      /* empty */
+    }
+    const pinnedSet = new Set(pinnedStates);
 
     const hasDynamic = columns.some((c) => !c.folderName);
     const desc = new Setting(containerEl)
       .setName("Column display order")
       .setDesc(
         hasDynamic
-          ? "Use arrow buttons to reorder kanban board columns. Dynamic columns (from custom frontmatter states) are shown with a star. Changes take effect immediately."
+          ? "Use arrow buttons to reorder kanban board columns. Dynamic columns (from custom frontmatter states) are shown with a star. Use the pin button to keep a dynamic column visible even when it has no tasks. Changes take effect immediately."
           : "Use arrow buttons to reorder kanban board columns. Changes take effect immediately.",
       );
 
@@ -348,6 +361,7 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
       btn.setButtonText("Reset to default").onClick(async () => {
         await this.saveSettings((settings) => {
           settings["adapter.columnOrder"] = "";
+          settings["adapter.pinnedCustomStates"] = "[]";
         });
         this.display();
       }),
@@ -361,8 +375,30 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
 
       // Column label (with dynamic indicator for custom frontmatter states)
       const isDynamic = !col.folderName;
-      const labelText = isDynamic ? `${col.label} *` : col.label;
+      const isPinned = isDynamic && pinnedSet.has(col.id);
+      const labelText = isDynamic ? `${col.label} *${isPinned ? " (pinned)" : ""}` : col.label;
       rowEl.createSpan({ text: labelText, cls: "wt-column-order-label" });
+
+      // Pin toggle for dynamic columns
+      if (isDynamic) {
+        const pinBtn = rowEl.createEl("button", {
+          text: isPinned ? "Unpin" : "Pin",
+          cls: "wt-column-order-btn wt-column-pin-btn",
+          attr: { "aria-label": isPinned ? `Unpin ${col.label}` : `Pin ${col.label}` },
+        });
+        pinBtn.addEventListener("click", async () => {
+          const currentPinned = new Set(pinnedStates);
+          if (isPinned) {
+            currentPinned.delete(col.id);
+          } else {
+            currentPinned.add(col.id);
+          }
+          await this.saveSettings((settings) => {
+            settings["adapter.pinnedCustomStates"] = JSON.stringify([...currentPinned]);
+          });
+          this.display();
+        });
+      }
 
       // Up button
       const upBtn = rowEl.createEl("button", {
@@ -398,6 +434,52 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
         this.display();
       });
     }
+
+    // "Create custom state" input
+    this.renderCreateCustomStateInput(containerEl, pinnedStates);
+  }
+
+  /**
+   * Render an input for creating a new custom state column.
+   * Newly created states are pinned by default so they remain visible.
+   */
+  private renderCreateCustomStateInput(
+    containerEl: HTMLElement,
+    currentPinnedStates: string[],
+  ): void {
+    const existingIds = new Set(this.adapter.config.columns.map((c) => c.id));
+
+    new Setting(containerEl)
+      .setName("Create custom state")
+      .setDesc(
+        "Add a new custom state column. The column will be pinned by default so it stays visible even with no tasks. Use lowercase identifiers with hyphens (e.g. review, blocked-upstream).",
+      )
+      .addText((text) => {
+        text.inputEl.placeholder = "e.g. review";
+        text.inputEl.addEventListener("keydown", async (e: KeyboardEvent) => {
+          if (e.key !== "Enter") return;
+          e.preventDefault();
+          const value = text.inputEl.value.trim().toLowerCase().replace(/\s+/g, "-");
+          if (!value) return;
+          if (existingIds.has(value)) {
+            new Notice(`Column "${value}" already exists`);
+            return;
+          }
+
+          // Add to column order and pin it
+          const columns = this.adapter.config.columns;
+          const ids = columns.map((c) => c.id);
+          ids.push(value);
+          const newPinned = [...currentPinnedStates, value];
+
+          await this.saveSettings((settings) => {
+            settings["adapter.columnOrder"] = JSON.stringify(ids);
+            settings["adapter.pinnedCustomStates"] = JSON.stringify(newPinned);
+          });
+          new Notice(`Custom state "${value}" created and pinned`);
+          this.display();
+        });
+      });
   }
 
   /**


### PR DESCRIPTION
## Summary

- **Auto-cleanup**: Empty dynamic/custom state columns (those without a `folderName`) are automatically removed from the board and column order settings when no tasks remain in them. Predefined columns (Priority, Active, To Do, Done) are never removed.
- **Pin custom states**: Dynamic columns can be pinned via a new Pin/Unpin button in the column order settings UI. Pinned columns remain visible on the board even with zero tasks, preventing auto-cleanup.
- **Create custom states from settings**: A new "Create custom state" text input in settings lets users pre-create custom state columns without requiring existing tasks. Newly created states are pinned by default.

## Files changed

- `src/adapters/task-agent/TaskAgentConfig.ts` - `pinnedCustomStates` setting, helper functions
- `src/framework/SettingsTab.ts` - Pin toggle UI, create-custom-state input
- `src/framework/MainView.ts` - Auto-cleanup logic in `refreshList`
- `src/framework/ListPanel.ts` - `setPinnedCustomStates` method, skip-hide for pinned columns
- `src/adapters/task-agent/TaskAgentConfig.test.ts` - Tests for new helpers and defaults
- `src/framework/MainView.test.ts` - Tests for cleanup logic (4 scenarios)
- `docs/user-guide.md` - Documentation for all three features

## Test plan

- [x] All 1145 tests pass (`pnpm exec vitest run`)
- [x] Build succeeds (`pnpm run build`)
- [ ] Create a task with a custom frontmatter state (e.g. `state: review`), verify column appears
- [ ] Move the task out of the custom state, verify the column auto-cleans from the board
- [ ] Pin a custom state in settings, verify it stays visible when empty
- [ ] Use "Create custom state" input to create a new column, verify it appears pinned
- [ ] Reset column order to defaults, verify pinned states are also cleared

Fixes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)