### PR TITLE
Promote no-unused-vars to error and fix CI unhandled rejections

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,7 @@ export default tseslint.config(
   eslintConfigPrettier,
   {
     rules: {
-      "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-require-imports": "off",
     },

--- a/src/adapters/task-agent/BackgroundEnrich.ts
+++ b/src/adapters/task-agent/BackgroundEnrich.ts
@@ -3,7 +3,6 @@ import {
   spawnHeadlessClaude,
   spawnHeadlessAgent,
   DEFAULT_TIMEOUT_MS,
-  type HeadlessAgentConfig,
 } from "../../core/claude/HeadlessClaude";
 import { generateTaskContent, generatePendingFilename } from "./TaskFileTemplate";
 import type { SplitSource, EnrichmentMeta } from "./TaskFileTemplate";
@@ -485,26 +484,6 @@ export function insertIngestionFailedFlag(content: string): string {
   }
 
   return result;
-}
-
-/**
- * Clear the `background-ingestion: failed` flag from a task file by setting it to `retrying`.
- * Called before retrying enrichment.
- */
-async function clearIngestionFailedFlag(app: App, filePath: string): Promise<void> {
-  const file = app.vault.getAbstractFileByPath(filePath) as TFile | null;
-  if (!file) return;
-
-  try {
-    let content = await app.vault.read(file);
-    content = content.replace(
-      /^background-ingestion:[ \t]*failed[^\r\n]*/m,
-      "background-ingestion: retrying",
-    );
-    await app.vault.modify(file, content);
-  } catch (err) {
-    console.error(`[work-terminal] Failed to clear ingestion flag on ${filePath}:`, err);
-  }
 }
 
 /**

--- a/src/adapters/task-agent/TaskMover.test.ts
+++ b/src/adapters/task-agent/TaskMover.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { TaskMover } from "./TaskMover";
 import type { App, TFile } from "obsidian";
 

--- a/src/core/agents/AgentLauncher.nvmFnm.test.ts
+++ b/src/core/agents/AgentLauncher.nvmFnm.test.ts
@@ -28,7 +28,7 @@ vi.mock("../utils", async () => {
       if (moduleName === "fs") {
         return {
           existsSync: (p: string) => p in mockFs,
-          readFileSync: (p: string, encoding: string) => {
+          readFileSync: (p: string, _encoding: string) => {
             if (p in mockFs && typeof mockFs[p] === "string") {
               return mockFs[p];
             }

--- a/src/core/agents/AgentProfileManager.test.ts
+++ b/src/core/agents/AgentProfileManager.test.ts
@@ -252,7 +252,7 @@ describe("AgentProfileManager", () => {
     });
 
     it("resolves command for each agent type", () => {
-      for (const [agentType, settingKey, fallback] of [
+      for (const [agentType, settingKey, _fallback] of [
         ["claude", "core.claudeCommand", "claude"],
         ["copilot", "core.copilotCommand", "copilot"],
         ["strands", "core.strandsCommand", "strands"],

--- a/src/core/terminal/TabManager.test.ts
+++ b/src/core/terminal/TabManager.test.ts
@@ -562,8 +562,7 @@ describe("TabManager - onProcessExit auto-close behaviour", () => {
     terminalTabMock.MockTerminalTab.constructorArgs.length = 0;
     const baseTime = 1000000;
     // First call (spawnTime) returns baseTime, subsequent calls return 31s later
-    const nowMock = vi
-      .spyOn(Date, "now")
+    vi.spyOn(Date, "now")
       .mockReturnValueOnce(baseTime) // spawnTime in createTabForItem
       .mockReturnValue(baseTime + 31_000); // exit check in onProcessExit
 
@@ -580,8 +579,7 @@ describe("TabManager - onProcessExit auto-close behaviour", () => {
   it("keeps the tab open when a long-running process exits with non-zero code", () => {
     terminalTabMock.MockTerminalTab.constructorArgs.length = 0;
     const baseTime = 1000000;
-    const nowMock = vi
-      .spyOn(Date, "now")
+    vi.spyOn(Date, "now")
       .mockReturnValueOnce(baseTime)
       .mockReturnValue(baseTime + 31_000);
 

--- a/src/framework/ActivityTracker.test.ts
+++ b/src/framework/ActivityTracker.test.ts
@@ -9,8 +9,6 @@ import {
   thresholdToMs,
   ACTIVITY_BUCKETS,
   ACTIVITY_BUCKET_LABELS,
-  type RecentThreshold,
-  type ActivityBucket,
 } from "./ActivityTracker";
 
 describe("thresholdToMs", () => {

--- a/src/framework/GuidedTour.ts
+++ b/src/framework/GuidedTour.ts
@@ -799,6 +799,7 @@ export class GuidedTourController {
 
   private async waitForTarget(selector: string): Promise<HTMLElement | null> {
     for (let attempt = 0; attempt < 40; attempt += 1) {
+      if (this.isDisposed) return null;
       const target = document.querySelector<HTMLElement>(selector);
       if (target) return target;
       await new Promise((resolve) => window.setTimeout(resolve, 50));

--- a/src/framework/ListPanel.test.ts
+++ b/src/framework/ListPanel.test.ts
@@ -1028,7 +1028,7 @@ describe("ListPanel", () => {
     });
 
     it("passes comfortable displayMode to card renderer", () => {
-      const renderSpy = vi.fn((item: WorkItem) => {
+      const renderSpy = vi.fn((_item: WorkItem) => {
         const el = document.createElement("div");
         el.createDiv({ cls: "wt-card-actions" });
         return el;
@@ -1098,7 +1098,7 @@ describe("ListPanel", () => {
     });
 
     it("passes displayMode to card renderer", () => {
-      const renderSpy = vi.fn((item: WorkItem) => {
+      const renderSpy = vi.fn((_item: WorkItem) => {
         const el = document.createElement("div");
         el.createDiv({ cls: "wt-card-actions" });
         return el;
@@ -1144,7 +1144,7 @@ describe("ListPanel", () => {
     });
 
     it("passes standard displayMode to card renderer when not compact", () => {
-      const renderSpy = vi.fn((item: WorkItem) => {
+      const renderSpy = vi.fn((_item: WorkItem) => {
         const el = document.createElement("div");
         el.createDiv({ cls: "wt-card-actions" });
         return el;

--- a/src/framework/SettingsTab.test.ts
+++ b/src/framework/SettingsTab.test.ts
@@ -269,6 +269,7 @@ const adapter = {
     defaultSettings: {},
     itemName: "task",
   },
+  createPromptBuilder: () => null,
 } as any;
 
 const mockProfileManager = {

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -402,7 +402,7 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
    * agent context textarea, and buttons to the Background enrichment and
    * Agent actions dialogs.
    */
-  private renderAgentsSection(containerEl: HTMLElement, settings: SettingsSnapshot): void {
+  private renderAgentsSection(containerEl: HTMLElement, _settings: SettingsSnapshot): void {
     containerEl.createEl("h2", { text: "Agents" });
 
     // Profile Manager - first because it's the most frequent touchpoint.

--- a/src/framework/TerminalPanelView.test.ts
+++ b/src/framework/TerminalPanelView.test.ts
@@ -1713,7 +1713,7 @@ describe("profile launch", () => {
       getProfile: () => null,
     };
 
-    const tab = await (view as any).spawnAgentSession({
+    await (view as any).spawnAgentSession({
       agentType: "custom",
       sessionType: "custom",
       command: "pi",

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -24,7 +24,6 @@ import type {
 } from "../core/session/types";
 import { electronRequire, expandTilde } from "../core/utils";
 import type { AdapterBundle, WorkItem, WorkItemPromptBuilder } from "../core/interfaces";
-import { mergeAndSavePluginData } from "../core/PluginDataStore";
 import { expandProfilePlaceholders } from "./AgentContextPrompt";
 import { ProfileLaunchModal, type ProfileLaunchOverrides } from "./ProfileLaunchModal";
 import { SETTINGS_CHANGED_EVENT } from "./SettingsTab";


### PR DESCRIPTION
Fixes the CI failure on the 0.4.0 release branch caused by two unhandled rejections in GuidedTour tests, and promotes `no-unused-vars` from `warn` to `error` to keep the codebase clean going forward.

## Changes

### Lint rule upgrade
- `@typescript-eslint/no-unused-vars`: `warn` -> `error`
- Added `varsIgnorePattern: "^_"` to allow intentional underscore-prefixed variables (e.g. exhaustive switch checks)

### 16 unused-variable fixes
- Removed unused imports (`HeadlessAgentConfig`, `beforeEach`, `RecentThreshold`, `ActivityBucket`, `mergeAndSavePluginData`)
- Removed dead `clearIngestionFailedFlag` function from BackgroundEnrich
- Prefixed intentionally-unused callback/destructuring args with `_`
- Dropped unnecessary spy assignments (`nowMock`, `tab`)

### CI fix: GuidedTour unhandled rejections
- Added `this.isDisposed` guard at the top of the `waitForTarget` polling loop
- Prevents `ReferenceError: document is not defined` when jsdom tears down while `waitForTarget` timers are still in flight
- This was the root cause of the CI exit code 1 (vitest caught 2 unhandled errors)

### Test mock fix
- Added `createPromptBuilder` to the SettingsTab test mock adapter, eliminating the `TypeError: adapter.createPromptBuilder is not a function` stderr noise