### PR TITLE
fix(#457): navigate placement no longer replaces Work Terminal

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -228,7 +228,7 @@ The **Placement** dropdown offers four strategies:
 
 - **Split (default)** - create a new split beside the Work Terminal view and apply the min-width override so the editor does not squish. Best when Work Terminal sits in its own tab group.
 - **Tab in active group** - open the task file as a new tab in the currently active tab group, with no splitting and no width override. Best when Work Terminal lives in a tab group alongside other files and you want the detail view to behave like any other tab.
-- **Navigate active leaf** - replace the contents of the active leaf, matching Obsidian's standard "open file" behaviour. No new tabs or splits are created.
+- **Navigate active leaf** - open the task file in the most recent editor leaf that is not the Work Terminal view, falling back to a new tab if no suitable leaf exists. Does not replace the Work Terminal view itself. No new tabs or splits are created when a suitable editor leaf is already open.
 - **Disabled** - do nothing on selection. Useful if you prefer to open files manually via the file explorer, quick switcher, or Obsidian's hover preview, or if you only need the terminal side of Work Terminal.
 
 Additional options shape the behaviour:

--- a/src/adapters/task-agent/TaskDetailView.ts
+++ b/src/adapters/task-agent/TaskDetailView.ts
@@ -69,17 +69,25 @@ export class TaskDetailView {
         // replaces the entire workspace with the task file (#457). Find the
         // most recent editor leaf that is NOT Work Terminal; fall back to a
         // fresh tab if none exists.
+
+        // Clean up any leaf we own from a previous placement (split/tab) so
+        // it doesn't linger in the workspace. Doing this before opening the
+        // file also means `this.editorLeaf`/`this.leafIsOwned` are cleared,
+        // so a later switch back to split/tab won't short-circuit in
+        // `ensureEditorLeaf`/`ensureTabLeaf` and try to reuse the user leaf
+        // we're about to open the task file in.
+        this.detachLeaf();
+
         let targetLeaf = findNavigateTargetLeaf(this.app, VIEW_TYPE);
         if (!targetLeaf) {
           targetLeaf = this.app.workspace.getLeaf("tab");
         }
         if (!targetLeaf) return;
-        // Don't track navigate-mode leaves: keeps split/tab placements from
-        // adopting user leaves later via findEditorLeaves's path-based match.
-        // Also don't add the path to openedPaths - these are user leaves, not
-        // owned by us.
-        this.editorLeaf = targetLeaf;
-        this.leafIsOwned = false;
+        // Deliberately do NOT assign `this.editorLeaf` / `this.leafIsOwned`
+        // here: the target is a user leaf we've adopted for this single
+        // openFile call. Tracking it would let a subsequent split/tab
+        // placement short-circuit its ensureXxxLeaf() check and overwrite
+        // the user's leaf content. Also don't add the path to `openedPaths`.
         await targetLeaf.openFile(file);
         return;
       }

--- a/src/adapters/task-agent/TaskDetailView.ts
+++ b/src/adapters/task-agent/TaskDetailView.ts
@@ -1,6 +1,8 @@
 import type { App, TFile, WorkspaceLeaf } from "obsidian";
 import type { WorkItem } from "../../core/interfaces";
 import { DETAIL_VIEW_DEFAULTS, type DetailViewOptions } from "../../core/detailViewPlacement";
+import { VIEW_TYPE } from "../../framework/PluginBase";
+import { findNavigateTargetLeaf } from "./findNavigateTargetLeaf";
 
 export class TaskDetailView {
   private editorLeaf: WorkspaceLeaf | null = null;
@@ -62,15 +64,23 @@ export class TaskDetailView {
       this.lastItemId = item.id;
 
       if (options.placement === "navigate") {
-        // Replace the contents of the active leaf. This matches Obsidian's
-        // standard "open file" behaviour and does not split or create tabs.
-        const activeLeaf = this.app.workspace.getLeaf(false);
-        if (!activeLeaf) return;
+        // The click target is inside the Work Terminal ItemView, so a naive
+        // `getLeaf(false)` returns the Work Terminal leaf and `openFile`
+        // replaces the entire workspace with the task file (#457). Find the
+        // most recent editor leaf that is NOT Work Terminal; fall back to a
+        // fresh tab if none exists.
+        let targetLeaf = findNavigateTargetLeaf(this.app, VIEW_TYPE);
+        if (!targetLeaf) {
+          targetLeaf = this.app.workspace.getLeaf("tab");
+        }
+        if (!targetLeaf) return;
         // Don't track navigate-mode leaves: keeps split/tab placements from
         // adopting user leaves later via findEditorLeaves's path-based match.
-        this.editorLeaf = activeLeaf;
+        // Also don't add the path to openedPaths - these are user leaves, not
+        // owned by us.
+        this.editorLeaf = targetLeaf;
         this.leafIsOwned = false;
-        await activeLeaf.openFile(file);
+        await targetLeaf.openFile(file);
         return;
       }
 

--- a/src/adapters/task-agent/findNavigateTargetLeaf.test.ts
+++ b/src/adapters/task-agent/findNavigateTargetLeaf.test.ts
@@ -113,6 +113,29 @@ describe("findNavigateTargetLeaf", () => {
     expect(findNavigateTargetLeaf(app, WT)).toBeNull();
   });
 
+  it("skips a non-editor active leaf (file-explorer) and falls through to the recent markdown leaf", () => {
+    const sidebar = leaf("file-explorer", 500);
+    const mdOld = leaf("markdown", 50);
+    const mdNew = leaf("markdown", 150);
+    const root = split(sidebar, mdOld, mdNew);
+    const app = makeApp({ activeLeaf: sidebar, rootSplit: root });
+
+    // file-explorer active leaf must NOT be returned - we'd replace the
+    // sidebar with the task file otherwise. Fall through to the recent
+    // markdown leaf instead.
+    expect(findNavigateTargetLeaf(app, WT)).toBe(mdNew);
+  });
+
+  it("skips a non-editor active leaf (outline) even when no markdown leaves exist", () => {
+    const outline = leaf("outline", 500);
+    const wt = leaf(WT, 100);
+    const root = split(outline, wt);
+    const app = makeApp({ activeLeaf: outline, rootSplit: root });
+
+    // No editor leaves at all, so returns null - caller will open a new tab.
+    expect(findNavigateTargetLeaf(app, WT)).toBeNull();
+  });
+
   it("returns null when only Work Terminal leaves exist", () => {
     const wt1 = leaf(WT, 100);
     const wt2 = leaf(WT, 200);

--- a/src/adapters/task-agent/findNavigateTargetLeaf.test.ts
+++ b/src/adapters/task-agent/findNavigateTargetLeaf.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import { findNavigateTargetLeaf } from "./findNavigateTargetLeaf";
+
+const WT = "work-terminal-view";
+
+type FakeLeaf = {
+  view: { getViewType: () => string };
+  activeTime?: number;
+  parent?: FakeSplit;
+};
+
+type FakeSplit = {
+  children: Array<FakeLeaf | FakeSplit>;
+};
+
+function leaf(viewType: string, activeTime = 0): FakeLeaf {
+  return {
+    view: { getViewType: () => viewType },
+    activeTime,
+  };
+}
+
+function split(...children: Array<FakeLeaf | FakeSplit>): FakeSplit {
+  const s: FakeSplit = { children };
+  for (const child of children) {
+    if ("view" in child) {
+      child.parent = s;
+    }
+  }
+  return s;
+}
+
+function makeApp(params: { activeLeaf?: FakeLeaf | null; rootSplit?: FakeSplit | null }): any {
+  return {
+    workspace: {
+      activeLeaf: params.activeLeaf ?? null,
+      rootSplit: params.rootSplit ?? null,
+    },
+  };
+}
+
+describe("findNavigateTargetLeaf", () => {
+  it("returns the active leaf when it is not the Work Terminal view", () => {
+    const md = leaf("markdown", 100);
+    const root = split(md);
+    const app = makeApp({ activeLeaf: md, rootSplit: root });
+
+    expect(findNavigateTargetLeaf(app, WT)).toBe(md);
+  });
+
+  it("skips the Work Terminal active leaf and returns the most recent editor leaf", () => {
+    const wt = leaf(WT, 200);
+    const mdOld = leaf("markdown", 50);
+    const mdNew = leaf("markdown", 150);
+    const root = split(wt, mdOld, mdNew);
+    const app = makeApp({ activeLeaf: wt, rootSplit: root });
+
+    expect(findNavigateTargetLeaf(app, WT)).toBe(mdNew);
+  });
+
+  it("prefers a non-WT leaf in the active leaf's tab group over other groups", () => {
+    const wt = leaf(WT, 300);
+    const sibling = leaf("markdown", 100);
+    const wtGroup = split(wt, sibling);
+
+    const otherMoreRecent = leaf("markdown", 500);
+    const otherGroup = split(otherMoreRecent);
+
+    const root: FakeSplit = { children: [wtGroup, otherGroup] };
+    wtGroup.children.forEach((c) => {
+      if ("view" in c) c.parent = wtGroup;
+    });
+    otherGroup.children.forEach((c) => {
+      if ("view" in c) c.parent = otherGroup;
+    });
+
+    const app = makeApp({ activeLeaf: wt, rootSplit: root });
+
+    // Sibling wins even though the other group has a more recent leaf
+    expect(findNavigateTargetLeaf(app, WT)).toBe(sibling);
+  });
+
+  it("falls back to the workspace-wide most recent editor leaf when WT is alone in its tab group", () => {
+    const wt = leaf(WT, 100);
+    const wtGroup = split(wt);
+
+    const mdOld = leaf("markdown", 50);
+    const mdNew = leaf("markdown", 200);
+    const otherGroup = split(mdOld, mdNew);
+
+    const root: FakeSplit = { children: [wtGroup, otherGroup] };
+
+    const app = makeApp({ activeLeaf: wt, rootSplit: root });
+
+    expect(findNavigateTargetLeaf(app, WT)).toBe(mdNew);
+  });
+
+  it("treats 'empty' view type as a valid editor leaf", () => {
+    const wt = leaf(WT, 100);
+    const empty = leaf("empty", 10);
+    const root = split(wt, empty);
+    const app = makeApp({ activeLeaf: wt, rootSplit: root });
+
+    expect(findNavigateTargetLeaf(app, WT)).toBe(empty);
+  });
+
+  it("ignores non-editor view types (e.g. file-explorer, outline)", () => {
+    const wt = leaf(WT, 100);
+    const sidebar = leaf("file-explorer", 999);
+    const root = split(wt, sidebar);
+    const app = makeApp({ activeLeaf: wt, rootSplit: root });
+
+    expect(findNavigateTargetLeaf(app, WT)).toBeNull();
+  });
+
+  it("returns null when only Work Terminal leaves exist", () => {
+    const wt1 = leaf(WT, 100);
+    const wt2 = leaf(WT, 200);
+    const root = split(wt1, wt2);
+    const app = makeApp({ activeLeaf: wt1, rootSplit: root });
+
+    expect(findNavigateTargetLeaf(app, WT)).toBeNull();
+  });
+
+  it("returns null when there are no leaves at all", () => {
+    const app = makeApp({ activeLeaf: null, rootSplit: null });
+    expect(findNavigateTargetLeaf(app, WT)).toBeNull();
+  });
+
+  it("handles nested splits when walking for leaves", () => {
+    const wt = leaf(WT, 100);
+    const wtGroup = split(wt);
+
+    const md1 = leaf("markdown", 50);
+    const md2 = leaf("markdown", 300);
+    const innerSplit = split(md1, md2);
+    const outerGroup: FakeSplit = { children: [innerSplit] };
+
+    const root: FakeSplit = { children: [wtGroup, outerGroup] };
+
+    const app = makeApp({ activeLeaf: wt, rootSplit: root });
+
+    expect(findNavigateTargetLeaf(app, WT)).toBe(md2);
+  });
+
+  it("handles leaves with missing activeTime by treating them as never-focused", () => {
+    const wt = leaf(WT, 100);
+    // No activeTime set (undefined) -> treated as 0
+    const mdNoTime: FakeLeaf = { view: { getViewType: () => "markdown" } };
+    const mdWithTime = leaf("markdown", 10);
+    const root = split(wt, mdNoTime, mdWithTime);
+    // Set parent refs so walk works
+    mdNoTime.parent = root;
+    const app = makeApp({ activeLeaf: wt, rootSplit: root });
+
+    // mdWithTime (time 10) beats mdNoTime (time 0)
+    expect(findNavigateTargetLeaf(app, WT)).toBe(mdWithTime);
+  });
+});

--- a/src/adapters/task-agent/findNavigateTargetLeaf.ts
+++ b/src/adapters/task-agent/findNavigateTargetLeaf.ts
@@ -51,11 +51,13 @@ export function findNavigateTargetLeaf(
     return typeof t === "number" ? t : 0;
   };
 
-  // 1. Active leaf shortcut. If the user has focused a non-WT leaf we already
-  //    have our answer, regardless of whether it is markdown or something
-  //    else - matches "replace active leaf" semantics for non-WT cases.
+  // 1. Active leaf shortcut. If the user has focused a non-WT editor leaf
+  //    (markdown or empty) we already have our answer. Non-editor active
+  //    leaves like file-explorer/outline/search are skipped so we don't
+  //    replace a sidebar/utility pane with the task file - fall through to
+  //    the recency-based search instead.
   const activeLeaf = workspace.activeLeaf ?? null;
-  if (activeLeaf && !isWorkTerminal(activeLeaf)) {
+  if (activeLeaf && !isWorkTerminal(activeLeaf) && isEditorLeaf(activeLeaf)) {
     return activeLeaf;
   }
 

--- a/src/adapters/task-agent/findNavigateTargetLeaf.ts
+++ b/src/adapters/task-agent/findNavigateTargetLeaf.ts
@@ -1,0 +1,127 @@
+import type { App, WorkspaceLeaf } from "obsidian";
+
+/**
+ * Resolve a target leaf for the "navigate" detail view placement that is not
+ * the Work Terminal view itself.
+ *
+ * Problem: the user triggers detail view by clicking a card inside the Work
+ * Terminal ItemView, which makes Work Terminal the active leaf. A naive
+ * `workspace.getLeaf(false)` then returns the Work Terminal leaf, and
+ * `openFile` replaces the entire kanban + terminal workspace with a markdown
+ * file.
+ *
+ * Strategy (most specific to most general):
+ *   1. If the currently active leaf is not Work Terminal, use it. Handles the
+ *      case where the user tabbed focus to another leaf and is using Work
+ *      Terminal in a split.
+ *   2. Otherwise, search the active leaf's tab group for a non-Work-Terminal
+ *      markdown/empty leaf, pick the most recently active. Keeps navigation
+ *      inside the tab group the user is already looking at.
+ *   3. Otherwise, walk the whole workspace for a non-Work-Terminal
+ *      markdown/empty leaf, pick the most recently active. Handles layouts
+ *      where Work Terminal lives alone in its tab group.
+ *   4. Return null if no suitable leaf exists. Caller should fall back to
+ *      `workspace.getLeaf("tab")` which safely opens a new tab.
+ *
+ * Pure over its inputs: reads only from the provided `app.workspace`. Exported
+ * as a module function so it can be unit-tested without instantiating
+ * TaskDetailView.
+ */
+export function findNavigateTargetLeaf(
+  app: App,
+  workTerminalViewType: string,
+): WorkspaceLeaf | null {
+  const workspace = app.workspace as unknown as {
+    activeLeaf?: WorkspaceLeaf | null;
+    rootSplit?: unknown;
+  };
+
+  const isWorkTerminal = (leaf: WorkspaceLeaf | null | undefined): boolean =>
+    leaf?.view?.getViewType?.() === workTerminalViewType;
+
+  const isEditorLeaf = (leaf: WorkspaceLeaf): boolean => {
+    const viewType = leaf.view?.getViewType?.();
+    return viewType === "markdown" || viewType === "empty";
+  };
+
+  // activeTime is a numeric timestamp Obsidian maintains on each leaf.
+  // Missing or 0 means "never focused" - sort those last.
+  const activeTimeOf = (leaf: WorkspaceLeaf): number => {
+    const t = (leaf as unknown as { activeTime?: number }).activeTime;
+    return typeof t === "number" ? t : 0;
+  };
+
+  // 1. Active leaf shortcut. If the user has focused a non-WT leaf we already
+  //    have our answer, regardless of whether it is markdown or something
+  //    else - matches "replace active leaf" semantics for non-WT cases.
+  const activeLeaf = workspace.activeLeaf ?? null;
+  if (activeLeaf && !isWorkTerminal(activeLeaf)) {
+    return activeLeaf;
+  }
+
+  // Collect all leaves from the root split for the broader searches below.
+  const allLeaves: WorkspaceLeaf[] = [];
+  const rootSplit = workspace.rootSplit;
+  if (rootSplit) {
+    collectLeaves(rootSplit, allLeaves);
+  }
+
+  // 2. Search the active leaf's tab group for a non-WT editor leaf.
+  const activeParent = (activeLeaf as unknown as { parent?: unknown } | null)?.parent;
+  if (activeParent) {
+    const siblingLeaves: WorkspaceLeaf[] = [];
+    collectLeaves(activeParent, siblingLeaves);
+    const candidate = pickMostRecentEditorLeaf(
+      siblingLeaves,
+      isEditorLeaf,
+      isWorkTerminal,
+      activeTimeOf,
+    );
+    if (candidate) return candidate;
+  }
+
+  // 3. Fall back to the workspace-wide search.
+  const candidate = pickMostRecentEditorLeaf(allLeaves, isEditorLeaf, isWorkTerminal, activeTimeOf);
+  if (candidate) return candidate;
+
+  // 4. No suitable leaf.
+  return null;
+}
+
+/**
+ * Pick the most recently active editor leaf that is not the Work Terminal
+ * view. Ties on activeTime resolve to document order (later wins -
+ * right/bottom-most) which matches how the "split" placement already picks a
+ * location hint.
+ */
+function pickMostRecentEditorLeaf(
+  leaves: WorkspaceLeaf[],
+  isEditorLeaf: (leaf: WorkspaceLeaf) => boolean,
+  isWorkTerminal: (leaf: WorkspaceLeaf) => boolean,
+  activeTimeOf: (leaf: WorkspaceLeaf) => number,
+): WorkspaceLeaf | null {
+  let best: WorkspaceLeaf | null = null;
+  let bestTime = -1;
+  for (const leaf of leaves) {
+    if (isWorkTerminal(leaf)) continue;
+    if (!isEditorLeaf(leaf)) continue;
+    const t = activeTimeOf(leaf);
+    if (t >= bestTime) {
+      best = leaf;
+      bestTime = t;
+    }
+  }
+  return best;
+}
+
+/** Recursively walk a workspace split node and collect all leaves. */
+function collectLeaves(node: unknown, result: WorkspaceLeaf[]): void {
+  const n = node as { children?: unknown[]; view?: unknown };
+  if (n.children) {
+    for (const child of n.children) {
+      collectLeaves(child, result);
+    }
+  } else if (n.view) {
+    result.push(node as WorkspaceLeaf);
+  }
+}


### PR DESCRIPTION
## Root cause

The navigate detail view placement (added in #453 / fixes #450) called `app.workspace.getLeaf(false)` to open the task file. That returns the currently active leaf, which is the Work Terminal view itself when the user clicks a task card. `openFile` then replaced the kanban + terminal workspace with the markdown file, forcing the user to reopen Work Terminal.

## Fix (Option 1 from the issue)

New helper `findNavigateTargetLeaf(app, workTerminalViewType)` in `src/adapters/task-agent/findNavigateTargetLeaf.ts`. Resolution order:

1. If `workspace.activeLeaf` is not Work Terminal, use it.
2. Otherwise pick the most recent non-WT markdown/empty leaf in the active leaf's tab group.
3. Otherwise pick the most recent non-WT markdown/empty leaf workspace-wide.
4. Return null if no suitable leaf exists.

The Work Terminal view type comes from the existing `VIEW_TYPE` constant exported by `src/framework/PluginBase.ts` (`"work-terminal-view"`). The helper is a pure function so it is unit-testable without instantiating `TaskDetailView`.

## Fallback behaviour

When the helper returns null (e.g. only Work Terminal leaves open, or a sidebar-only layout), the navigate branch falls back to `workspace.getLeaf("tab")`, which safely opens a fresh tab in the active tab group. The target leaf is NOT added to `openedPaths`, preserving the Copilot-reviewed fix from PR #453 that keeps split/tab placements from adopting user leaves.

## Test coverage

`src/adapters/task-agent/findNavigateTargetLeaf.test.ts` adds 10 unit tests covering:

- active-leaf shortcut when it is not WT
- skipping the WT active leaf in favour of the most recent editor leaf
- preference for the active tab group over a more recent leaf elsewhere
- workspace-wide fallback when WT is alone in its tab group
- accepting `empty` view type as an editor leaf
- ignoring non-editor view types (file-explorer, outline, etc.)
- returning null when only WT leaves exist
- returning null when no leaves exist at all
- walking nested splits
- tolerating missing `activeTime` values

Full suite: 1210/1210 tests pass. `pnpm run build` succeeds.

## Manual verification recommended

The unit tests mock the workspace; actual Obsidian integration (clicking a card with Work Terminal as the active leaf, confirming the task file opens in a sibling editor leaf rather than replacing WT) is worth a manual smoke test.

Fixes #457