### PR TITLE
Fix $filePath/$absoluteFilePath distinction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ GitHub release notes should mirror these entries rather than pasting the raw aut
 
 ## [Unreleased]
 
+### Fixed
+- Fixed `$filePath` and `$absoluteFilePath` placeholders in agent context prompts and profile templates so they now resolve to distinct values: `$filePath` is always the vault-relative path and `$absoluteFilePath` is the fully resolved absolute filesystem path. Previously both placeholders expanded to the same value when an absolute path was available. When `$absoluteFilePath` is used but no absolute path can be resolved, the placeholder falls back to the vault-relative path and logs a `console.warn`. (#465)
+
 ### Added
 - Added diagnostic log files for failed background enrichment attempts. Each failure now writes a categorised log to `<vault>/<configDir>/plugins/work-terminal/logs/enrich-<ts>-<slug>.log` (usually `<vault>/.obsidian/plugins/work-terminal/logs/...`) containing the enrichment prompt, agent stdout/stderr, exit code, adapter validation detail, and any JS error plus stack trace. Retention is 7 days / 50 files with auto-pruning on every write. Controlled by the new **Enrichment failure logs** toggle under Core settings (default: enabled). (#449)
 - Moved the enrichment prompt, retry prompt, agent profile, and timeout into a dedicated **Configure enrichment...** dialog opened from a new **Background enrichment** section in settings. The dialog shows each default prompt in a collapsible "View default prompt" block so users can read the built-in defaults before customising, and includes a **Preview resolved prompt** helper that substitutes `{{FILE_PATH}}` with an example path. The `enrichmentEnabled` toggle stays at the top level. No setting keys changed, so enrichment behaviour is identical for users who never open the dialog. (#451)

--- a/src/framework/AgentContextPrompt.test.ts
+++ b/src/framework/AgentContextPrompt.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorkItem } from "../core/interfaces";
 import {
   buildAgentContextPrompt,
@@ -17,6 +17,16 @@ const item: WorkItem = {
 };
 
 describe("buildAgentContextPrompt", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
   it("uses the fresh template when available", () => {
     const prompt = buildAgentContextPrompt(item, {
       "core.additionalAgentContext": "Task: $title\nState: $state\nPath: $filePath\nId: $id",
@@ -27,7 +37,7 @@ describe("buildAgentContextPrompt", () => {
     );
   });
 
-  it("uses the resolved absolute path when provided", () => {
+  it("keeps $filePath vault-relative even when a fullPath is provided", () => {
     const prompt = buildAgentContextPrompt(
       item,
       {
@@ -36,10 +46,10 @@ describe("buildAgentContextPrompt", () => {
       "/vault/2 - Areas/Tasks/priority/task.md",
     );
 
-    expect(prompt).toBe("Path: /vault/2 - Areas/Tasks/priority/task.md");
+    expect(prompt).toBe("Path: 2 - Areas/Tasks/priority/task.md");
   });
 
-  it("expands $absoluteFilePath to the resolved absolute path", () => {
+  it("expands $filePath and $absoluteFilePath to distinct values when both are meaningful", () => {
     const prompt = buildAgentContextPrompt(
       item,
       {
@@ -49,16 +59,39 @@ describe("buildAgentContextPrompt", () => {
     );
 
     expect(prompt).toBe(
-      "Abs: /vault/2 - Areas/Tasks/priority/task.md\nRel: /vault/2 - Areas/Tasks/priority/task.md",
+      "Abs: /vault/2 - Areas/Tasks/priority/task.md\nRel: 2 - Areas/Tasks/priority/task.md",
     );
   });
 
-  it("falls back to item.path for $absoluteFilePath when no fullPath provided", () => {
+  it("expands $absoluteFilePath to the provided fullPath", () => {
+    const prompt = buildAgentContextPrompt(
+      item,
+      {
+        "core.additionalAgentContext": "Abs: $absoluteFilePath",
+      },
+      "/vault/2 - Areas/Tasks/priority/task.md",
+    );
+
+    expect(prompt).toBe("Abs: /vault/2 - Areas/Tasks/priority/task.md");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to item.path for $absoluteFilePath and warns when no fullPath is provided", () => {
     const prompt = buildAgentContextPrompt(item, {
       "core.additionalAgentContext": "Abs: $absoluteFilePath",
     });
 
     expect(prompt).toBe("Abs: 2 - Areas/Tasks/priority/task.md");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("$absoluteFilePath");
+  });
+
+  it("does not warn about absolute fallback when the template does not reference $absoluteFilePath", () => {
+    buildAgentContextPrompt(item, {
+      "core.additionalAgentContext": "Task: $title\nPath: $filePath",
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it("treats an explicitly cleared template as unavailable", () => {
@@ -96,6 +129,16 @@ describe("buildAgentContextPrompt", () => {
 });
 
 describe("expandProfilePlaceholders", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
   it("expands $title, $state, $filePath, $id", () => {
     const result = expandProfilePlaceholders(
       "--title $title --state $state --path $filePath --id $id",
@@ -158,6 +201,17 @@ describe("expandProfilePlaceholders", () => {
     expect(result).toBe("--verbose --model opus");
   });
 
+  it("keeps $filePath vault-relative even when an absolute path is provided", () => {
+    const result = expandProfilePlaceholders(
+      "--path $filePath",
+      item,
+      "sess-abc",
+      undefined,
+      "/vault/2 - Areas/Tasks/priority/task.md",
+    );
+    expect(result).toBe("--path 2 - Areas/Tasks/priority/task.md");
+  });
+
   it("expands $absoluteFilePath when provided", () => {
     const result = expandProfilePlaceholders(
       "--path $absoluteFilePath",
@@ -167,14 +221,22 @@ describe("expandProfilePlaceholders", () => {
       "/vault/2 - Areas/Tasks/priority/task.md",
     );
     expect(result).toBe("--path /vault/2 - Areas/Tasks/priority/task.md");
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it("falls back to item.path for $absoluteFilePath when not provided", () => {
+  it("falls back to item.path for $absoluteFilePath and warns when not provided", () => {
     const result = expandProfilePlaceholders("--path $absoluteFilePath", item, "sess-abc");
     expect(result).toBe("--path 2 - Areas/Tasks/priority/task.md");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("$absoluteFilePath");
   });
 
-  it("expands $absoluteFilePath and $filePath independently", () => {
+  it("does not warn about absolute fallback when the template does not reference $absoluteFilePath", () => {
+    expandProfilePlaceholders("--path $filePath", item, "sess-abc");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("expands $absoluteFilePath and $filePath to distinct values when both are meaningful", () => {
     const result = expandProfilePlaceholders(
       "--abs $absoluteFilePath --rel $filePath",
       item,
@@ -189,14 +251,14 @@ describe("expandProfilePlaceholders", () => {
 
   it("expands $absoluteFilePath alongside all other placeholders", () => {
     const result = expandProfilePlaceholders(
-      "--title $title --abs $absoluteFilePath --id $id --session $sessionId",
+      "--title $title --abs $absoluteFilePath --rel $filePath --id $id --session $sessionId",
       item,
       "sess-abc",
       undefined,
       "/vault/task.md",
     );
     expect(result).toBe(
-      "--title Fix prompt sync --abs /vault/task.md --id task-123 --session sess-abc",
+      "--title Fix prompt sync --abs /vault/task.md --rel 2 - Areas/Tasks/priority/task.md --id task-123 --session sess-abc",
     );
   });
 });

--- a/src/framework/AgentContextPrompt.test.ts
+++ b/src/framework/AgentContextPrompt.test.ts
@@ -86,6 +86,42 @@ describe("buildAgentContextPrompt", () => {
     expect(warnSpy.mock.calls[0][0]).toContain("$absoluteFilePath");
   });
 
+  it("falls back to item.path for $absoluteFilePath and warns when fullPath is not absolute", () => {
+    const prompt = buildAgentContextPrompt(
+      item,
+      {
+        "core.additionalAgentContext": "Abs: $absoluteFilePath",
+      },
+      "2 - Areas/Tasks/priority/task.md",
+    );
+
+    expect(prompt).toBe("Abs: 2 - Areas/Tasks/priority/task.md");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("not absolute");
+  });
+
+  it("accepts Windows drive letter and UNC absolute paths for $absoluteFilePath", () => {
+    const windowsPrompt = buildAgentContextPrompt(
+      item,
+      {
+        "core.additionalAgentContext": "Abs: $absoluteFilePath",
+      },
+      "C:\\vault\\task.md",
+    );
+    expect(windowsPrompt).toBe("Abs: C:\\vault\\task.md");
+
+    const uncPrompt = buildAgentContextPrompt(
+      item,
+      {
+        "core.additionalAgentContext": "Abs: $absoluteFilePath",
+      },
+      "//server/share/task.md",
+    );
+    expect(uncPrompt).toBe("Abs: //server/share/task.md");
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
   it("does not warn about absolute fallback when the template does not reference $absoluteFilePath", () => {
     buildAgentContextPrompt(item, {
       "core.additionalAgentContext": "Task: $title\nPath: $filePath",
@@ -229,6 +265,19 @@ describe("expandProfilePlaceholders", () => {
     expect(result).toBe("--path 2 - Areas/Tasks/priority/task.md");
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy.mock.calls[0][0]).toContain("$absoluteFilePath");
+  });
+
+  it("falls back to item.path for $absoluteFilePath and warns when a relative path is provided", () => {
+    const result = expandProfilePlaceholders(
+      "--path $absoluteFilePath",
+      item,
+      "sess-abc",
+      undefined,
+      "2 - Areas/Tasks/priority/task.md",
+    );
+    expect(result).toBe("--path 2 - Areas/Tasks/priority/task.md");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("not absolute");
   });
 
   it("does not warn about absolute fallback when the template does not reference $absoluteFilePath", () => {

--- a/src/framework/AgentContextPrompt.ts
+++ b/src/framework/AgentContextPrompt.ts
@@ -12,18 +12,54 @@ export function getAgentContextTemplate(settings: Record<string, unknown>): stri
 export const getClaudeContextTemplate = getAgentContextTemplate;
 
 /**
+ * Check whether a path is actually absolute in any common form we might
+ * encounter at runtime. We intentionally accept POSIX, Windows drive letter,
+ * and UNC style paths regardless of the current platform - the Obsidian
+ * renderer might be asked to format paths from a different OS convention,
+ * and it's cheap to be permissive here.
+ */
+function isAbsolutePath(candidate: string): boolean {
+  // POSIX absolute ("/foo") and POSIX-style UNC ("//server/share").
+  if (candidate.startsWith("/")) {
+    return true;
+  }
+  // Windows UNC ("\\\\server\\share") and Windows root ("\\foo").
+  if (candidate.startsWith("\\")) {
+    return true;
+  }
+  // Windows drive letter ("C:/foo" or "C:\\foo").
+  if (/^[a-zA-Z]:[\\/]/.test(candidate)) {
+    return true;
+  }
+  return false;
+}
+
+/**
  * Resolve the value for `$absoluteFilePath`. When a fully resolved absolute
  * path is provided, use it. Otherwise warn and fall back to the vault-relative
  * `item.path` so the placeholder still expands to something rather than the
  * literal `$absoluteFilePath`.
+ *
+ * Callers occasionally can't resolve the vault base path (e.g.
+ * `TerminalPanelView.resolveWorkItemPath` returns `itemPath` unchanged when
+ * `vaultPath` is empty), which would hand us a vault-relative string even
+ * though the parameter is typed as the absolute path. Validate the shape of
+ * the input and treat non-absolute values the same as if nothing was
+ * provided - warn and fall back to `item.path`.
  */
 function resolveAbsoluteFilePath(item: WorkItem, absolutePath?: string): string {
-  if (absolutePath) {
+  if (absolutePath && isAbsolutePath(absolutePath)) {
     return absolutePath;
   }
-  console.warn(
-    `[work-terminal] $absoluteFilePath requested but no absolute path available for item "${item.id}"; falling back to vault-relative path "${item.path}".`,
-  );
+  if (absolutePath) {
+    console.warn(
+      `[work-terminal] $absoluteFilePath requested but the supplied path "${absolutePath}" is not absolute for item "${item.id}"; falling back to vault-relative path "${item.path}".`,
+    );
+  } else {
+    console.warn(
+      `[work-terminal] $absoluteFilePath requested but no absolute path available for item "${item.id}"; falling back to vault-relative path "${item.path}".`,
+    );
+  }
   return item.path;
 }
 

--- a/src/framework/AgentContextPrompt.ts
+++ b/src/framework/AgentContextPrompt.ts
@@ -11,6 +11,34 @@ export function getAgentContextTemplate(settings: Record<string, unknown>): stri
 
 export const getClaudeContextTemplate = getAgentContextTemplate;
 
+/**
+ * Resolve the value for `$absoluteFilePath`. When a fully resolved absolute
+ * path is provided, use it. Otherwise warn and fall back to the vault-relative
+ * `item.path` so the placeholder still expands to something rather than the
+ * literal `$absoluteFilePath`.
+ */
+function resolveAbsoluteFilePath(item: WorkItem, absolutePath?: string): string {
+  if (absolutePath) {
+    return absolutePath;
+  }
+  console.warn(
+    `[work-terminal] $absoluteFilePath requested but no absolute path available for item "${item.id}"; falling back to vault-relative path "${item.path}".`,
+  );
+  return item.path;
+}
+
+/**
+ * Build the additional agent context prompt from the user-configured template.
+ *
+ * Supported placeholders:
+ * - $title             - Work item title
+ * - $state             - Work item state (e.g. "priority", "active")
+ * - $filePath          - Work item file path (vault-relative)
+ * - $absoluteFilePath  - Fully resolved absolute filesystem path to the work item file.
+ *                        Falls back to the vault-relative `item.path` (with a console warning)
+ *                        when no `fullPath` is supplied.
+ * - $id                - Work item UUID
+ */
 export function buildAgentContextPrompt(
   item: WorkItem,
   settings: Record<string, unknown>,
@@ -21,11 +49,14 @@ export function buildAgentContextPrompt(
     return null;
   }
 
+  const needsAbsolute = /\$absoluteFilePath/.test(template);
+  const absolute = needsAbsolute ? resolveAbsoluteFilePath(item, fullPath) : item.path;
+
   return template
-    .replace(/\$absoluteFilePath/g, fullPath ?? item.path)
+    .replace(/\$absoluteFilePath/g, absolute)
     .replace(/\$title/g, item.title)
     .replace(/\$state/g, item.state)
-    .replace(/\$filePath/g, fullPath ?? item.path)
+    .replace(/\$filePath/g, item.path)
     .replace(/\$id/g, item.id);
 }
 
@@ -38,7 +69,9 @@ export const buildClaudeContextPrompt = buildAgentContextPrompt;
  * - $title             - Work item title
  * - $state             - Work item state (e.g. "priority", "active")
  * - $filePath          - Work item file path (vault-relative)
- * - $absoluteFilePath  - Fully resolved absolute filesystem path to the work item file
+ * - $absoluteFilePath  - Fully resolved absolute filesystem path to the work item file.
+ *                        Falls back to the vault-relative `item.path` (with a console warning)
+ *                        when no `absoluteFilePath` is supplied.
  * - $id                - Work item UUID
  * - $sessionId         - Agent session ID (may be a literal "$sessionId" when deferred)
  * - $workTerminalPrompt - The fully assembled context prompt string, when provided via
@@ -55,9 +88,12 @@ export function expandProfilePlaceholders(
   contextPrompt?: string,
   absoluteFilePath?: string,
 ): string {
+  const needsAbsolute = /\$absoluteFilePath/.test(template);
+  const absolute = needsAbsolute ? resolveAbsoluteFilePath(item, absoluteFilePath) : item.path;
+
   return template
     .replace(/\$workTerminalPrompt/g, contextPrompt ?? "")
-    .replace(/\$absoluteFilePath/g, absoluteFilePath ?? item.path)
+    .replace(/\$absoluteFilePath/g, absolute)
     .replace(/\$title/g, item.title)
     .replace(/\$state/g, item.state)
     .replace(/\$filePath/g, item.path)

--- a/src/framework/TerminalPanelView.test.ts
+++ b/src/framework/TerminalPanelView.test.ts
@@ -908,14 +908,14 @@ describe("TerminalPanelView", () => {
     ]);
   });
 
-  it("expands template $filePath with the resolved absolute work item path", async () => {
+  it("keeps template $filePath vault-relative and expands $absoluteFilePath to the resolved absolute path", async () => {
     mockState.activeItemId = "task-1";
     const promptBuilder = {
       buildPrompt: vi.fn(() => "Built prompt"),
     };
     const { view } = createView(
       {
-        "core.additionalAgentContext": "Template path: $filePath",
+        "core.additionalAgentContext": "Rel: $filePath\nAbs: $absoluteFilePath",
         "core.claudeCommand": "/bin/echo",
         "core.defaultTerminalCwd": "~/ctx",
       },
@@ -937,7 +937,7 @@ describe("TerminalPanelView", () => {
     expect(promptBuilder.buildPrompt).toHaveBeenCalledOnce();
     expect(mockState.latestCreateTabArgs?.[5]).toEqual([
       "/bin/echo",
-      "Built prompt\n\nTemplate path: /vault/Tasks/task-1.md",
+      "Built prompt\n\nRel: Tasks/task-1.md\nAbs: /vault/Tasks/task-1.md",
     ]);
   });
 
@@ -1218,7 +1218,7 @@ describe("TerminalPanelView", () => {
     const defaultElectronRequire = vi.mocked(electronRequire).getMockImplementation();
     const { view } = createView(
       {
-        "core.additionalAgentContext": "Path: $filePath",
+        "core.additionalAgentContext": "Path: $absoluteFilePath",
       },
       {
         app: {
@@ -1261,7 +1261,7 @@ describe("TerminalPanelView", () => {
     const defaultElectronRequire = vi.mocked(electronRequire).getMockImplementation();
     const { view } = createView(
       {
-        "core.additionalAgentContext": "Path: $filePath",
+        "core.additionalAgentContext": "Path: $absoluteFilePath",
       },
       {
         app: {


### PR DESCRIPTION
## Summary

`buildAgentContextPrompt` and `expandProfilePlaceholders` in `src/framework/AgentContextPrompt.ts` both replaced `$filePath` and `$absoluteFilePath` with the same value (the absolute path when available, otherwise `item.path`), even though the docstring, profile-settings UI and user guide all describe them as distinct placeholders.

- `$filePath` now always resolves to the vault-relative `item.path`.
- `$absoluteFilePath` resolves to the fully resolved absolute filesystem path when one is provided.
- When a template references `$absoluteFilePath` but no absolute path is available, it falls back to `item.path` and emits a `console.warn` so the fallback is visible.
- Docstrings for both functions now match the implementation.

## Changes

- `src/framework/AgentContextPrompt.ts`: split the two placeholders, added a shared `resolveAbsoluteFilePath` helper with a warn-on-fallback path, and tightened docstrings.
- `src/framework/AgentContextPrompt.test.ts`: expanded coverage to 24 tests covering both placeholders in all four states (fullPath provided / not provided, for both `buildAgentContextPrompt` and `expandProfilePlaceholders`), including the warn-on-fallback behaviour.
- `src/framework/TerminalPanelView.test.ts`: updated three existing tests that asserted the buggy conflated behaviour to use `$absoluteFilePath` (the correct placeholder for absolute-path assertions); the Windows and UNC vault path tests still cover `path.win32` resolution semantics.
- `CHANGELOG.md`: added an Unreleased `Fixed` entry.

No user guide update is needed — this is an internal fix and the user guide already documented the intended (distinct) semantics for these two placeholders.

## Test plan

- [x] `pnpm exec vitest run` — all 1238 tests pass (53 files)
- [x] `pnpm run build` — no type or bundle errors
- [x] New/updated tests assert `$filePath` and `$absoluteFilePath` resolve to different values when both are meaningful, and cover the warn-on-fallback path
- [ ] Manual verification in live Obsidian (not performed — clear acceptance criteria and covered by unit tests)

Fixes #465