### PR TITLE
Move Retry Enrichment profile into Configure Enrichment dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ GitHub release notes should mirror these entries rather than pasting the raw aut
 
 ### Changed
 - Removed the duplicate **Enable background enrichment** toggle from the main settings list. The toggle now lives exclusively inside the **Configure enrichment...** dialog, matching the button-only pattern used for Agent Profiles and Card Flag Rules. The **Background enrichment** section in settings shows just the **Configure enrichment...** button. (#461)
+- Moved the **Retry enrichment profile** dropdown from the Agent Actions dialog into the Configure Enrichment dialog, so all enrichment-related settings (prompts, profile, retry profile, timeout) are configurable in one place. The underlying `adapter.retryEnrichmentProfile` setting key, resolution chain, and default behaviour are unchanged. The Agent Actions dialog now contains only the Split Task profile binding. (#464)
 
 ### Fixed
 - Fixed `$filePath` and `$absoluteFilePath` placeholders in agent context prompts and profile templates so they now resolve to distinct values: `$filePath` is always the vault-relative path and `$absoluteFilePath` is the fully resolved absolute filesystem path. Previously both placeholders expanded to the same value when an absolute path was available. When `$absoluteFilePath` is used but no absolute path can be resolved, the placeholder falls back to the vault-relative path and logs a `console.warn`. (#465)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -458,6 +458,7 @@ The dialog contains:
 - **Enrichment prompt** - custom prompt template sent to the agent. Use `{{FILE_PATH}}` as a placeholder for the task file path. Leave blank to use the built-in default; the full default prompt is shown in a collapsible "View default prompt" block below the textarea so you can read it before deciding whether to override.
 - **Retry enrichment prompt** - separate prompt used when retrying via the context menu. Same placeholder and default-preview treatment as the enrichment prompt.
 - **Enrichment agent profile** - which agent profile to use (defaults to core Claude settings)
+- **Retry enrichment profile** - which agent profile to launch for the **Retry Enrichment** context-menu action. Lists Claude-family profiles only. Default: the background enrichment profile above if set, otherwise the built-in Claude (ctx) profile.
 - **Enrichment timeout** - maximum time in seconds before the enrichment process is killed (default: 300s / 5 minutes)
 - **Preview resolved prompt** - pick either prompt and click **Preview** to see the template with `{{FILE_PATH}}` substituted using the example path `vault/2 - Areas/Tasks/todo/example.md`. Useful for sanity-checking a customised prompt without creating a real task.
 
@@ -541,12 +542,13 @@ The retry session also runs through a resolvable agent profile. By default it fo
 
 ### Agent actions settings
 
-Profile bindings for adapter-driven actions (Split Task, Retry Enrichment) live behind the **Configure agent actions...** button under **Settings > Agent actions**. The dialog exposes two dropdowns:
+Profile binding for the **Split Task** adapter-driven action lives behind the **Configure agent actions...** button under **Settings > Agent actions**. The dialog exposes one dropdown:
 
 - **Split task profile** - which agent profile to launch for Split Task. Default: the built-in Claude (ctx) profile.
-- **Retry enrichment profile** - which agent profile to launch for Retry Enrichment. Default: the background enrichment profile if set, otherwise the built-in Claude (ctx) profile.
 
-Both dropdowns list all configured agent profiles. Select **Default (see description)** to restore the fallback chain described above. Changes persist immediately; no save button is required.
+The dropdown lists all configured agent profiles. Select **Default (see description)** to restore the fallback chain described above. Changes persist immediately; no save button is required.
+
+The **Retry Enrichment** profile binding lives in the [Background enrichment](#background-enrichment) dialog instead, so all enrichment-related settings (prompts, profile, retry profile, timeout) are configurable in one place.
 
 The fallback chain ensures new users get sensible, profile-aware behaviour without touching the dialog, while power users can bind a dedicated profile (e.g. one with `--dangerously-skip-permissions` pre-configured) to any agent-driven action.
 
@@ -649,6 +651,7 @@ These settings are specific to the task-agent adapter. Adapter-level fields appe
 | Enrichment prompt | Custom prompt template for enrichment (edited via **Configure enrichment...**) | (default) |
 | Retry enrichment prompt | Custom prompt for retry enrichment (edited via **Configure enrichment...**) | (default) |
 | Enrichment agent profile | Which profile to use for enrichment (edited via **Configure enrichment...**) | Default |
+| Retry enrichment profile | Which profile to use when running Retry Enrichment from the card context menu (edited via **Configure enrichment...**) | Default |
 | Enrichment timeout | Max seconds for enrichment (edited via **Configure enrichment...**) | 300 |
 | Show card indicators | Show metadata indicators on cards (source badges, priority scores, goal tags, card flags, indicator dots). See [Hiding card indicators](#hiding-card-indicators). | `true` |
 | Task card icons | Show icons on task cards | `false` |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -458,7 +458,7 @@ The dialog contains:
 - **Enrichment prompt** - custom prompt template sent to the agent. Use `{{FILE_PATH}}` as a placeholder for the task file path. Leave blank to use the built-in default; the full default prompt is shown in a collapsible "View default prompt" block below the textarea so you can read it before deciding whether to override.
 - **Retry enrichment prompt** - separate prompt used when retrying via the context menu. Same placeholder and default-preview treatment as the enrichment prompt.
 - **Enrichment agent profile** - which agent profile to use (defaults to core Claude settings)
-- **Retry enrichment profile** - which agent profile to launch for the **Retry Enrichment** context-menu action. Lists Claude-family profiles only. Default: the background enrichment profile above if set, otherwise the built-in Claude (ctx) profile.
+- **Retry enrichment profile** - which agent profile to launch for the **Retry Enrichment** context-menu action. Lists Claude-family profiles only. Default: reuse the background enrichment profile above if it is set to a Claude-family profile; if the background enrichment profile is unset or is a non-Claude profile, it is ignored and Retry Enrichment falls back to the built-in Claude (ctx) profile.
 - **Enrichment timeout** - maximum time in seconds before the enrichment process is killed (default: 300s / 5 minutes)
 - **Preview resolved prompt** - pick either prompt and click **Preview** to see the template with `{{FILE_PATH}}` substituted using the example path `vault/2 - Areas/Tasks/todo/example.md`. Useful for sanity-checking a customised prompt without creating a real task.
 
@@ -538,7 +538,7 @@ The Claude session launched by Split Task runs through the same agent-profile pi
 
 When background enrichment for a newly created task fails, the card shows a warning and a **Retry Enrichment** context menu entry. Running it opens a Claude session that picks up where background enrichment left off.
 
-The retry session also runs through a resolvable agent profile. By default it follows the **background enrichment profile** (so the retry matches what automated enrichment would have used); if none is set, it falls back to the built-in Claude (ctx) profile. You can override this to any profile via [Agent actions settings](#agent-actions-settings).
+The retry session also runs through a resolvable agent profile. By default it follows the **background enrichment profile** (so the retry matches what automated enrichment would have used) when that profile is Claude-family; if the background enrichment profile is unset or is a non-Claude profile, it falls back to the built-in Claude (ctx) profile. You can override this to any Claude-family profile via the **Retry enrichment profile** dropdown in the [Background enrichment](#background-enrichment) **Configure enrichment...** dialog.
 
 ### Agent actions settings
 
@@ -546,7 +546,7 @@ Profile binding for the **Split Task** adapter-driven action lives behind the **
 
 - **Split task profile** - which agent profile to launch for Split Task. Default: the built-in Claude (ctx) profile.
 
-The dropdown lists all configured agent profiles. Select **Default (see description)** to restore the fallback chain described above. Changes persist immediately; no save button is required.
+The dropdown lists configured Claude-family agent profiles only. Select **Default (see description)** to restore the fallback chain described above. Changes persist immediately; no save button is required.
 
 The **Retry Enrichment** profile binding lives in the [Background enrichment](#background-enrichment) dialog instead, so all enrichment-related settings (prompts, profile, retry profile, timeout) are configurable in one place.
 

--- a/src/framework/AgentActionsDialog.ts
+++ b/src/framework/AgentActionsDialog.ts
@@ -1,7 +1,6 @@
 /**
  * AgentActionsDialog - dedicated modal housing profile bindings for
- * agent-driven adapter actions (Split Task, Retry Enrichment, and future
- * per-action hooks).
+ * agent-driven adapter actions (Split Task, and future per-action hooks).
  *
  * Mirrors the structure of EnrichmentSettingsDialog - the pattern is
  * deliberately duplicated (not extracted to a base class) so each dialog
@@ -10,13 +9,14 @@
  * Settings are persisted through the same `plugin.loadData`/saveData path
  * as the rest of the adapter schema. Keys written here are:
  *   - adapter.splitTaskProfile
- *   - adapter.retryEnrichmentProfile
  *
- * The resolution chains (see splitTaskProfile.ts) mean that leaving
- * either dropdown on "Default" still produces sensible behaviour:
- *   - Split Task -> built-in Claude (ctx) profile.
- *   - Retry Enrichment -> adapter.enrichmentProfile if set, else the
- *     built-in Claude (ctx) profile.
+ * The `adapter.retryEnrichmentProfile` binding used to live here too but
+ * moved to EnrichmentSettingsDialog (issue #464) so all enrichment-related
+ * settings are configurable in one place.
+ *
+ * The resolution chain (see splitTaskProfile.ts) means that leaving the
+ * dropdown on "Default" still produces sensible behaviour: Split Task
+ * falls back to the built-in Claude (ctx) profile.
  */
 import { App, Modal, Setting } from "obsidian";
 import type { Plugin } from "obsidian";
@@ -82,15 +82,6 @@ export class AgentActionsDialog extends Modal {
       "Profile used when launching Claude for the Split Task context menu action. " +
         "Default: the built-in Claude (ctx) profile, matching the 'Claude (ctx)' tab bar button.",
       "adapter.splitTaskProfile",
-      settings,
-    );
-
-    this.renderProfileDropdown(
-      containerEl,
-      "Retry enrichment profile",
-      "Profile used when re-running enrichment from the card context menu. " +
-        "Default: the background enrichment profile if set, otherwise the built-in Claude (ctx) profile.",
-      "adapter.retryEnrichmentProfile",
       settings,
     );
   }

--- a/src/framework/EnrichmentSettingsDialog.ts
+++ b/src/framework/EnrichmentSettingsDialog.ts
@@ -259,8 +259,8 @@ export class EnrichmentSettingsDialog extends Modal {
       .setName("Retry enrichment profile")
       .setDesc(
         "Profile used when re-running enrichment from the card context menu. " +
-          "Default: the background enrichment profile above if set, otherwise " +
-          "the built-in Claude (ctx) profile.",
+          "Default: the background enrichment profile above if it is Claude-family; " +
+          "otherwise the built-in Claude (ctx) profile.",
       )
       .addDropdown((dropdown) => {
         dropdown.addOption("", "Default (see description)");

--- a/src/framework/EnrichmentSettingsDialog.ts
+++ b/src/framework/EnrichmentSettingsDialog.ts
@@ -100,6 +100,7 @@ export class EnrichmentSettingsDialog extends Modal {
       settings,
     );
     this.renderProfileDropdown(containerEl, settings);
+    this.renderRetryProfileDropdown(containerEl, settings);
     this.renderTimeoutField(containerEl, settings);
     this.renderPreviewPanel(containerEl, settings);
   }
@@ -236,6 +237,39 @@ export class EnrichmentSettingsDialog extends Modal {
         dropdown.setValue(value).onChange(async (newValue) => {
           await this.saveSettings((s) => {
             s["adapter.enrichmentProfile"] = newValue;
+          });
+        });
+      });
+  }
+
+  /**
+   * Render the Retry enrichment profile dropdown. Lives alongside the main
+   * enrichment profile so users can configure everything enrichment-related
+   * in one place (issue #464). Only Claude-family profiles are surfaced
+   * because the Retry Enrichment action launches through spawnClaudeWithPrompt
+   * which rejects non-Claude profiles at launch time.
+   */
+  private renderRetryProfileDropdown(
+    containerEl: HTMLElement,
+    settings: Record<string, unknown>,
+  ): void {
+    const value = (settings["adapter.retryEnrichmentProfile"] as string) || "";
+    const claudeProfiles = this.profileManager.getProfilesByType("claude");
+    new Setting(containerEl)
+      .setName("Retry enrichment profile")
+      .setDesc(
+        "Profile used when re-running enrichment from the card context menu. " +
+          "Default: the background enrichment profile above if set, otherwise " +
+          "the built-in Claude (ctx) profile.",
+      )
+      .addDropdown((dropdown) => {
+        dropdown.addOption("", "Default (see description)");
+        for (const profile of claudeProfiles) {
+          dropdown.addOption(profile.id, profile.name);
+        }
+        dropdown.setValue(value).onChange(async (newValue) => {
+          await this.saveSettings((s) => {
+            s["adapter.retryEnrichmentProfile"] = newValue;
           });
         });
       });

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -213,10 +213,14 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
       "retryEnrichmentPrompt",
       "enrichmentProfile",
       "enrichmentTimeout",
+      // retryEnrichmentProfile moved from Agent actions dialog to the
+      // enrichment dialog (#464) so all enrichment-related settings live
+      // in one place.
+      "retryEnrichmentProfile",
     ]);
     // Agent-action profile bindings live behind a dedicated dialog (#448) so
     // the main adapter section stays focused on adapter-intrinsic settings.
-    const agentActionsDialogKeys = new Set(["splitTaskProfile", "retryEnrichmentProfile"]);
+    const agentActionsDialogKeys = new Set(["splitTaskProfile"]);
     const hasEnrichmentSchema = schema.some((field) => enrichmentDialogKeys.has(field.key));
     const hasAgentActionsSchema = schema.some((field) => agentActionsDialogKeys.has(field.key));
     const nonEnrichmentSchema = schema.filter(
@@ -254,8 +258,9 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
         .setName("Configure agent actions")
         .setDesc(
           "Open a dialog to bind agent profiles to adapter-driven actions " +
-            "(Split Task, Retry Enrichment). Defaults follow the built-in 'Claude (ctx)' " +
-            "profile so users who never open this dialog still get profile-aware launches.",
+            "(currently Split Task). Defaults follow the built-in 'Claude (ctx)' " +
+            "profile so users who never open this dialog still get profile-aware launches. " +
+            "The Retry Enrichment profile now lives in the Configure enrichment... dialog.",
         )
         .addButton((btn) =>
           btn

--- a/src/framework/splitTaskProfile.ts
+++ b/src/framework/splitTaskProfile.ts
@@ -16,7 +16,8 @@
  *     -> first Claude profile
  *     -> null
  *
- * Retry Enrichment profile:
+ * Retry Enrichment profile (configured in the Configure Enrichment
+ * dialog, key `adapter.retryEnrichmentProfile`):
  *   adapter.retryEnrichmentProfile
  *     -> adapter.enrichmentProfile (shared with background enrichment)
  *     -> default-claude-ctx


### PR DESCRIPTION
## Summary
- Moves the `adapter.retryEnrichmentProfile` dropdown from `AgentActionsDialog` into `EnrichmentSettingsDialog`, next to the existing enrichment prompt/retry prompt/profile/timeout fields, so all enrichment-related settings live in one place.
- Keeps `AgentActionsDialog` as the hub for Split Task and future per-action hooks. It now contains only the Split Task profile binding.
- Updates the fallback-chain doc comment in `splitTaskProfile.ts` to reflect the dropdown's new home. Resolution logic and setting keys are unchanged, so behaviour is identical for users who never open the dialog.
- Updates `docs/user-guide.md`: the Background enrichment section gains the Retry enrichment profile bullet and a row in the adapter settings table; the Agent actions settings section now documents only Split Task.
- Adds an Unreleased `### Changed` entry to `CHANGELOG.md`.

Second PR in the settings-UI cleanup sequence (after #461). No data migration needed.

## Test plan
- [x] `pnpm exec vitest run` (1241 tests pass)
- [x] `pnpm run build` (clean)
- [ ] Open settings in Obsidian: **Configure enrichment...** now shows the Retry enrichment profile dropdown alongside the other enrichment fields.
- [ ] Open **Configure agent actions...** and verify it shows only the Split task profile dropdown.
- [ ] Changing the retry profile in the new location persists and is picked up by the Retry Enrichment action.

Closes #464