### PR TITLE
Configurable detail view placement (#450)

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -16,6 +16,7 @@ Work Terminal turns your Obsidian vault into a work item board with per-item tab
   - [Hiding card indicators](#hiding-card-indicators)
   - [Context menu](#context-menu)
   - [Detail panel](#detail-panel)
+  - [Detail view placement](#detail-view-placement)
   - [Drag-drop reordering](#drag-drop-reordering)
   - [Filtering](#filtering)
   - [Activity view](#activity-view)
@@ -218,6 +219,25 @@ The detail panel provides:
 - **Backlinks** - Obsidian's native backlinks panel shows other notes that reference this task
 
 Because the detail panel is a standard Obsidian markdown view, all Obsidian features work: live preview, reading view, plugins that operate on markdown views, and the command palette.
+
+### Detail view placement
+
+The way the detail file is opened is configurable under **Settings > Detail view**. By default, selecting a task opens its file in a vertical split next to the Work Terminal view and applies a readable line-width override - this matches the behaviour shipped in earlier versions, so users who never open the settings see no change.
+
+The **Placement** dropdown offers four strategies:
+
+- **Split (default)** - create a new split beside the Work Terminal view and apply the min-width override so the editor does not squish. Best when Work Terminal sits in its own tab group.
+- **Tab in active group** - open the task file as a new tab in the currently active tab group, with no splitting and no width override. Best when Work Terminal lives in a tab group alongside other files and you want the detail view to behave like any other tab.
+- **Navigate active leaf** - replace the contents of the active leaf, matching Obsidian's standard "open file" behaviour. No new tabs or splits are created.
+- **Disabled** - do nothing on selection. Useful if you prefer to open files manually via the file explorer, quick switcher, or Obsidian's hover preview, or if you only need the terminal side of Work Terminal.
+
+Additional options shape the behaviour:
+
+- **Auto-close on selection change** (all placements except Disabled) - detaches the detail leaf when you select a different item, so the next selection opens a fresh leaf at the current placement target. With this off, the same leaf is reused across selections.
+- **Apply readable line-width override to split** (Split only) - toggles the width override. When off, Obsidian's default flex layout controls the split and any previously-applied inline styles are cleared on the next selection.
+- **Split direction** (Split only) - choose Vertical (side by side) or Horizontal (top and bottom). Vertical matches the default behaviour.
+
+The plugin never touches leaves you opened yourself. Adopted leaves (ones Work Terminal discovered rather than created) are left in place when the selection changes; only leaves the plugin created are detached by auto-close or plugin reload.
 
 ### Drag-drop reordering
 

--- a/src/adapters/task-agent/TaskDetailView.ts
+++ b/src/adapters/task-agent/TaskDetailView.ts
@@ -189,9 +189,13 @@ export class TaskDetailView {
 
   /**
    * Ensure we have a leaf to render the detail view into for the "tab"
-   * placement. Uses Obsidian's active tab group via `getLeaf("tab")`, which
-   * opens a new tab in the currently active tab group without splitting.
-   * Reuses an owned leaf if one already exists.
+   * placement. Prefers the currently-managed leaf if still attached; falls
+   * back to a fresh tab in the active tab group via `getLeaf("tab")`.
+   *
+   * Deliberately does NOT scan the workspace for arbitrary owned leaves -
+   * doing so can adopt a leaf that lives in a different tab group than the
+   * active one, which would violate the documented "open in the active tab
+   * group" semantics of this placement.
    */
   private ensureTabLeaf(): void {
     // Reuse our managed leaf if still attached
@@ -203,15 +207,6 @@ export class TaskDetailView {
       }
     }
     if (this.editorLeaf) return;
-
-    // Look for an owned leaf (one showing a file we previously opened) and
-    // reuse it to avoid piling up tabs on repeated selections.
-    const { ownedLeaf } = this.findEditorLeaves();
-    if (ownedLeaf) {
-      this.editorLeaf = ownedLeaf;
-      this.leafIsOwned = false;
-      return;
-    }
 
     // Open a fresh tab in the currently active tab group.
     this.leafIsOwned = true;

--- a/src/adapters/task-agent/TaskDetailView.ts
+++ b/src/adapters/task-agent/TaskDetailView.ts
@@ -1,5 +1,6 @@
 import type { App, TFile, WorkspaceLeaf } from "obsidian";
 import type { WorkItem } from "../../core/interfaces";
+import { DETAIL_VIEW_DEFAULTS, type DetailViewOptions } from "../../core/detailViewPlacement";
 
 export class TaskDetailView {
   private editorLeaf: WorkspaceLeaf | null = null;
@@ -10,10 +11,27 @@ export class TaskDetailView {
   // Paths we've opened - used to identify leaves safe to adopt (they're showing
   // a file we put there, not something the user or another plugin opened).
   private openedPaths = new Set<string>();
+  // Containers whose flex styles we modified via applyMinEditorWidth. We track
+  // them so we can restore them when the width override is turned off.
+  private widthOverrideContainers: HTMLElement[] = [];
+  // Identifier of the last item we opened a detail view for. Used by the
+  // auto-close behaviour to detach the previous leaf when the selection moves
+  // to a different item.
+  private lastItemId: string | null = null;
 
   constructor(private app: App) {}
 
-  async show(item: WorkItem, ownerLeaf: WorkspaceLeaf): Promise<void> {
+  async show(
+    item: WorkItem,
+    ownerLeaf: WorkspaceLeaf,
+    options: DetailViewOptions = DETAIL_VIEW_DEFAULTS,
+  ): Promise<void> {
+    // "Disabled" short-circuits: no leaf creation, no file open. Respect the
+    // user's current workspace arrangement entirely.
+    if (options.placement === "disabled") {
+      return;
+    }
+
     const file = this.app.vault.getAbstractFileByPath(item.path) as TFile;
     if (!file) return;
 
@@ -21,7 +39,46 @@ export class TaskDetailView {
     if (this._showInProgress) return;
     this._showInProgress = true;
     try {
-      this.ensureEditorLeaf(ownerLeaf);
+      // Auto-close: when the selection moves to a different item, detach the
+      // previously-opened leaf so the detail view always opens fresh at the
+      // current placement target. Re-selecting the same item keeps the leaf.
+      if (options.autoClose && this.lastItemId && this.lastItemId !== item.id) {
+        this.detachLeaf();
+      }
+      this.lastItemId = item.id;
+
+      if (options.placement === "navigate") {
+        // Replace the contents of the active leaf. This matches Obsidian's
+        // standard "open file" behaviour and does not split or create tabs.
+        const activeLeaf = this.app.workspace.getLeaf(false);
+        if (!activeLeaf) return;
+        // Treat the active leaf as not-owned so we don't detach user state.
+        this.editorLeaf = activeLeaf;
+        this.leafIsOwned = false;
+        await activeLeaf.openFile(file);
+        this.openedPaths.add(item.path);
+        return;
+      }
+
+      if (options.placement === "tab") {
+        // Create a new tab in the active tab group. No splitting; no width
+        // override. If the file is already open in a tab we own we reuse it,
+        // matching the split-mode adoption behaviour.
+        this.ensureTabLeaf();
+        if (this.editorLeaf) {
+          await this.editorLeaf.openFile(file);
+          this.openedPaths.add(item.path);
+          const tabGroup = (this.editorLeaf as any).parent;
+          if (tabGroup?.selectTab) {
+            tabGroup.selectTab(this.editorLeaf);
+          }
+        }
+        return;
+      }
+
+      // Default: "split" - preserve the original behaviour, with configurable
+      // direction and an optional width override.
+      this.ensureEditorLeaf(ownerLeaf, options.splitDirection);
 
       if (this.editorLeaf) {
         await this.editorLeaf.openFile(file);
@@ -32,13 +89,27 @@ export class TaskDetailView {
         if (tabGroup?.selectTab) {
           tabGroup.selectTab(this.editorLeaf);
         }
+
+        if (!options.widthOverride) {
+          // The override may have been applied in a previous show() call.
+          // Clear any inline styles we set so Obsidian's flex layout takes over.
+          this.clearWidthOverride();
+        }
       }
     } finally {
       this._showInProgress = false;
     }
   }
 
-  private ensureEditorLeaf(ownerLeaf: WorkspaceLeaf): void {
+  /**
+   * Ensure we have an editor leaf to render the detail view into, for the
+   * "split" placement. Prefers reusing an owned leaf or an existing editor
+   * leaf in a sibling tab group; falls back to creating a fresh split.
+   */
+  private ensureEditorLeaf(
+    ownerLeaf: WorkspaceLeaf,
+    splitDirection: "vertical" | "horizontal",
+  ): void {
     // Check if our managed leaf is still attached to the workspace.
     // Uses parent reference instead of getLeavesOfType("markdown") because
     // a freshly-split leaf starts as type "empty" before openFile completes.
@@ -77,10 +148,41 @@ export class TaskDetailView {
 
     // No editor leaves at all - create a new split off our owner leaf
     this.leafIsOwned = true;
-    this.editorLeaf = this.app.workspace.createLeafBySplit(ownerLeaf, "vertical", false);
+    this.editorLeaf = this.app.workspace.createLeafBySplit(ownerLeaf, splitDirection, false);
 
     // Defer width application to let Obsidian's layout pass complete
     setTimeout(() => this.applyMinEditorWidth(), 100);
+  }
+
+  /**
+   * Ensure we have a leaf to render the detail view into for the "tab"
+   * placement. Uses Obsidian's active tab group via `getLeaf("tab")`, which
+   * opens a new tab in the currently active tab group without splitting.
+   * Reuses an owned leaf if one already exists.
+   */
+  private ensureTabLeaf(): void {
+    // Reuse our managed leaf if still attached
+    if (this.editorLeaf) {
+      const parent = (this.editorLeaf as any).parent;
+      if (!parent) {
+        this.editorLeaf = null;
+        this.leafIsOwned = false;
+      }
+    }
+    if (this.editorLeaf) return;
+
+    // Look for an owned leaf (one showing a file we previously opened) and
+    // reuse it to avoid piling up tabs on repeated selections.
+    const { ownedLeaf } = this.findEditorLeaves();
+    if (ownedLeaf) {
+      this.editorLeaf = ownedLeaf;
+      this.leafIsOwned = false;
+      return;
+    }
+
+    // Open a fresh tab in the currently active tab group.
+    this.leafIsOwned = true;
+    this.editorLeaf = this.app.workspace.getLeaf("tab");
   }
 
   /**
@@ -165,13 +267,29 @@ export class TaskDetailView {
       editorChild.containerEl.style.flexGrow = "0";
       editorChild.containerEl.style.flexShrink = "0";
       editorChild.containerEl.style.flexBasis = `${editorWidth}px`;
+      this.widthOverrideContainers.push(editorChild.containerEl);
     }
     // Terminal split: fill remaining space
     if (ttChild?.containerEl) {
       ttChild.containerEl.style.flexGrow = "1";
       ttChild.containerEl.style.flexShrink = "1";
       ttChild.containerEl.style.flexBasis = "0%";
+      this.widthOverrideContainers.push(ttChild.containerEl);
     }
+  }
+
+  /**
+   * Restore the flex styles on any containers we previously modified via
+   * applyMinEditorWidth(). Called when the width override setting is turned
+   * off so Obsidian's default flex layout resumes controlling the split.
+   */
+  private clearWidthOverride(): void {
+    for (const el of this.widthOverrideContainers) {
+      el.style.flexGrow = "";
+      el.style.flexShrink = "";
+      el.style.flexBasis = "";
+    }
+    this.widthOverrideContainers = [];
   }
 
   rekeyPath(oldPath: string, newPath: string): void {
@@ -180,14 +298,24 @@ export class TaskDetailView {
     }
   }
 
-  detach(): void {
+  /**
+   * Detach the managed leaf (if we own it) and clear width override styles.
+   * Leaves the `openedPaths` set intact so future adoption still works.
+   * Used by auto-close and `detach()`.
+   */
+  private detachLeaf(): void {
     if (this.editorLeaf) {
-      // Only detach leaves we created via split - leave adopted leaves intact
       if (this.leafIsOwned) {
         this.editorLeaf.detach();
       }
       this.editorLeaf = null;
       this.leafIsOwned = false;
     }
+    this.clearWidthOverride();
+  }
+
+  detach(): void {
+    this.detachLeaf();
+    this.lastItemId = null;
   }
 }

--- a/src/adapters/task-agent/TaskDetailView.ts
+++ b/src/adapters/task-agent/TaskDetailView.ts
@@ -59,11 +59,11 @@ export class TaskDetailView {
         // standard "open file" behaviour and does not split or create tabs.
         const activeLeaf = this.app.workspace.getLeaf(false);
         if (!activeLeaf) return;
-        // Treat the active leaf as not-owned so we don't detach user state.
+        // Don't track navigate-mode leaves: keeps split/tab placements from
+        // adopting user leaves later via findEditorLeaves's path-based match.
         this.editorLeaf = activeLeaf;
         this.leafIsOwned = false;
         await activeLeaf.openFile(file);
-        this.openedPaths.add(item.path);
         return;
       }
 

--- a/src/adapters/task-agent/TaskDetailView.ts
+++ b/src/adapters/task-agent/TaskDetailView.ts
@@ -14,6 +14,13 @@ export class TaskDetailView {
   // Containers whose flex styles we modified via applyMinEditorWidth. We track
   // them so we can restore them when the width override is turned off.
   private widthOverrideContainers: HTMLElement[] = [];
+  // Tracks whether the width override is currently enabled. Checked inside
+  // applyMinEditorWidth() so a deferred timeout can't re-apply styles after
+  // the setting has been turned off or placement has switched away from split.
+  private widthOverrideActive = false;
+  // Pending timeout handle for applyMinEditorWidth. Cleared when placement
+  // changes or width override is disabled to prevent races.
+  private applyWidthTimer: ReturnType<typeof setTimeout> | null = null;
   // Identifier of the last item we opened a detail view for. Used by the
   // auto-close behaviour to detach the previous leaf when the selection moves
   // to a different item.
@@ -90,7 +97,14 @@ export class TaskDetailView {
           tabGroup.selectTab(this.editorLeaf);
         }
 
-        if (!options.widthOverride) {
+        if (options.widthOverride) {
+          // Mark the override as active and schedule application once
+          // Obsidian's layout pass settles. The flag is also checked inside
+          // applyMinEditorWidth so a stale timer can't re-apply styles after
+          // the setting has flipped off or placement has changed.
+          this.widthOverrideActive = true;
+          this.scheduleApplyMinEditorWidth();
+        } else {
           // The override may have been applied in a previous show() call.
           // Clear any inline styles we set so Obsidian's flex layout takes over.
           this.clearWidthOverride();
@@ -149,9 +163,21 @@ export class TaskDetailView {
     // No editor leaves at all - create a new split off our owner leaf
     this.leafIsOwned = true;
     this.editorLeaf = this.app.workspace.createLeafBySplit(ownerLeaf, splitDirection, false);
+  }
 
-    // Defer width application to let Obsidian's layout pass complete
-    setTimeout(() => this.applyMinEditorWidth(), 100);
+  /**
+   * Schedule a deferred width override application once Obsidian's layout
+   * pass has settled. Any pending timer is cleared first so rapid placement
+   * changes can't stack or race.
+   */
+  private scheduleApplyMinEditorWidth(): void {
+    if (this.applyWidthTimer !== null) {
+      clearTimeout(this.applyWidthTimer);
+    }
+    this.applyWidthTimer = setTimeout(() => {
+      this.applyWidthTimer = null;
+      this.applyMinEditorWidth();
+    }, 100);
   }
 
   /**
@@ -241,6 +267,10 @@ export class TaskDetailView {
   }
 
   private applyMinEditorWidth(): void {
+    // Defensive check - a stale timer may fire after the override was turned
+    // off or placement changed. Don't write inline styles unless the override
+    // is still the active configuration.
+    if (!this.widthOverrideActive) return;
     if (!this.editorLeaf) return;
 
     // createLeafBySplit wraps each side in its own split container,
@@ -284,6 +314,12 @@ export class TaskDetailView {
    * off so Obsidian's default flex layout resumes controlling the split.
    */
   private clearWidthOverride(): void {
+    // Mark inactive first so any in-flight timer becomes a no-op.
+    this.widthOverrideActive = false;
+    if (this.applyWidthTimer !== null) {
+      clearTimeout(this.applyWidthTimer);
+      this.applyWidthTimer = null;
+    }
     for (const el of this.widthOverrideContainers) {
       el.style.flexGrow = "";
       el.style.flexShrink = "";

--- a/src/adapters/task-agent/TaskDetailView.ts
+++ b/src/adapters/task-agent/TaskDetailView.ts
@@ -33,6 +33,13 @@ export class TaskDetailView {
     ownerLeaf: WorkspaceLeaf,
     options: DetailViewOptions = DETAIL_VIEW_DEFAULTS,
   ): Promise<void> {
+    // Any non-split placement must clear the split width override so stale
+    // inline flex styles from a previous split don't persist after the user
+    // switches placement. Runs before early returns for "disabled" etc.
+    if (options.placement !== "split") {
+      this.clearWidthOverride();
+    }
+
     // "Disabled" short-circuits: no leaf creation, no file open. Respect the
     // user's current workspace arrangement entirely.
     if (options.placement === "disabled") {

--- a/src/adapters/task-agent/index.ts
+++ b/src/adapters/task-agent/index.ts
@@ -16,6 +16,7 @@ import { TaskMover } from "./TaskMover";
 import { TaskCard } from "./TaskCard";
 import { TaskPromptBuilder } from "./TaskPromptBuilder";
 import { TaskDetailView } from "./TaskDetailView";
+import { resolveDetailViewOptions } from "../../core/detailViewPlacement";
 import {
   handleItemCreated,
   handleSplitTaskCreated,
@@ -129,10 +130,17 @@ export class TaskAgentAdapter extends BaseAdapter {
 
   createDetailView(item: WorkItem, app: App, ownerLeaf: WorkspaceLeaf): void {
     this._app = app;
+    const options = resolveDetailViewOptions(this._settings);
+    // "Disabled" placement means: do not instantiate a detail view at all.
+    // Early-return also prevents opening the file so the user's layout is
+    // left untouched on selection.
+    if (options.placement === "disabled") {
+      return;
+    }
     if (!this.detailView) {
       this.detailView = new TaskDetailView(app);
     }
-    this.detailView.show(item, ownerLeaf);
+    this.detailView.show(item, ownerLeaf, options);
   }
 
   rekeyDetailPath(oldPath: string, newPath: string): void {

--- a/src/core/detailViewPlacement.test.ts
+++ b/src/core/detailViewPlacement.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { DETAIL_VIEW_DEFAULTS, resolveDetailViewOptions } from "./detailViewPlacement";
+
+describe("resolveDetailViewOptions", () => {
+  it("returns defaults when settings are undefined", () => {
+    const options = resolveDetailViewOptions(undefined);
+    expect(options).toEqual(DETAIL_VIEW_DEFAULTS);
+  });
+
+  it("returns defaults for an empty settings object", () => {
+    const options = resolveDetailViewOptions({});
+    expect(options).toEqual(DETAIL_VIEW_DEFAULTS);
+  });
+
+  it("preserves backwards-compatible split defaults", () => {
+    // Covers acceptance criterion: "Default is backwards-compatible (split mode)"
+    expect(DETAIL_VIEW_DEFAULTS.placement).toBe("split");
+    expect(DETAIL_VIEW_DEFAULTS.widthOverride).toBe(true);
+    expect(DETAIL_VIEW_DEFAULTS.autoClose).toBe(false);
+    expect(DETAIL_VIEW_DEFAULTS.splitDirection).toBe("vertical");
+  });
+
+  it("accepts each valid placement value", () => {
+    for (const placement of ["split", "tab", "navigate", "disabled"] as const) {
+      const options = resolveDetailViewOptions({
+        "core.detailViewPlacement": placement,
+      });
+      expect(options.placement).toBe(placement);
+    }
+  });
+
+  it("falls back to split for an unknown placement value", () => {
+    const options = resolveDetailViewOptions({
+      "core.detailViewPlacement": "bogus",
+    });
+    expect(options.placement).toBe("split");
+  });
+
+  it("falls back to split for a non-string placement value", () => {
+    const options = resolveDetailViewOptions({
+      "core.detailViewPlacement": 42,
+    });
+    expect(options.placement).toBe("split");
+  });
+
+  it("accepts both split directions", () => {
+    for (const direction of ["vertical", "horizontal"] as const) {
+      const options = resolveDetailViewOptions({
+        "core.detailViewSplitDirection": direction,
+      });
+      expect(options.splitDirection).toBe(direction);
+    }
+  });
+
+  it("falls back to vertical for an unknown split direction", () => {
+    const options = resolveDetailViewOptions({
+      "core.detailViewSplitDirection": "diagonal",
+    });
+    expect(options.splitDirection).toBe("vertical");
+  });
+
+  it("honours widthOverride when explicitly set", () => {
+    const off = resolveDetailViewOptions({ "core.detailViewWidthOverride": false });
+    expect(off.widthOverride).toBe(false);
+
+    const on = resolveDetailViewOptions({ "core.detailViewWidthOverride": true });
+    expect(on.widthOverride).toBe(true);
+  });
+
+  it("defaults widthOverride to true when value is not a boolean", () => {
+    const options = resolveDetailViewOptions({
+      "core.detailViewWidthOverride": "yes",
+    });
+    expect(options.widthOverride).toBe(true);
+  });
+
+  it("honours autoClose when explicitly set", () => {
+    const on = resolveDetailViewOptions({ "core.detailViewAutoClose": true });
+    expect(on.autoClose).toBe(true);
+
+    const off = resolveDetailViewOptions({ "core.detailViewAutoClose": false });
+    expect(off.autoClose).toBe(false);
+  });
+
+  it("defaults autoClose to false when value is not a boolean", () => {
+    const options = resolveDetailViewOptions({
+      "core.detailViewAutoClose": "true",
+    });
+    expect(options.autoClose).toBe(false);
+  });
+
+  it("combines all settings into a single options object", () => {
+    const options = resolveDetailViewOptions({
+      "core.detailViewPlacement": "tab",
+      "core.detailViewSplitDirection": "horizontal",
+      "core.detailViewWidthOverride": false,
+      "core.detailViewAutoClose": true,
+    });
+    expect(options).toEqual({
+      placement: "tab",
+      splitDirection: "horizontal",
+      widthOverride: false,
+      autoClose: true,
+    });
+  });
+
+  it("ignores unrelated settings", () => {
+    const options = resolveDetailViewOptions({
+      "core.defaultShell": "/bin/zsh",
+      "core.viewMode": "kanban",
+    });
+    expect(options).toEqual(DETAIL_VIEW_DEFAULTS);
+  });
+});

--- a/src/core/detailViewPlacement.ts
+++ b/src/core/detailViewPlacement.ts
@@ -1,0 +1,75 @@
+/**
+ * Detail view placement options.
+ *
+ * Controls how the detail view for a selected work item is opened relative to
+ * the Work Terminal view. Users with single-pane or tab-based layouts can
+ * pick an option that respects their workspace arrangement.
+ *
+ * - `split` - default. Create a new split beside the Work Terminal view and
+ *   optionally apply a min-width override so the editor does not squish.
+ * - `tab` - open the detail file as a new tab in the currently active tab
+ *   group (no splitting, no width override).
+ * - `navigate` - replace the contents of the currently active leaf, matching
+ *   the standard Obsidian "file open" behaviour.
+ * - `disabled` - do nothing on selection. Users open files manually via the
+ *   file explorer, quick switcher, or context menu.
+ */
+export type DetailViewPlacement = "split" | "tab" | "navigate" | "disabled";
+
+/** Orientation for the `split` placement. Matches Obsidian's createLeafBySplit arg. */
+export type DetailViewSplitDirection = "vertical" | "horizontal";
+
+/** Resolved, strongly-typed options for TaskDetailView behaviour. */
+export interface DetailViewOptions {
+  placement: DetailViewPlacement;
+  /** Apply min-width flex override. Only meaningful when placement is "split". */
+  widthOverride: boolean;
+  /** Detach the detail leaf when a different item is selected. */
+  autoClose: boolean;
+  /** Orientation for createLeafBySplit. Only meaningful when placement is "split". */
+  splitDirection: DetailViewSplitDirection;
+}
+
+export const DETAIL_VIEW_DEFAULTS: DetailViewOptions = {
+  placement: "split",
+  widthOverride: true,
+  autoClose: false,
+  splitDirection: "vertical",
+};
+
+const VALID_PLACEMENTS: ReadonlySet<string> = new Set(["split", "tab", "navigate", "disabled"]);
+
+const VALID_SPLIT_DIRECTIONS: ReadonlySet<string> = new Set(["vertical", "horizontal"]);
+
+/**
+ * Resolve typed DetailViewOptions from a flat settings map. Unknown or invalid
+ * values fall back to the defaults, which preserves backwards-compatible
+ * behaviour (split, width override on, horizontal split off, auto-close off).
+ */
+export function resolveDetailViewOptions(
+  settings: Record<string, unknown> | undefined,
+): DetailViewOptions {
+  const s = settings ?? {};
+
+  const rawPlacement = s["core.detailViewPlacement"];
+  const placement: DetailViewPlacement =
+    typeof rawPlacement === "string" && VALID_PLACEMENTS.has(rawPlacement)
+      ? (rawPlacement as DetailViewPlacement)
+      : DETAIL_VIEW_DEFAULTS.placement;
+
+  const rawDirection = s["core.detailViewSplitDirection"];
+  const splitDirection: DetailViewSplitDirection =
+    typeof rawDirection === "string" && VALID_SPLIT_DIRECTIONS.has(rawDirection)
+      ? (rawDirection as DetailViewSplitDirection)
+      : DETAIL_VIEW_DEFAULTS.splitDirection;
+
+  const rawWidthOverride = s["core.detailViewWidthOverride"];
+  const widthOverride =
+    typeof rawWidthOverride === "boolean" ? rawWidthOverride : DETAIL_VIEW_DEFAULTS.widthOverride;
+
+  const rawAutoClose = s["core.detailViewAutoClose"];
+  const autoClose =
+    typeof rawAutoClose === "boolean" ? rawAutoClose : DETAIL_VIEW_DEFAULTS.autoClose;
+
+  return { placement, widthOverride, autoClose, splitDirection };
+}

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -183,6 +183,12 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
         }),
       );
 
+    // Detail view section - controls how task detail files are opened when
+    // a work item is selected. Placement-dependent controls are only shown
+    // when they apply.
+    containerEl.createEl("h2", { text: "Detail view" });
+    this.renderDetailViewSettings(containerEl);
+
     // Adapter settings section
     const schema = this.adapter.config.settingsSchema;
     if (schema.length > 0) {
@@ -295,6 +301,71 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
           });
         });
       });
+  }
+
+  /**
+   * Render the Detail view settings group: placement dropdown plus
+   * placement-dependent width override, auto-close, and split direction
+   * controls. Re-renders the whole settings page on placement change so the
+   * conditional controls appear or disappear.
+   */
+  private async renderDetailViewSettings(containerEl: HTMLElement): Promise<void> {
+    const data = (await this.plugin.loadData()) || {};
+    const settings = data.settings || {};
+    const placement =
+      (settings["core.detailViewPlacement"] as string) ?? CORE_DEFAULTS["core.detailViewPlacement"];
+
+    // Placement dropdown - drives visibility of other fields in this section.
+    new Setting(containerEl)
+      .setName("Placement")
+      .setDesc(
+        "How the task file opens when you select a work item. " +
+          "Split opens a new split beside the Work Terminal view (default). " +
+          "Tab opens a new tab in the active tab group. " +
+          "Navigate replaces the contents of the active editor. " +
+          "Disabled does nothing - open files manually via the file explorer or quick switcher.",
+      )
+      .addDropdown((dropdown) => {
+        dropdown.addOption("split", "Split (default)");
+        dropdown.addOption("tab", "Tab in active group");
+        dropdown.addOption("navigate", "Navigate active leaf");
+        dropdown.addOption("disabled", "Disabled");
+        dropdown.setValue(placement).onChange(async (newValue) => {
+          await this.saveSettings((s) => {
+            s["core.detailViewPlacement"] = newValue;
+          });
+          // Re-render to update visibility of placement-dependent settings
+          this.display();
+        });
+      });
+
+    // Auto-close applies to any placement except "disabled" (where nothing is
+    // opened anyway). It's a general behaviour toggle, not split-specific.
+    if (placement !== "disabled") {
+      this.addCoreToggle(
+        containerEl,
+        "core.detailViewAutoClose",
+        "Auto-close on selection change",
+        "Detach the detail leaf when you select a different item, opening a fresh one at the current placement target. When off, the same leaf is reused across selections.",
+      );
+    }
+
+    // Width override and split direction only apply when placement is "split".
+    if (placement === "split") {
+      this.addCoreToggle(
+        containerEl,
+        "core.detailViewWidthOverride",
+        "Apply readable line-width override to split",
+        "Forces the editor split to the Obsidian readable line width and lets the terminal panel fill the rest. Turn off if you prefer Obsidian's default flex sizing for the split.",
+      );
+      this.addCoreDropdown(
+        containerEl,
+        "core.detailViewSplitDirection",
+        "Split direction",
+        "Orientation of the split created alongside the Work Terminal view. Vertical stacks side-by-side; horizontal stacks top-and-bottom.",
+        { vertical: "Vertical (side by side)", horizontal: "Horizontal (top and bottom)" },
+      );
+    }
   }
 
   private async addCardFlagRulesButton(containerEl: HTMLElement): Promise<void> {

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -22,6 +22,7 @@ import { AgentProfileManagerModal } from "./AgentProfileManagerModal";
 import { CardFlagManagerModal } from "./CardFlagManagerModal";
 import { parseCardFlagRulesJson, serializeCardFlagRules } from "../core/cardFlags";
 import type { ViewMode, RecentThreshold } from "./ActivityTracker";
+import type { DetailViewPlacement, DetailViewSplitDirection } from "../core/detailViewPlacement";
 
 interface CoreSettings {
   "core.claudeCommand": string;
@@ -38,6 +39,10 @@ interface CoreSettings {
   "core.cardDisplayMode": CardDisplayMode;
   "core.viewMode": ViewMode;
   "core.recentThreshold": RecentThreshold;
+  "core.detailViewPlacement": DetailViewPlacement;
+  "core.detailViewWidthOverride": boolean;
+  "core.detailViewAutoClose": boolean;
+  "core.detailViewSplitDirection": DetailViewSplitDirection;
 }
 
 export const SETTINGS_CHANGED_EVENT = "work-terminal:settings-changed";
@@ -57,6 +62,10 @@ const CORE_DEFAULTS: CoreSettings = {
   "core.cardDisplayMode": "standard",
   "core.viewMode": "kanban",
   "core.recentThreshold": "3h",
+  "core.detailViewPlacement": "split",
+  "core.detailViewWidthOverride": true,
+  "core.detailViewAutoClose": false,
+  "core.detailViewSplitDirection": "vertical",
 };
 
 export class WorkTerminalSettingsTab extends PluginSettingTab {

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -23,6 +23,7 @@ import { CardFlagManagerModal } from "./CardFlagManagerModal";
 import { parseCardFlagRulesJson, serializeCardFlagRules } from "../core/cardFlags";
 import type { ViewMode, RecentThreshold } from "./ActivityTracker";
 import type { DetailViewPlacement, DetailViewSplitDirection } from "../core/detailViewPlacement";
+import { resolveDetailViewOptions } from "../core/detailViewPlacement";
 
 interface CoreSettings {
   "core.claudeCommand": string;
@@ -312,8 +313,10 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
   private async renderDetailViewSettings(containerEl: HTMLElement): Promise<void> {
     const data = (await this.plugin.loadData()) || {};
     const settings = data.settings || {};
-    const placement =
-      (settings["core.detailViewPlacement"] as string) ?? CORE_DEFAULTS["core.detailViewPlacement"];
+    // Resolve via resolveDetailViewOptions so invalid persisted values (from
+    // manual edits or older plugin versions) fall back to the default and
+    // the dropdown/conditional rendering stay consistent.
+    const placement = resolveDetailViewOptions(settings).placement;
 
     // Placement dropdown - drives visibility of other fields in this section.
     new Setting(containerEl)


### PR DESCRIPTION
## Summary

Makes detail view placement configurable under **Settings > Detail view**, replacing the previously-unconditional "split beside Work Terminal + width override" behaviour. Users with tab-based layouts or single-pane workflows can now pick a placement that respects their workspace.

Default behaviour is unchanged (split, width override on, vertical, auto-close off), so existing users see no difference unless they visit the new settings section.

## Changes

- `src/core/detailViewPlacement.ts` - typed enums (`DetailViewPlacement`, `DetailViewSplitDirection`), `DetailViewOptions` interface, defaults, and the pure `resolveDetailViewOptions()` helper that translates raw settings into typed options with sane fallbacks for unknown/invalid values.
- `src/adapters/task-agent/TaskDetailView.ts` - `show()` now accepts `DetailViewOptions` and dispatches on placement:
  - `split` - original path, with configurable split direction and a width override that can be cleared at runtime.
  - `tab` - `app.workspace.getLeaf("tab")` opens a new tab in the active tab group; no splitting, no width override.
  - `navigate` - `app.workspace.getLeaf(false)` replaces the active leaf's contents.
  - `disabled` - early return, no leaf creation or file open.
  - Auto-close detaches the previously-owned detail leaf when selection moves to a different item. Adopted (not-owned) leaves are never detached - ownership tracking is unchanged.
- `src/adapters/task-agent/index.ts` - reads options from cached settings and short-circuits `createDetailView` entirely when placement is `disabled`.
- `src/framework/SettingsTab.ts` - new "Detail view" section with placement dropdown, width override toggle, auto-close toggle, and split direction dropdown. Width override and split direction only appear when placement is `split`; auto-close is hidden when placement is `disabled`.
- `docs/user-guide.md` - new "Detail view placement" subsection documenting each option and calling out backwards compatibility.
- `src/core/detailViewPlacement.test.ts` - 14 new vitest cases for the helper, covering defaults, enum validation, fallback on bad input, and end-to-end combinations.

## Acceptance criteria

- [x] Users can choose placement from settings
- [x] "Disabled" option prevents any leaf creation (early return in both `createDetailView` and `show()`)
- [x] Width override can be independently toggled off (and previously-applied inline styles are cleared)
- [x] Default is backwards-compatible (split, vertical, width override on, auto-close off)
- [x] User guide updated with a dedicated section
- [x] Works correctly when Work Terminal is a tab in a group with other files (tab / navigate placements leave tab arrangement untouched)

## UX decisions for review

- **Auto-close semantic** - the spec says "when selection changes"; since the current `onSelect` path only fires with a non-null item, I interpreted this as "detach the previously-owned leaf when selection moves to a different item, so the next selection opens a fresh leaf at the current placement target". Re-selecting the same item keeps the leaf in place.
- **Auto-close scope** - exposed for every non-disabled placement, not just split. It's a general behaviour toggle.
- **Conditional UI** - placement-dependent settings (width override, split direction) are hidden when they don't apply, and the settings page re-renders on placement change. An alternative would be to grey them out; hiding felt less noisy.
- **Tab placement reuse** - if we've previously opened the file in a tab we own, that tab is reused rather than spawning a new one on every selection. Matches the split-mode adoption behaviour.
- **Width override gate** - toggling width override off at runtime clears the inline flex styles on the sibling containers, restoring Obsidian's default flex layout on the next selection rather than requiring a plugin reload.

## Test plan

- [x] `pnpm exec vitest run` - 1159 tests pass (1145 baseline + 14 new)
- [x] `pnpm run build` - clean production build
- [ ] Manual: set placement to each of the four values in a vault with Work Terminal as a split, verify behaviour
- [ ] Manual: Work Terminal as a tab in a group with other files, confirm `tab` and `navigate` placements do not disrupt the tab arrangement
- [ ] Manual: toggle width override off while Work Terminal is open, select a different task, confirm Obsidian's flex layout resumes
- [ ] Manual: toggle auto-close on, switch between tasks, confirm the detail leaf is detached between selections

Fixes #450