### PR TITLE
Enrichment settings dialog with default prompt previews (#451)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ GitHub release notes should mirror these entries rather than pasting the raw aut
 
 ### Added
 - Added diagnostic log files for failed background enrichment attempts. Each failure now writes a categorised log to `<vault>/<configDir>/plugins/work-terminal/logs/enrich-<ts>-<slug>.log` (usually `<vault>/.obsidian/plugins/work-terminal/logs/...`) containing the enrichment prompt, agent stdout/stderr, exit code, adapter validation detail, and any JS error plus stack trace. Retention is 7 days / 50 files with auto-pruning on every write. Controlled by the new **Enrichment failure logs** toggle under Core settings (default: enabled). (#449)
+- Moved the enrichment prompt, retry prompt, agent profile, and timeout into a dedicated **Configure enrichment...** dialog opened from a new **Background enrichment** section in settings. The dialog shows each default prompt in a collapsible "View default prompt" block so users can read the built-in defaults before customising, and includes a **Preview resolved prompt** helper that substitutes `{{FILE_PATH}}` with an example path. The `enrichmentEnabled` toggle stays at the top level. No setting keys changed, so enrichment behaviour is identical for users who never open the dialog. (#451)
 
 ## [0.3.0] - 2026-04-17
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -450,13 +450,18 @@ Type a lowercase identifier with hyphens (e.g. `review`, `blocked-upstream`, `te
 
 When enabled, new tasks created via the prompt box are automatically enriched by a headless agent session. The agent reads the task file and adds context, acceptance criteria, and other useful content.
 
-Configure under **Adapter** in settings:
+The **Enable background enrichment** toggle lives under the **Background enrichment** section in the main settings. The rest of the enrichment options live in a dedicated dialog opened by the **Configure enrichment...** button next to the toggle.
 
-- **Enable background enrichment** - toggle on/off
-- **Enrichment prompt** - custom prompt template sent to the agent. Use `{{FILE_PATH}}` as a placeholder for the task file path.
-- **Retry enrichment prompt** - separate prompt used when retrying via the context menu
+The dialog contains:
+
+- **Enable background enrichment** - toggle on/off (also shown on the main settings page)
+- **Enrichment prompt** - custom prompt template sent to the agent. Use `{{FILE_PATH}}` as a placeholder for the task file path. Leave blank to use the built-in default; the full default prompt is shown in a collapsible "View default prompt" block below the textarea so you can read it before deciding whether to override.
+- **Retry enrichment prompt** - separate prompt used when retrying via the context menu. Same placeholder and default-preview treatment as the enrichment prompt.
 - **Enrichment agent profile** - which agent profile to use (defaults to core Claude settings)
 - **Enrichment timeout** - maximum time in seconds before the enrichment process is killed (default: 300s / 5 minutes)
+- **Preview resolved prompt** - pick either prompt and click **Preview** to see the template with `{{FILE_PATH}}` substituted using the example path `vault/2 - Areas/Tasks/todo/example.md`. Useful for sanity-checking a customised prompt without creating a real task.
+
+Changes save as you type; there is no Save button. Close the dialog with **Done** when you are finished.
 
 Tasks being enriched show an "ingesting..." indicator on their card. If enrichment fails, a red "enrichment failed" badge appears, and the context menu offers a "Retry Enrichment" option.
 
@@ -621,11 +626,11 @@ These settings appear under the **Adapter** section and are specific to the task
 | Task base path | Vault path containing task folders | `2 - Areas/Tasks` |
 | State resolution strategy | How task state is determined (folder/frontmatter/composite) | `folder` |
 | Jira base URL | URL prefix for turning Jira keys into links (e.g. `https://your-org.atlassian.net/browse`) | (empty) |
-| Enable background enrichment | Auto-enrich new tasks via headless agent | `true` |
-| Enrichment prompt | Custom prompt template for enrichment | (default) |
-| Retry enrichment prompt | Custom prompt for retry enrichment | (default) |
-| Enrichment agent profile | Which profile to use for enrichment | Default |
-| Enrichment timeout | Max seconds for enrichment | 300 |
+| Enable background enrichment | Auto-enrich new tasks via headless agent. Top-level toggle; rest of the options live in **Configure enrichment...** dialog | `true` |
+| Enrichment prompt | Custom prompt template for enrichment (edit via **Configure enrichment...**) | (default) |
+| Retry enrichment prompt | Custom prompt for retry enrichment (edit via **Configure enrichment...**) | (default) |
+| Enrichment agent profile | Which profile to use for enrichment (edit via **Configure enrichment...**) | Default |
+| Enrichment timeout | Max seconds for enrichment (edit via **Configure enrichment...**) | 300 |
 | Show card indicators | Show metadata indicators on cards (source badges, priority scores, goal tags, card flags, indicator dots). See [Hiding card indicators](#hiding-card-indicators). | `true` |
 | Task card icons | Show icons on task cards | `false` |
 | Automatic icon mode | How automatic icons are assigned (none/source/state) | `none` |

--- a/src/framework/EnrichmentSettingsDialog.ts
+++ b/src/framework/EnrichmentSettingsDialog.ts
@@ -138,7 +138,12 @@ export class EnrichmentSettingsDialog extends Modal {
     const output = section.createEl("pre", {
       cls: "wt-enrichment-dialog__preview-output",
     });
-    output.textContent = "Click Preview to resolve the selected prompt.";
+    // Seed the preview with the currently-persisted enrichment prompt so the
+    // panel is useful immediately, without requiring the user to click Preview
+    // just to see what their saved prompt resolves to.
+    const initialTemplate =
+      (settings["adapter.enrichmentPrompt"] as string) || DEFAULT_ENRICHMENT_PROMPT;
+    output.textContent = resolvePromptPreview(initialTemplate);
 
     const previewBtn = actions.createEl("button", { text: "Preview" });
     previewBtn.addEventListener("click", async () => {
@@ -156,9 +161,6 @@ export class EnrichmentSettingsDialog extends Modal {
           : (latestSettings["adapter.enrichmentPrompt"] as string) || DEFAULT_ENRICHMENT_PROMPT;
       output.textContent = resolvePromptPreview(template);
     });
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const _unused = settings;
   }
 
   private renderEnabledToggle(containerEl: HTMLElement, settings: Record<string, unknown>): void {

--- a/src/framework/EnrichmentSettingsDialog.ts
+++ b/src/framework/EnrichmentSettingsDialog.ts
@@ -22,7 +22,11 @@ import {
   DEFAULT_ENRICHMENT_PROMPT,
   DEFAULT_RETRY_ENRICHMENT_PROMPT,
 } from "../adapters/task-agent/BackgroundEnrich";
-import { describePromptPlaceholder } from "./enrichmentPromptPreview";
+import {
+  describePromptPlaceholder,
+  resolvePromptPreview,
+  DEFAULT_PREVIEW_VARS,
+} from "./enrichmentPromptPreview";
 import { SETTINGS_CHANGED_EVENT, loadAllSettings } from "./SettingsTab";
 
 export class EnrichmentSettingsDialog extends Modal {
@@ -97,6 +101,64 @@ export class EnrichmentSettingsDialog extends Modal {
     );
     this.renderProfileDropdown(containerEl, settings);
     this.renderTimeoutField(containerEl, settings);
+    this.renderPreviewPanel(containerEl, settings);
+  }
+
+  /**
+   * Render a "Preview resolved prompt" section that substitutes `{{FILE_PATH}}`
+   * (and any other known placeholder) using a fixed example path. Gives users
+   * a concrete view of what the agent will receive without actually creating
+   * a task. The substitution is synchronous and purely string-based; we do
+   * not load a real task or reach into BackgroundEnrich internals.
+   */
+  private renderPreviewPanel(containerEl: HTMLElement, settings: Record<string, unknown>): void {
+    const section = containerEl.createDiv({ cls: "wt-enrichment-dialog__preview" });
+    section.createEl("h4", { text: "Preview resolved prompt" });
+    section.createEl("p", {
+      text:
+        "Show the selected prompt with placeholders substituted using the example " +
+        `path ${DEFAULT_PREVIEW_VARS.FILE_PATH}. Useful for sanity-checking a customised prompt ` +
+        "before creating a real task.",
+      cls: "wt-enrichment-dialog__help",
+    });
+
+    const actions = section.createDiv({ cls: "wt-enrichment-dialog__preview-actions" });
+    const select = actions.createEl("select", {
+      cls: "wt-enrichment-dialog__preview-select",
+    });
+    const opts: Array<{ value: "prompt" | "retry"; label: string }> = [
+      { value: "prompt", label: "Enrichment prompt" },
+      { value: "retry", label: "Retry enrichment prompt" },
+    ];
+    for (const opt of opts) {
+      const el = select.createEl("option", { text: opt.label });
+      el.value = opt.value;
+    }
+
+    const output = section.createEl("pre", {
+      cls: "wt-enrichment-dialog__preview-output",
+    });
+    output.textContent = "Click Preview to resolve the selected prompt.";
+
+    const previewBtn = actions.createEl("button", { text: "Preview" });
+    previewBtn.addEventListener("click", async () => {
+      // Re-read settings so the preview reflects any edits the user has made
+      // since the dialog was opened. saveSettings writes are debounced via
+      // mergeAndSavePluginData but have already resolved by the time onChange
+      // returns, so loadData here sees the latest values.
+      const latestData = (await this.plugin.loadData()) || {};
+      const latestSettings: Record<string, unknown> = latestData.settings || {};
+      const selected = (select.value as "prompt" | "retry") || "prompt";
+      const template =
+        selected === "retry"
+          ? (latestSettings["adapter.retryEnrichmentPrompt"] as string) ||
+            DEFAULT_RETRY_ENRICHMENT_PROMPT
+          : (latestSettings["adapter.enrichmentPrompt"] as string) || DEFAULT_ENRICHMENT_PROMPT;
+      output.textContent = resolvePromptPreview(template);
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const _unused = settings;
   }
 
   private renderEnabledToggle(containerEl: HTMLElement, settings: Record<string, unknown>): void {

--- a/src/framework/EnrichmentSettingsDialog.ts
+++ b/src/framework/EnrichmentSettingsDialog.ts
@@ -13,10 +13,17 @@
  * split-task settings dialog) can mirror the structure without sharing a base
  * class.
  */
-import { App, Modal } from "obsidian";
+import { App, Modal, Setting } from "obsidian";
 import type { Plugin } from "obsidian";
 import type { AdapterBundle } from "../core/interfaces";
+import { mergeAndSavePluginData } from "../core/PluginDataStore";
 import type { AgentProfileManager } from "../core/agents/AgentProfileManager";
+import {
+  DEFAULT_ENRICHMENT_PROMPT,
+  DEFAULT_RETRY_ENRICHMENT_PROMPT,
+} from "../adapters/task-agent/BackgroundEnrich";
+import { describePromptPlaceholder } from "./enrichmentPromptPreview";
+import { SETTINGS_CHANGED_EVENT, loadAllSettings } from "./SettingsTab";
 
 export class EnrichmentSettingsDialog extends Modal {
   protected plugin: Plugin;
@@ -65,14 +72,136 @@ export class EnrichmentSettingsDialog extends Modal {
     closeBtn.addEventListener("click", () => this.close());
   }
 
-  /**
-   * Render the body of the dialog. Subclasses and future commits add the
-   * actual setting fields and prompt previews here.
-   */
   protected async renderFields(containerEl: HTMLElement): Promise<void> {
-    containerEl.createEl("p", {
-      text: "Enrichment settings will appear here.",
-      cls: "wt-enrichment-dialog__placeholder",
+    const data = (await this.plugin.loadData()) || {};
+    const settings: Record<string, unknown> = data.settings || {};
+
+    this.renderEnabledToggle(containerEl, settings);
+    this.renderPromptField(
+      containerEl,
+      "Enrichment prompt",
+      "Prompt sent to the headless agent for background enrichment. Use " +
+        "{{FILE_PATH}} as a placeholder for the task file path.",
+      "adapter.enrichmentPrompt",
+      DEFAULT_ENRICHMENT_PROMPT,
+      settings,
+    );
+    this.renderPromptField(
+      containerEl,
+      "Retry enrichment prompt",
+      "Prompt used when retrying enrichment via the right-click menu. Use " +
+        "{{FILE_PATH}} as a placeholder for the task file path.",
+      "adapter.retryEnrichmentPrompt",
+      DEFAULT_RETRY_ENRICHMENT_PROMPT,
+      settings,
+    );
+    this.renderProfileDropdown(containerEl, settings);
+    this.renderTimeoutField(containerEl, settings);
+  }
+
+  private renderEnabledToggle(containerEl: HTMLElement, settings: Record<string, unknown>): void {
+    const value = settings["adapter.enrichmentEnabled"] !== false;
+    new Setting(containerEl)
+      .setName("Enable background enrichment")
+      .setDesc("Automatically enrich new tasks in the background using a headless agent session.")
+      .addToggle((toggle) =>
+        toggle.setValue(value).onChange(async (newValue) => {
+          await this.saveSettings((s) => {
+            s["adapter.enrichmentEnabled"] = newValue;
+          });
+        }),
+      );
+  }
+
+  /**
+   * Render a prompt textarea with a collapsible "View default prompt"
+   * disclosure block beneath. The default prompt is rendered verbatim in a
+   * preformatted read-only block so users can read and copy from it.
+   */
+  private renderPromptField(
+    containerEl: HTMLElement,
+    name: string,
+    description: string,
+    key: string,
+    defaultPrompt: string,
+    settings: Record<string, unknown>,
+  ): void {
+    const value = (settings[key] as string) || "";
+    const placeholder = describePromptPlaceholder(defaultPrompt);
+
+    const setting = new Setting(containerEl).setName(name).setDesc(description);
+    setting.settingEl.style.flexWrap = "wrap";
+    setting.controlEl.style.width = "100%";
+    setting.addTextArea((ta) => {
+      ta.setPlaceholder(placeholder);
+      ta.setValue(value);
+      ta.onChange(async (newValue) => {
+        await this.saveSettings((s) => {
+          s[key] = newValue;
+        });
+      });
+      ta.inputEl.addClass("wt-enrichment-dialog__prompt-input");
     });
+
+    // Collapsible default prompt disclosure. Users can expand to read the
+    // full default text and copy from it if they want to customise.
+    const disclosure = containerEl.createEl("details", {
+      cls: "wt-enrichment-dialog__default-prompt-toggle",
+    });
+    disclosure.createEl("summary", { text: "View default prompt" });
+    const pre = disclosure.createEl("pre", {
+      cls: "wt-enrichment-dialog__default-prompt",
+    });
+    pre.textContent = defaultPrompt;
+  }
+
+  private renderProfileDropdown(containerEl: HTMLElement, settings: Record<string, unknown>): void {
+    const value = (settings["adapter.enrichmentProfile"] as string) || "";
+    new Setting(containerEl)
+      .setName("Enrichment agent profile")
+      .setDesc(
+        "Agent profile to use for background enrichment. The profile's command, " +
+          "arguments, and working directory are used. Select 'Default' to use the " +
+          "core Claude command settings.",
+      )
+      .addDropdown((dropdown) => {
+        dropdown.addOption("", "Default (core settings)");
+        for (const profile of this.profileManager.getProfiles()) {
+          dropdown.addOption(profile.id, profile.name);
+        }
+        dropdown.setValue(value).onChange(async (newValue) => {
+          await this.saveSettings((s) => {
+            s["adapter.enrichmentProfile"] = newValue;
+          });
+        });
+      });
+  }
+
+  private renderTimeoutField(containerEl: HTMLElement, settings: Record<string, unknown>): void {
+    const value = (settings["adapter.enrichmentTimeout"] as string) || "";
+    new Setting(containerEl)
+      .setName("Enrichment timeout (seconds)")
+      .setDesc(
+        "Maximum time in seconds for background enrichment before it is killed. " +
+          "Leave empty for default (300s / 5 min).",
+      )
+      .addText((text) => {
+        text.inputEl.placeholder = "300";
+        text.setValue(value).onChange(async (newValue) => {
+          await this.saveSettings((s) => {
+            s["adapter.enrichmentTimeout"] = newValue;
+          });
+        });
+      });
+  }
+
+  private async saveSettings(update: (settings: Record<string, unknown>) => void): Promise<void> {
+    await mergeAndSavePluginData(this.plugin, async (data) => {
+      if (!data.settings) data.settings = {};
+      update(data.settings);
+    });
+    const allSettings = await loadAllSettings(this.plugin, this.adapter);
+    this.adapter.onSettingsChanged?.(allSettings);
+    window.dispatchEvent(new CustomEvent(SETTINGS_CHANGED_EVENT, { detail: allSettings }));
   }
 }

--- a/src/framework/EnrichmentSettingsDialog.ts
+++ b/src/framework/EnrichmentSettingsDialog.ts
@@ -1,0 +1,78 @@
+/**
+ * EnrichmentSettingsDialog - dedicated modal housing the background-enrichment
+ * settings group. Extracted from the main SettingsTab so the growing surface
+ * (toggle, prompt, retry prompt, agent profile, timeout, plus default-prompt
+ * previews) has room to breathe without cluttering the top-level settings page.
+ *
+ * Settings are persisted through the same `plugin.saveSettings` path as the
+ * rest of the adapter fields. The existing `adapter.enrichment*` keys are
+ * reused verbatim, so opening the dialog does not change enrichment behaviour
+ * for users who never open it.
+ *
+ * The pattern is kept deliberately generic so sibling dialogs (e.g. a future
+ * split-task settings dialog) can mirror the structure without sharing a base
+ * class.
+ */
+import { App, Modal } from "obsidian";
+import type { Plugin } from "obsidian";
+import type { AdapterBundle } from "../core/interfaces";
+import type { AgentProfileManager } from "../core/agents/AgentProfileManager";
+
+export class EnrichmentSettingsDialog extends Modal {
+  protected plugin: Plugin;
+  protected adapter: AdapterBundle;
+  protected profileManager: AgentProfileManager;
+
+  constructor(
+    app: App,
+    plugin: Plugin,
+    adapter: AdapterBundle,
+    profileManager: AgentProfileManager,
+  ) {
+    super(app);
+    this.plugin = plugin;
+    this.adapter = adapter;
+    this.profileManager = profileManager;
+  }
+
+  onOpen(): void {
+    void this.render();
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+
+  private async render(): Promise<void> {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.addClass("wt-enrichment-dialog");
+
+    contentEl.createEl("h3", { text: "Background enrichment" });
+    contentEl.createEl("p", {
+      text:
+        "Configure how newly created tasks are enriched by a headless agent. " +
+        "Leave the prompt fields blank to use the built-in defaults shown below each field.",
+      cls: "wt-enrichment-dialog__help",
+    });
+
+    const bodyEl = contentEl.createDiv({ cls: "wt-enrichment-dialog__body" });
+    await this.renderFields(bodyEl);
+
+    // Close button. Settings persist on change, so no Save button is needed.
+    const actions = contentEl.createDiv({ cls: "wt-enrichment-dialog__actions" });
+    const closeBtn = actions.createEl("button", { text: "Done" });
+    closeBtn.addEventListener("click", () => this.close());
+  }
+
+  /**
+   * Render the body of the dialog. Subclasses and future commits add the
+   * actual setting fields and prompt previews here.
+   */
+  protected async renderFields(containerEl: HTMLElement): Promise<void> {
+    containerEl.createEl("p", {
+      text: "Enrichment settings will appear here.",
+      cls: "wt-enrichment-dialog__placeholder",
+    });
+  }
+}

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -20,6 +20,7 @@ import { resetGuidedTourStatus } from "./GuidedTour";
 import type { AgentProfileManager } from "../core/agents/AgentProfileManager";
 import { AgentProfileManagerModal } from "./AgentProfileManagerModal";
 import { CardFlagManagerModal } from "./CardFlagManagerModal";
+import { EnrichmentSettingsDialog } from "./EnrichmentSettingsDialog";
 import { parseCardFlagRulesJson, serializeCardFlagRules } from "../core/cardFlags";
 import type { ViewMode, RecentThreshold } from "./ActivityTracker";
 import type { DetailViewPlacement, DetailViewSplitDirection } from "../core/detailViewPlacement";
@@ -200,9 +201,53 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
 
     // Adapter settings section
     const schema = this.adapter.config.settingsSchema;
-    if (schema.length > 0) {
+    // Enrichment settings live behind a dedicated dialog to reduce clutter in
+    // the main adapter section. The enrichmentEnabled toggle stays top-level
+    // so users see at a glance that enrichment exists and can switch it off
+    // without opening the dialog.
+    const enrichmentDialogKeys = new Set([
+      "enrichmentEnabled",
+      "enrichmentPrompt",
+      "retryEnrichmentPrompt",
+      "enrichmentProfile",
+      "enrichmentTimeout",
+    ]);
+    const hasEnrichmentSchema = schema.some((field) => enrichmentDialogKeys.has(field.key));
+    const nonEnrichmentSchema = schema.filter((field) => !enrichmentDialogKeys.has(field.key));
+
+    if (hasEnrichmentSchema) {
+      containerEl.createEl("h2", { text: "Background enrichment" });
+      // Render the enabled toggle if it is in the schema (keeps the default
+      // wiring intact for non-task-agent adapters that might omit it).
+      const enabledField = schema.find((f) => f.key === "enrichmentEnabled");
+      if (enabledField) {
+        this.addAdapterSetting(containerEl, enabledField);
+      }
+      new Setting(containerEl)
+        .setName("Configure enrichment")
+        .setDesc(
+          "Open a dialog to customise the enrichment prompt, retry prompt, agent " +
+            "profile, and timeout. The built-in default prompts are displayed inside " +
+            "the dialog so you can read them before deciding whether to override.",
+        )
+        .addButton((btn) =>
+          btn
+            .setButtonText("Configure enrichment...")
+            .setCta()
+            .onClick(() => {
+              new EnrichmentSettingsDialog(
+                this.app,
+                this.plugin,
+                this.adapter,
+                this.profileManager,
+              ).open();
+            }),
+        );
+    }
+
+    if (nonEnrichmentSchema.length > 0) {
       containerEl.createEl("h2", { text: "Adapter" });
-      for (const field of schema) {
+      for (const field of nonEnrichmentSchema) {
         this.addAdapterSetting(containerEl, field);
       }
     }

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -235,12 +235,21 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
             .setButtonText("Configure enrichment...")
             .setCta()
             .onClick(() => {
-              new EnrichmentSettingsDialog(
+              const dialog = new EnrichmentSettingsDialog(
                 this.app,
                 this.plugin,
                 this.adapter,
                 this.profileManager,
-              ).open();
+              );
+              // The enrichmentEnabled toggle is rendered both here and inside
+              // the dialog. Re-render the settings tab after the dialog closes
+              // so the two stay in sync if the user toggles inside the dialog.
+              const originalOnClose = dialog.onClose.bind(dialog);
+              dialog.onClose = () => {
+                originalOnClose();
+                this.display();
+              };
+              dialog.open();
             }),
         );
     }

--- a/src/framework/enrichmentPromptPreview.test.ts
+++ b/src/framework/enrichmentPromptPreview.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolvePromptPreview,
+  describePromptPlaceholder,
+  DEFAULT_PREVIEW_VARS,
+} from "./enrichmentPromptPreview";
+
+describe("resolvePromptPreview", () => {
+  it("substitutes a known placeholder with the default example vars", () => {
+    const template = "Review the task file at {{FILE_PATH}} and enrich it.";
+    expect(resolvePromptPreview(template)).toBe(
+      `Review the task file at ${DEFAULT_PREVIEW_VARS.FILE_PATH} and enrich it.`,
+    );
+  });
+
+  it("substitutes multiple occurrences of the same placeholder", () => {
+    const template = "{{FILE_PATH}} then again {{FILE_PATH}}";
+    const expected = `${DEFAULT_PREVIEW_VARS.FILE_PATH} then again ${DEFAULT_PREVIEW_VARS.FILE_PATH}`;
+    expect(resolvePromptPreview(template)).toBe(expected);
+  });
+
+  it("leaves unknown placeholders untouched", () => {
+    const template = "Hello {{UNKNOWN}} world {{FILE_PATH}}";
+    expect(resolvePromptPreview(template)).toBe(
+      `Hello {{UNKNOWN}} world ${DEFAULT_PREVIEW_VARS.FILE_PATH}`,
+    );
+  });
+
+  it("accepts a custom vars map", () => {
+    const template = "Path is {{FILE_PATH}} and id {{ITEM_ID}}";
+    expect(resolvePromptPreview(template, { FILE_PATH: "/tmp/a.md", ITEM_ID: "abc-123" })).toBe(
+      "Path is /tmp/a.md and id abc-123",
+    );
+  });
+
+  it("returns empty string for empty template", () => {
+    expect(resolvePromptPreview("")).toBe("");
+  });
+
+  it("returns the template verbatim when no placeholders present", () => {
+    expect(resolvePromptPreview("no placeholders here")).toBe("no placeholders here");
+  });
+});
+
+describe("describePromptPlaceholder", () => {
+  it("returns just the hint for an empty default", () => {
+    expect(describePromptPlaceholder("")).toBe("(default - leave blank to use)");
+  });
+
+  it("uses the first sentence of the default when short", () => {
+    const defaultText = "Review the task. Then do more stuff.";
+    expect(describePromptPlaceholder(defaultText)).toBe(
+      "Review the task. (default - leave blank to use)",
+    );
+  });
+
+  it("truncates long first sentences with ellipsis", () => {
+    const long = "a".repeat(200);
+    const result = describePromptPlaceholder(long, 60);
+    // Must end with `... (default - leave blank to use)` and not contain
+    // the full 200 character run.
+    expect(result.endsWith("(default - leave blank to use)")).toBe(true);
+    expect(result).toContain("...");
+    // The snippet preceding the suffix must be 60 chars or fewer.
+    const snippet = result.replace(" (default - leave blank to use)", "");
+    expect(snippet.length).toBeLessThanOrEqual(60);
+  });
+
+  it("trims whitespace from the default", () => {
+    const defaultText = "   Leading whitespace. And more.   ";
+    expect(describePromptPlaceholder(defaultText)).toBe(
+      "Leading whitespace. (default - leave blank to use)",
+    );
+  });
+});

--- a/src/framework/enrichmentPromptPreview.ts
+++ b/src/framework/enrichmentPromptPreview.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure helpers for enrichment prompt display. Kept separate from the modal so
+ * they can be unit-tested without jsdom, and so BackgroundEnrich remains the
+ * single source of truth for the default prompt templates while this file
+ * only concerns itself with how the preview is formatted.
+ */
+
+/** The example placeholder substitutions used when users request a preview. */
+export const DEFAULT_PREVIEW_VARS: Record<string, string> = {
+  FILE_PATH: "vault/2 - Areas/Tasks/todo/example.md",
+};
+
+/**
+ * Substitute `{{KEY}}` placeholders in a prompt template with the provided
+ * variable map. Unknown placeholders are left untouched so users can see
+ * exactly which ones the resolver recognises.
+ */
+export function resolvePromptPreview(
+  template: string,
+  vars: Record<string, string> = DEFAULT_PREVIEW_VARS,
+): string {
+  if (!template) return "";
+  return template.replace(/\{\{([A-Z0-9_]+)\}\}/g, (match, name: string) => {
+    if (Object.prototype.hasOwnProperty.call(vars, name)) {
+      return vars[name];
+    }
+    return match;
+  });
+}
+
+/**
+ * Produce a short placeholder hint summarising the default prompt for an
+ * empty textarea. Shows a short leading fragment plus an instruction that
+ * leaving the field blank uses the default.
+ */
+export function describePromptPlaceholder(defaultPrompt: string, maxChars = 120): string {
+  const trimmed = defaultPrompt.trim();
+  if (!trimmed) return "(default - leave blank to use)";
+  const firstSentence = trimmed.split(/(?<=[.!?])\s+/, 1)[0] || trimmed;
+  // When truncating we keep the final snippet (including the ellipsis) within
+  // maxChars so callers can reason about the bound independently of the
+  // suffix we append.
+  const snippet =
+    firstSentence.length > maxChars
+      ? `${firstSentence.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`
+      : firstSentence;
+  return `${snippet} (default - leave blank to use)`;
+}

--- a/styles.css
+++ b/styles.css
@@ -2295,13 +2295,6 @@ button.wt-spawn-claude-ctx:hover svg {
   margin-bottom: 12px;
 }
 
-.wt-enrichment-dialog__placeholder {
-  color: var(--text-muted);
-  font-style: italic;
-  text-align: center;
-  padding: 16px 0;
-}
-
 .wt-enrichment-dialog__actions {
   display: flex;
   justify-content: flex-end;

--- a/styles.css
+++ b/styles.css
@@ -2273,3 +2273,100 @@ button.wt-spawn-claude-ctx:hover svg {
 .wt-activity-view .wt-section[data-column="__pinned__"] {
   display: none;
 }
+
+/* =============================================================================
+   Enrichment Settings Dialog
+   ============================================================================= */
+
+.wt-enrichment-dialog {
+  max-width: 640px;
+}
+
+.wt-enrichment-dialog__help {
+  color: var(--text-muted);
+  font-size: var(--font-ui-smaller);
+  margin-bottom: 12px;
+}
+
+.wt-enrichment-dialog__body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.wt-enrichment-dialog__placeholder {
+  color: var(--text-muted);
+  font-style: italic;
+  text-align: center;
+  padding: 16px 0;
+}
+
+.wt-enrichment-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.wt-enrichment-dialog__default-prompt {
+  font-family: var(--font-monospace);
+  font-size: var(--font-ui-smaller);
+  white-space: pre-wrap;
+  background: var(--background-secondary);
+  padding: 8px 10px;
+  margin: 6px 0 10px;
+  border-radius: var(--radius-s);
+  border: 1px solid var(--background-modifier-border);
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.wt-enrichment-dialog__default-prompt-toggle {
+  cursor: pointer;
+  font-size: var(--font-ui-smaller);
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+.wt-enrichment-dialog__default-prompt-toggle summary {
+  list-style: revert;
+}
+
+.wt-enrichment-dialog__preview {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+.wt-enrichment-dialog__preview-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.wt-enrichment-dialog__preview-select {
+  font-size: var(--font-ui-smaller);
+}
+
+.wt-enrichment-dialog__preview-output {
+  font-family: var(--font-monospace);
+  font-size: var(--font-ui-smaller);
+  white-space: pre-wrap;
+  background: var(--background-secondary);
+  padding: 8px 10px;
+  border-radius: var(--radius-s);
+  border: 1px solid var(--background-modifier-border);
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.wt-enrichment-dialog__prompt-input {
+  width: 100%;
+  min-height: 80px;
+  font-family: var(--font-monospace);
+  font-size: var(--font-ui-smaller);
+}


### PR DESCRIPTION
## Problem

Default enrichment behaviour was invisible to users and the related settings were mixed in with unrelated adapter options. Empty prompt inputs gave no indication of what the agent would actually be asked to do; users had to read source to make an informed override decision. As enrichment grew to 6+ settings (toggle, prompt, retry prompt, profile, timeout, profile-internal fields), the main settings page was getting crowded.

Fixes #451.

## Dialog structure

New `src/framework/EnrichmentSettingsDialog.ts` extends Obsidian's `Modal` with CSS prefix `wt-enrichment-dialog`. Body contains:

1. **Enable background enrichment** toggle (also mirrored at top level on the main settings page).
2. **Enrichment prompt** textarea with placeholder summarising the default + collapsible "View default prompt" disclosure showing the full default verbatim.
3. **Retry enrichment prompt** textarea with the same default-preview treatment.
4. **Enrichment agent profile** dropdown (profiles from `AgentProfileManager`).
5. **Enrichment timeout (seconds)** text field.
6. **Preview resolved prompt** panel - pick either prompt, click Preview, see the template with `{{FILE_PATH}}` substituted using the example path `vault/2 - Areas/Tasks/todo/example.md`.
7. **Done** close button. Settings persist on change, so no Save button is needed.

## Default prompt surfacing

- Textarea placeholder shows the first sentence of the default prompt + ` (default - leave blank to use)`.
- Collapsible `<details>` disclosure below the textarea renders the full default prompt in a `<pre>` block with `white-space: pre-wrap` and monospace font, so users can read it fully and copy from it.
- Not truncated - users see every line.

## Entry point

`SettingsTab.display()` now filters the five enrichment schema keys (`enrichmentEnabled`, `enrichmentPrompt`, `retryEnrichmentPrompt`, `enrichmentProfile`, `enrichmentTimeout`) out of the inline 'Adapter' section and renders a dedicated **Background enrichment** section instead. That section contains the toggle + a **Configure enrichment...** CTA button that opens the dialog.

## Preview feature

Implemented using a new pure helper module `src/framework/enrichmentPromptPreview.ts` with `resolvePromptPreview(template, vars)` and `describePromptPlaceholder(default)`. Fully unit tested; no DOM or async work required. The in-dialog Preview button re-reads saved settings on click so it reflects edits made while the dialog is open.

## Design decisions

- **No setting migration**: reuses the existing `adapter.enrichment*` keys verbatim, so users who never open the dialog see identical behaviour.
- **No shared base class yet**: dialog is self-contained with simple composition. Issue #448 can mirror the structure without needing a refactor (YAGNI).
- **Dry-run scope**: deliberately synchronous string substitution with a fixed example path, not a real task load through `BackgroundEnrich` internals. Keeps the feature lightweight and free of runtime dependencies.
- **BackgroundEnrich untouched**: defaults, timeout resolution, spawn path all unchanged. This is a UX change only.

## Test plan

- [x] `pnpm exec vitest run` passes (1200 tests; 10 new for the preview helper).
- [x] `pnpm run build` passes.
- [ ] Manual Obsidian verification (cannot be automated from CI):
  - Open **Settings > Work Terminal** and confirm the new **Background enrichment** section with toggle + **Configure enrichment...** button.
  - Open the dialog; confirm every field persists on change and that the dialog can be reopened to see the saved value.
  - Confirm the default prompt placeholder text is shown when the textarea is empty, and the collapsible disclosure expands to show the full default.
  - Click **Preview** for both the enrichment and retry prompts and verify `{{FILE_PATH}}` is substituted.
  - Create a new task and confirm enrichment still runs with the expected prompt (default or custom).

Screenshots: pending manual capture from an isolated test vault.