### PR TITLE
Detail view placement: embedded editor tab (reparent hack)

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -226,13 +226,16 @@ Because the detail panel is a standard Obsidian markdown view, all Obsidian feat
 
 The way the detail file is opened is configurable under **Settings > Detail view**. By default, selecting a task opens its file in a vertical split next to the Work Terminal view and applies a readable line-width override - this matches the behaviour shipped in earlier versions, so users who never open the settings see no change.
 
-The **Placement** dropdown offers five strategies:
+The **Placement** dropdown offers six strategies:
 
 - **Split (default)** - create a new split beside the Work Terminal view and apply the min-width override so the editor does not squish. Best when Work Terminal sits in its own tab group.
 - **Tab in active group** - open the task file as a new tab in the currently active tab group, with no splitting and no width override. Best when Work Terminal lives in a tab group alongside other files and you want the detail view to behave like any other tab.
 - **Navigate active leaf** - open the task file in the most recent editor leaf that is not the Work Terminal view, falling back to a new tab if no suitable leaf exists. Does not replace the Work Terminal view itself. No new tabs or splits are created when a suitable editor leaf is already open.
 - **Preview in Work Terminal panel** - render the task file's markdown read-only as an overlay inside the Work Terminal panel itself, layered above the terminal tabs. Provides an **Open in editor** button that opens the file in a workspace leaf using the same target-leaf resolution as the Navigate placement. The preview re-renders automatically when the file is modified in another leaf, so edits you make elsewhere show up immediately. Best for small screens or single-pane layouts where keeping the terminal visible while glancing at the task description matters more than editing in place. There is intentionally no way to edit the file from the preview - use **Open in editor** for that.
+- **Embedded in terminal panel (experimental)** - render the detail view inside the terminal panel itself as a "Detail" pseudo-tab alongside shell and agent tabs. Useful on small screens or when you never want the detail view to leave the Work Terminal tab. See the callout below for trade-offs.
 - **Disabled** - do nothing on selection. Useful if you prefer to open files manually via the file explorer, quick switcher, or Obsidian's hover preview, or if you only need the terminal side of Work Terminal.
+
+**Experimental: Embedded placement.** The embedded mode works by creating a hidden Obsidian workspace leaf, then reparenting its MarkdownView content element into a slot inside the Work Terminal's terminal panel. This gives you the full MarkdownView - live preview, frontmatter editor, backlinks - without opening a separate leaf, but it relies on internal Obsidian APIs that may change between versions. Selecting a task auto-focuses the Detail pseudo-tab; clicking any terminal or agent tab switches back to the shell view. If you hit rendering or focus issues, switch to Split or Tab placement.
 
 Additional options shape the behaviour:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -239,7 +239,7 @@ The **Placement** dropdown offers six strategies:
 
 Additional options shape the behaviour:
 
-- **Auto-close on selection change** (all placements except Disabled) - detaches the detail leaf when you select a different item, so the next selection opens a fresh leaf at the current placement target. With this off, the same leaf is reused across selections.
+- **Auto-close on selection change** (all placements except Disabled) - detaches the detail leaf when you select a different item, so the next selection opens a fresh leaf at the current placement target. With this off, the same leaf is reused across selections. Applies to the embedded placement too: the hidden Obsidian leaf backing the embedded view is torn down and remounted on each selection when the toggle is on.
 - **Apply readable line-width override to split** (Split only) - toggles the width override. When off, Obsidian's default flex layout controls the split and any previously-applied inline styles are cleared on the next selection.
 - **Split direction** (Split only) - choose Vertical (side by side) or Horizontal (top and bottom). Vertical matches the default behaviour.
 

--- a/src/adapters/task-agent/EmbeddedDetailView.test.ts
+++ b/src/adapters/task-agent/EmbeddedDetailView.test.ts
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
+import { EmbeddedDetailView } from "./EmbeddedDetailView";
+import type { App } from "obsidian";
+
+// Polyfill Obsidian HTMLElement augmentations used by EmbeddedDetailView.
+beforeAll(() => {
+  const prototype = HTMLElement.prototype as typeof HTMLElement.prototype & {
+    addClass(cls: string): HTMLElement;
+    removeClass(cls: string): HTMLElement;
+    empty(): HTMLElement;
+  };
+  prototype.addClass = function (cls: string) {
+    this.classList.add(cls);
+    return this;
+  };
+  prototype.removeClass = function (cls: string) {
+    this.classList.remove(cls);
+    return this;
+  };
+  prototype.empty = function () {
+    while (this.firstChild) this.removeChild(this.firstChild);
+    return this;
+  };
+});
+
+/**
+ * Fabricate a minimal Obsidian App/Workspace/Leaf shape for EmbeddedDetailView.
+ * The class reaches into `workspace.getLeaf("window")`, the leaf's `openFile`,
+ * `view.contentEl`, and `leaf.detach` only.
+ */
+function makeApp(opts: { fileExists?: boolean; contentEl?: HTMLElement | null } = {}): {
+  app: App;
+  leaf: { openFile: ReturnType<typeof vi.fn>; detach: ReturnType<typeof vi.fn>; view: any };
+  getLeaf: ReturnType<typeof vi.fn>;
+} {
+  const contentEl = opts.contentEl === undefined ? document.createElement("div") : opts.contentEl;
+  if (contentEl) {
+    // Place content under an "original parent" to match what Obsidian would do.
+    const originalParent = document.createElement("div");
+    originalParent.appendChild(contentEl);
+  }
+  const leaf = {
+    openFile: vi.fn().mockResolvedValue(undefined),
+    detach: vi.fn(),
+    view: contentEl ? { contentEl } : null,
+  };
+  const getLeaf = vi.fn().mockReturnValue(leaf);
+  const app = {
+    vault: {
+      getAbstractFileByPath: (p: string) =>
+        opts.fileExists === false ? null : ({ path: p } as unknown),
+    },
+    workspace: {
+      getLeaf,
+    },
+  } as unknown as App;
+  return { app, leaf, getLeaf };
+}
+
+describe("EmbeddedDetailView", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("does nothing when the file does not exist", async () => {
+    const { app, getLeaf } = makeApp({ fileExists: false });
+    const view = new EmbeddedDetailView(app);
+    const host = document.createElement("div");
+    await view.show("missing.md", host);
+    expect(getLeaf).not.toHaveBeenCalled();
+    expect(host.children.length).toBe(0);
+  });
+
+  it("creates a hidden leaf and reparents contentEl into the host", async () => {
+    const contentEl = document.createElement("div");
+    contentEl.className = "markdown-source-view";
+    document.body.appendChild(document.createElement("div")).appendChild(contentEl);
+
+    const { app, leaf, getLeaf } = makeApp({ contentEl });
+    const view = new EmbeddedDetailView(app);
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+
+    await view.show("task.md", host);
+
+    expect(getLeaf).toHaveBeenCalledWith("window");
+    expect(leaf.openFile).toHaveBeenCalled();
+    expect(contentEl.parentElement).toBe(host);
+    expect(host.classList.contains("wt-embedded-detail-active")).toBe(true);
+  });
+
+  it("reuses the existing leaf on subsequent shows and does not re-create one", async () => {
+    const contentEl = document.createElement("div");
+    document.body.appendChild(document.createElement("div")).appendChild(contentEl);
+    const { app, leaf, getLeaf } = makeApp({ contentEl });
+    const view = new EmbeddedDetailView(app);
+    const host = document.createElement("div");
+
+    await view.show("a.md", host);
+    await view.show("b.md", host);
+
+    expect(getLeaf).toHaveBeenCalledTimes(1);
+    expect(leaf.openFile).toHaveBeenCalledTimes(2);
+    expect(contentEl.parentElement).toBe(host);
+  });
+
+  it("moves contentEl into a new host when host changes", async () => {
+    const contentEl = document.createElement("div");
+    document.body.appendChild(document.createElement("div")).appendChild(contentEl);
+    const { app } = makeApp({ contentEl });
+    const view = new EmbeddedDetailView(app);
+
+    const hostA = document.createElement("div");
+    const hostB = document.createElement("div");
+
+    await view.show("a.md", hostA);
+    expect(contentEl.parentElement).toBe(hostA);
+
+    await view.show("a.md", hostB);
+    expect(contentEl.parentElement).toBe(hostB);
+    expect(hostA.classList.contains("wt-embedded-detail-active")).toBe(false);
+    expect(hostB.classList.contains("wt-embedded-detail-active")).toBe(true);
+  });
+
+  it("detaches the leaf and restores the reparented element on detach", async () => {
+    const contentEl = document.createElement("div");
+    const { app, leaf } = makeApp({ contentEl });
+    // Track the parent the helper assigned so we can assert restore goes back to it.
+    const originalParent = contentEl.parentElement as HTMLElement;
+    expect(originalParent).not.toBeNull();
+
+    const view = new EmbeddedDetailView(app);
+    const host = document.createElement("div");
+    await view.show("a.md", host);
+    expect(contentEl.parentElement).toBe(host);
+
+    view.detach();
+
+    expect(leaf.detach).toHaveBeenCalled();
+    expect(contentEl.parentElement).toBe(originalParent);
+    expect(host.classList.contains("wt-embedded-detail-active")).toBe(false);
+    expect(host.children.length).toBe(0);
+  });
+
+  it("tracks path rename so rekey updates internal state", async () => {
+    const contentEl = document.createElement("div");
+    document.body.appendChild(document.createElement("div")).appendChild(contentEl);
+    const { app } = makeApp({ contentEl });
+    const view = new EmbeddedDetailView(app);
+    const host = document.createElement("div");
+    await view.show("old.md", host);
+
+    // Should not throw and should be a no-op for observable state
+    view.rekeyPath("old.md", "new.md");
+    view.rekeyPath("unrelated.md", "other.md");
+
+    // Subsequent show with new path still works
+    await view.show("new.md", host);
+    expect(contentEl.parentElement).toBe(host);
+  });
+});

--- a/src/adapters/task-agent/EmbeddedDetailView.test.ts
+++ b/src/adapters/task-agent/EmbeddedDetailView.test.ts
@@ -143,7 +143,7 @@ describe("EmbeddedDetailView", () => {
     expect(host.children.length).toBe(0);
   });
 
-  it("tracks path rename so rekey updates internal state", async () => {
+  it("handles show() on a new path after rename without tracking internal path state", async () => {
     const contentEl = document.createElement("div");
     document.body.appendChild(document.createElement("div")).appendChild(contentEl);
     const { app } = makeApp({ contentEl });
@@ -151,11 +151,8 @@ describe("EmbeddedDetailView", () => {
     const host = document.createElement("div");
     await view.show("old.md", host);
 
-    // Should not throw and should be a no-op for observable state
-    view.rekeyPath("old.md", "new.md");
-    view.rekeyPath("unrelated.md", "other.md");
-
-    // Subsequent show with new path still works
+    // A subsequent show() on the new path reuses the leaf and keeps the
+    // content mounted in the same host - no explicit rekey required.
     await view.show("new.md", host);
     expect(contentEl.parentElement).toBe(host);
   });

--- a/src/adapters/task-agent/EmbeddedDetailView.ts
+++ b/src/adapters/task-agent/EmbeddedDetailView.ts
@@ -1,0 +1,119 @@
+/**
+ * EmbeddedDetailView - EXPERIMENTAL.
+ *
+ * Renders the task detail MarkdownView inside a caller-provided host element
+ * (a DOM slot owned by TerminalPanelView) by reparenting a hidden workspace
+ * leaf's `contentEl` into the host. This gives us full MarkdownView
+ * functionality - live preview, frontmatter editor, backlinks - without
+ * requiring a dedicated workspace leaf.
+ *
+ * This relies on two undocumented / internal Obsidian behaviours:
+ *   1. `workspace.getLeaf("window")` returns a leaf whose root element is
+ *      detached from the workspace split. We keep the leaf alive but move
+ *      its content element into our own host.
+ *   2. MarkdownView renders into `leaf.view.contentEl`. Reparenting that
+ *      element preserves its internal editor state because CodeMirror is
+ *      content-agnostic about its mount location.
+ *
+ * Both may break across Obsidian versions. The placement is marked
+ * experimental in settings to set expectations accordingly.
+ */
+import type { App, TFile, WorkspaceLeaf } from "obsidian";
+
+export class EmbeddedDetailView {
+  private leaf: WorkspaceLeaf | null = null;
+  private reparentedEl: HTMLElement | null = null;
+  private host: HTMLElement | null = null;
+  private originalParent: HTMLElement | null = null;
+  private currentPath: string | null = null;
+
+  constructor(private app: App) {}
+
+  /**
+   * Open (or update) the embedded detail view for a file, mounting its
+   * MarkdownView content into the supplied host element.
+   */
+  async show(path: string, host: HTMLElement): Promise<void> {
+    const file = this.app.vault.getAbstractFileByPath(path) as TFile | null;
+    if (!file) return;
+
+    // Host changed (MainView re-rendered / panel was recreated): fully reset
+    // so we mount cleanly into the new host element.
+    if (this.host && this.host !== host) {
+      this.detach();
+    }
+
+    if (!this.leaf) {
+      // "window" leaves are created detached from the workspace split which
+      // lets us reparent their content element without Obsidian fighting us
+      // for layout. We never actually pop it out into a window - we reparent
+      // immediately.
+      const createLeaf = (
+        this.app.workspace as unknown as {
+          getLeaf: (how: "window" | "tab" | "split" | boolean) => WorkspaceLeaf;
+        }
+      ).getLeaf;
+      this.leaf = createLeaf.call(this.app.workspace, "window");
+      if (!this.leaf) return;
+    }
+
+    await this.leaf.openFile(file);
+    this.currentPath = path;
+
+    const view = this.leaf.view as unknown as { contentEl?: HTMLElement } | null;
+    const contentEl = view?.contentEl;
+    if (!contentEl) return;
+
+    if (!this.reparentedEl || this.reparentedEl !== contentEl) {
+      // First mount, or the MarkdownView swapped out contentEl.
+      this.originalParent = contentEl.parentElement;
+      host.empty();
+      host.appendChild(contentEl);
+      this.reparentedEl = contentEl;
+      this.host = host;
+      host.addClass("wt-embedded-detail-active");
+    }
+  }
+
+  /**
+   * Update tracking for a renamed file so a subsequent `show()` on the new
+   * path does not flash-close the view when the same file was in-place.
+   */
+  rekeyPath(oldPath: string, newPath: string): void {
+    if (this.currentPath === oldPath) {
+      this.currentPath = newPath;
+    }
+  }
+
+  /**
+   * Tear down: restore the content element to its original parent (so
+   * Obsidian can safely close the hidden leaf) and detach the leaf.
+   */
+  detach(): void {
+    if (this.reparentedEl && this.originalParent) {
+      try {
+        this.originalParent.appendChild(this.reparentedEl);
+      } catch {
+        // If the original parent is gone (e.g. the hidden leaf was already
+        // collected), let the element be garbage collected - the leaf detach
+        // below will clean up the rest.
+      }
+    }
+    if (this.host) {
+      this.host.removeClass("wt-embedded-detail-active");
+      this.host.empty();
+    }
+    if (this.leaf) {
+      try {
+        this.leaf.detach();
+      } catch (err) {
+        console.warn("[work-terminal] EmbeddedDetailView: leaf detach failed", err);
+      }
+    }
+    this.leaf = null;
+    this.reparentedEl = null;
+    this.originalParent = null;
+    this.host = null;
+    this.currentPath = null;
+  }
+}

--- a/src/adapters/task-agent/EmbeddedDetailView.ts
+++ b/src/adapters/task-agent/EmbeddedDetailView.ts
@@ -25,7 +25,6 @@ export class EmbeddedDetailView {
   private reparentedEl: HTMLElement | null = null;
   private host: HTMLElement | null = null;
   private originalParent: HTMLElement | null = null;
-  private currentPath: string | null = null;
 
   constructor(private app: App) {}
 
@@ -58,7 +57,6 @@ export class EmbeddedDetailView {
     }
 
     await this.leaf.openFile(file);
-    this.currentPath = path;
 
     const view = this.leaf.view as unknown as { contentEl?: HTMLElement } | null;
     const contentEl = view?.contentEl;
@@ -72,16 +70,6 @@ export class EmbeddedDetailView {
       this.reparentedEl = contentEl;
       this.host = host;
       host.addClass("wt-embedded-detail-active");
-    }
-  }
-
-  /**
-   * Update tracking for a renamed file so a subsequent `show()` on the new
-   * path does not flash-close the view when the same file was in-place.
-   */
-  rekeyPath(oldPath: string, newPath: string): void {
-    if (this.currentPath === oldPath) {
-      this.currentPath = newPath;
     }
   }
 
@@ -114,6 +102,5 @@ export class EmbeddedDetailView {
     this.reparentedEl = null;
     this.originalParent = null;
     this.host = null;
-    this.currentPath = null;
   }
 }

--- a/src/adapters/task-agent/embeddedAutoClose.test.ts
+++ b/src/adapters/task-agent/embeddedAutoClose.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+/**
+ * Adapter-level tests for the embedded detail auto-close behaviour.
+ * See issue #479 Copilot review comment 3.
+ */
+import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
+
+const embeddedShowMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const embeddedDetachMock = vi.hoisted(() => vi.fn());
+const embeddedRekeyMock = vi.hoisted(() => vi.fn());
+let embeddedInstanceCount = 0;
+
+vi.mock("./EmbeddedDetailView", () => ({
+  EmbeddedDetailView: class {
+    constructor() {
+      embeddedInstanceCount += 1;
+    }
+    show = embeddedShowMock;
+    detach = embeddedDetachMock;
+    rekeyPath = embeddedRekeyMock;
+  },
+}));
+
+// TaskDetailView isn't exercised by these tests but is imported from index.
+// Provide a minimal stub so `new TaskDetailView(app)` doesn't touch Obsidian.
+vi.mock("./TaskDetailView", () => ({
+  TaskDetailView: class {
+    show = vi.fn().mockResolvedValue(undefined);
+    detach = vi.fn();
+    rekeyPath = vi.fn();
+  },
+}));
+
+// Stub SetIconModal - it extends Modal and we don't want Obsidian's base classes.
+vi.mock("./SetIconModal", () => ({
+  SetIconModal: class {
+    open() {}
+  },
+}));
+
+vi.mock("./BackgroundEnrich", () => ({
+  handleItemCreated: vi.fn(),
+  handleSplitTaskCreated: vi.fn(),
+  prepareRetryEnrichment: vi.fn(),
+}));
+
+vi.mock("obsidian", () => ({
+  App: class {},
+}));
+
+import { TaskAgentAdapter } from "./index";
+
+beforeAll(() => {
+  const prototype = HTMLElement.prototype as typeof HTMLElement.prototype & {
+    addClass(cls: string): HTMLElement;
+    removeClass(cls: string): HTMLElement;
+    empty(): HTMLElement;
+  };
+  prototype.addClass ??= function (cls: string) {
+    this.classList.add(cls);
+    return this;
+  };
+  prototype.removeClass ??= function (cls: string) {
+    this.classList.remove(cls);
+    return this;
+  };
+  prototype.empty ??= function () {
+    while (this.firstChild) this.removeChild(this.firstChild);
+    return this;
+  };
+});
+
+function makeItem(id: string, path = `Tasks/${id}.md`) {
+  return {
+    id,
+    path,
+    title: id,
+    state: "todo",
+    metadata: {},
+  } as any;
+}
+
+describe("TaskAgentAdapter embedded auto-close (issue #479)", () => {
+  let adapter: TaskAgentAdapter;
+  let host: HTMLElement;
+  const app = {} as any;
+  const ownerLeaf = {} as any;
+
+  beforeEach(() => {
+    embeddedShowMock.mockClear();
+    embeddedDetachMock.mockClear();
+    embeddedRekeyMock.mockClear();
+    embeddedInstanceCount = 0;
+
+    adapter = new TaskAgentAdapter();
+    host = document.createElement("div");
+  });
+
+  it("detaches the embedded view when selection changes with autoClose enabled", () => {
+    (adapter as any)._settings = {
+      "core.detailViewPlacement": "embedded",
+      "core.detailViewAutoClose": true,
+    };
+
+    adapter.createDetailView(makeItem("task-1"), app, ownerLeaf, host);
+    expect(embeddedShowMock).toHaveBeenCalledTimes(1);
+    expect(embeddedDetachMock).not.toHaveBeenCalled();
+    expect(embeddedInstanceCount).toBe(1);
+
+    // Select a different item - should detach and mount fresh
+    adapter.createDetailView(makeItem("task-2"), app, ownerLeaf, host);
+    expect(embeddedDetachMock).toHaveBeenCalledTimes(1);
+    expect(embeddedShowMock).toHaveBeenCalledTimes(2);
+    expect(embeddedInstanceCount).toBe(2);
+  });
+
+  it("reuses the embedded view when re-selecting the same item even with autoClose enabled", () => {
+    (adapter as any)._settings = {
+      "core.detailViewPlacement": "embedded",
+      "core.detailViewAutoClose": true,
+    };
+
+    adapter.createDetailView(makeItem("task-1"), app, ownerLeaf, host);
+    adapter.createDetailView(makeItem("task-1"), app, ownerLeaf, host);
+
+    expect(embeddedDetachMock).not.toHaveBeenCalled();
+    expect(embeddedShowMock).toHaveBeenCalledTimes(2);
+    expect(embeddedInstanceCount).toBe(1);
+  });
+
+  it("reuses the embedded view when autoClose is disabled and selection changes", () => {
+    (adapter as any)._settings = {
+      "core.detailViewPlacement": "embedded",
+      "core.detailViewAutoClose": false,
+    };
+
+    adapter.createDetailView(makeItem("task-1"), app, ownerLeaf, host);
+    adapter.createDetailView(makeItem("task-2"), app, ownerLeaf, host);
+
+    expect(embeddedDetachMock).not.toHaveBeenCalled();
+    expect(embeddedShowMock).toHaveBeenCalledTimes(2);
+    expect(embeddedInstanceCount).toBe(1);
+  });
+});

--- a/src/adapters/task-agent/embeddedAutoClose.test.ts
+++ b/src/adapters/task-agent/embeddedAutoClose.test.ts
@@ -7,7 +7,6 @@ import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
 
 const embeddedShowMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const embeddedDetachMock = vi.hoisted(() => vi.fn());
-const embeddedRekeyMock = vi.hoisted(() => vi.fn());
 let embeddedInstanceCount = 0;
 
 vi.mock("./EmbeddedDetailView", () => ({
@@ -17,7 +16,6 @@ vi.mock("./EmbeddedDetailView", () => ({
     }
     show = embeddedShowMock;
     detach = embeddedDetachMock;
-    rekeyPath = embeddedRekeyMock;
   },
 }));
 
@@ -89,7 +87,6 @@ describe("TaskAgentAdapter embedded auto-close (issue #479)", () => {
   beforeEach(() => {
     embeddedShowMock.mockClear();
     embeddedDetachMock.mockClear();
-    embeddedRekeyMock.mockClear();
     embeddedInstanceCount = 0;
 
     adapter = new TaskAgentAdapter();

--- a/src/adapters/task-agent/index.ts
+++ b/src/adapters/task-agent/index.ts
@@ -202,7 +202,9 @@ export class TaskAgentAdapter extends BaseAdapter {
 
   rekeyDetailPath(oldPath: string, newPath: string): void {
     this.detailView?.rekeyPath(oldPath, newPath);
-    this.embeddedDetailView?.rekeyPath(oldPath, newPath);
+    // EmbeddedDetailView does not need to track paths: the hidden leaf
+    // follows the TFile reference through renames automatically, and
+    // `show()` reads the current path from the caller each time.
   }
 
   detachDetailView(): void {

--- a/src/adapters/task-agent/index.ts
+++ b/src/adapters/task-agent/index.ts
@@ -16,6 +16,7 @@ import { TaskMover } from "./TaskMover";
 import { TaskCard } from "./TaskCard";
 import { TaskPromptBuilder } from "./TaskPromptBuilder";
 import { TaskDetailView } from "./TaskDetailView";
+import { EmbeddedDetailView } from "./EmbeddedDetailView";
 import { resolveDetailViewOptions } from "../../core/detailViewPlacement";
 import {
   handleItemCreated,
@@ -36,6 +37,7 @@ export class TaskAgentAdapter extends BaseAdapter {
   private _app: App | null = null;
   private _settings: Record<string, unknown> = {};
   private detailView: TaskDetailView | null = null;
+  private embeddedDetailView: EmbeddedDetailView | null = null;
   private _cardRenderer: TaskCard | null = null;
   private _stateResolver: StateResolver | null = null;
   private _resolverStrategy: StateStrategy | null = null;
@@ -128,7 +130,12 @@ export class TaskAgentAdapter extends BaseAdapter {
     return new TaskPromptBuilder();
   }
 
-  createDetailView(item: WorkItem, app: App, ownerLeaf: WorkspaceLeaf): void {
+  createDetailView(
+    item: WorkItem,
+    app: App,
+    ownerLeaf: WorkspaceLeaf,
+    embeddedHost?: HTMLElement | null,
+  ): void {
     this._app = app;
     const options = resolveDetailViewOptions(this._settings);
     // "Disabled" placement means: do not instantiate a detail view at all.
@@ -137,6 +144,37 @@ export class TaskAgentAdapter extends BaseAdapter {
     if (options.placement === "disabled") {
       return;
     }
+
+    // Embedded placement (experimental): tear down any leaf-based detail view
+    // and mount into the framework-provided host instead.
+    if (options.placement === "embedded") {
+      if (this.detailView) {
+        this.detailView.detach();
+        this.detailView = null;
+      }
+      if (!embeddedHost) {
+        // No host available (e.g. adapter invoked outside of MainView).
+        // Fall back to a no-op rather than crashing - the framework should
+        // always supply a host when placement is embedded.
+        console.warn(
+          "[work-terminal] Embedded detail placement selected but no host element was supplied",
+        );
+        return;
+      }
+      if (!this.embeddedDetailView) {
+        this.embeddedDetailView = new EmbeddedDetailView(app);
+      }
+      void this.embeddedDetailView.show(item.path, embeddedHost);
+      return;
+    }
+
+    // Any non-embedded placement must drop any live embedded view so its
+    // hidden leaf is released before we open a leaf-based detail view.
+    if (this.embeddedDetailView) {
+      this.embeddedDetailView.detach();
+      this.embeddedDetailView = null;
+    }
+
     if (!this.detailView) {
       this.detailView = new TaskDetailView(app);
     }
@@ -145,12 +183,17 @@ export class TaskAgentAdapter extends BaseAdapter {
 
   rekeyDetailPath(oldPath: string, newPath: string): void {
     this.detailView?.rekeyPath(oldPath, newPath);
+    this.embeddedDetailView?.rekeyPath(oldPath, newPath);
   }
 
   detachDetailView(): void {
     if (this.detailView) {
       this.detailView.detach();
       this.detailView = null;
+    }
+    if (this.embeddedDetailView) {
+      this.embeddedDetailView.detach();
+      this.embeddedDetailView = null;
     }
   }
 

--- a/src/adapters/task-agent/index.ts
+++ b/src/adapters/task-agent/index.ts
@@ -38,6 +38,10 @@ export class TaskAgentAdapter extends BaseAdapter {
   private _settings: Record<string, unknown> = {};
   private detailView: TaskDetailView | null = null;
   private embeddedDetailView: EmbeddedDetailView | null = null;
+  // Identifier of the last item we mounted into the embedded host. Used by
+  // the auto-close behaviour to detach the hidden leaf when the selection
+  // moves to a different item, mirroring `TaskDetailView.lastItemId`.
+  private embeddedLastItemId: string | null = null;
   private _cardRenderer: TaskCard | null = null;
   private _stateResolver: StateResolver | null = null;
   private _resolverStrategy: StateStrategy | null = null;
@@ -161,6 +165,20 @@ export class TaskAgentAdapter extends BaseAdapter {
         );
         return;
       }
+      // Auto-close: when selection moves to a different item, detach the
+      // hidden leaf so show() remounts fresh. Mirrors TaskDetailView's
+      // lastItemId/detachLeaf pattern - re-selecting the same item keeps
+      // the existing view.
+      if (
+        options.autoClose &&
+        this.embeddedLastItemId &&
+        this.embeddedLastItemId !== item.id &&
+        this.embeddedDetailView
+      ) {
+        this.embeddedDetailView.detach();
+        this.embeddedDetailView = null;
+      }
+      this.embeddedLastItemId = item.id;
       if (!this.embeddedDetailView) {
         this.embeddedDetailView = new EmbeddedDetailView(app);
       }
@@ -173,6 +191,7 @@ export class TaskAgentAdapter extends BaseAdapter {
     if (this.embeddedDetailView) {
       this.embeddedDetailView.detach();
       this.embeddedDetailView = null;
+      this.embeddedLastItemId = null;
     }
 
     if (!this.detailView) {
@@ -195,6 +214,7 @@ export class TaskAgentAdapter extends BaseAdapter {
       this.embeddedDetailView.detach();
       this.embeddedDetailView = null;
     }
+    this.embeddedLastItemId = null;
   }
 
   async onItemCreated(

--- a/src/core/detailViewPlacement.test.ts
+++ b/src/core/detailViewPlacement.test.ts
@@ -21,7 +21,14 @@ describe("resolveDetailViewOptions", () => {
   });
 
   it("accepts each valid placement value", () => {
-    for (const placement of ["split", "tab", "navigate", "preview", "disabled"] as const) {
+    for (const placement of [
+      "split",
+      "tab",
+      "navigate",
+      "preview",
+      "embedded",
+      "disabled",
+    ] as const) {
       const options = resolveDetailViewOptions({
         "core.detailViewPlacement": placement,
       });

--- a/src/core/detailViewPlacement.ts
+++ b/src/core/detailViewPlacement.ts
@@ -14,10 +14,21 @@
  * - `preview` - render the task file's markdown read-only inside the Work
  *   Terminal panel itself, as an overlay above the terminal area. Provides
  *   an "Open in editor" button that falls back to the `navigate` behaviour.
+ * - `embedded` - EXPERIMENTAL. Render the detail view as a MarkdownView
+ *   embedded inside the terminal panel (alongside shell/agent tabs), by
+ *   reparenting a hidden Obsidian leaf's content element into a host slot
+ *   managed by the terminal panel. Relies on internal Obsidian APIs and may
+ *   break across Obsidian versions.
  * - `disabled` - do nothing on selection. Users open files manually via the
  *   file explorer, quick switcher, or context menu.
  */
-export type DetailViewPlacement = "split" | "tab" | "navigate" | "preview" | "disabled";
+export type DetailViewPlacement =
+  | "split"
+  | "tab"
+  | "navigate"
+  | "preview"
+  | "embedded"
+  | "disabled";
 
 /** Orientation for the `split` placement. Matches Obsidian's createLeafBySplit arg. */
 export type DetailViewSplitDirection = "vertical" | "horizontal";
@@ -45,6 +56,7 @@ const VALID_PLACEMENTS: ReadonlySet<string> = new Set([
   "tab",
   "navigate",
   "preview",
+  "embedded",
   "disabled",
 ]);
 

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -281,8 +281,18 @@ export interface AdapterBundle {
    * Open a detail view for the selected item. The adapter manages its own
    * Obsidian workspace leaf via `app.workspace.createLeafBySplit(ownerLeaf)`.
    * If undefined, the plugin renders a 2-column layout without a detail panel.
+   *
+   * `embeddedHost`, when supplied, is a DOM element owned by the framework
+   * into which the adapter can mount an embedded detail view (used by the
+   * experimental "embedded" placement). Adapters are free to ignore it when
+   * the current placement does not embed.
    */
-  createDetailView?(item: WorkItem, app: App, ownerLeaf: WorkspaceLeaf): void;
+  createDetailView?(
+    item: WorkItem,
+    app: App,
+    ownerLeaf: WorkspaceLeaf,
+    embeddedHost?: HTMLElement | null,
+  ): void;
   /** Detach the detail view leaf on close/reload. */
   detachDetailView?(): void;
   /** Update detail view tracking when an item file is renamed. */
@@ -367,7 +377,12 @@ export abstract class BaseAdapter implements AdapterBundle {
     // no-op by default
   }
 
-  createDetailView?(_item: WorkItem, _app: App, _ownerLeaf: WorkspaceLeaf): void {
+  createDetailView?(
+    _item: WorkItem,
+    _app: App,
+    _ownerLeaf: WorkspaceLeaf,
+    _embeddedHost?: HTMLElement | null,
+  ): void {
     return undefined;
   }
 

--- a/src/framework/MainView.ts
+++ b/src/framework/MainView.ts
@@ -389,7 +389,23 @@ export class MainView extends ItemView {
         this.terminalPanel?.setActiveItem(item?.id ?? null);
         this.terminalPanel?.setTitle(item);
         if (item && typeof this.adapter.createDetailView === "function") {
-          this.adapter.createDetailView(item, this.app, this.leaf);
+          // Supply an embedded host only when the user has opted into the
+          // experimental "embedded" placement. The adapter falls back to
+          // leaf-based placements otherwise.
+          const placement = this.settings?.["core.detailViewPlacement"];
+          const embeddedHost =
+            placement === "embedded" ? (this.terminalPanel?.getEmbeddedDetailHost() ?? null) : null;
+          this.adapter.createDetailView(item, this.app, this.leaf, embeddedHost);
+          if (placement === "embedded" && embeddedHost) {
+            // Auto-focus the Detail pseudo-tab whenever a new item is
+            // selected under embedded placement. Users can still click a
+            // terminal tab to flip back to the shell view.
+            this.terminalPanel?.activateEmbeddedDetail();
+          } else {
+            // Placement changed away from embedded: make sure we are not
+            // still showing a stale embedded host.
+            this.terminalPanel?.deactivateEmbeddedDetail();
+          }
         }
         if (item) {
           void this.ensureSelectedItemHasDurableId(item);

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -599,6 +599,7 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
           "Tab opens a new tab in the active tab group. " +
           "Navigate replaces the contents of the active editor. " +
           "Preview shows a read-only markdown preview of the file inside the Work Terminal panel, with an Open in editor button. " +
+          "Embedded (experimental) renders the detail view inside the terminal panel as a pseudo-tab, alongside shell and agent tabs. " +
           "Disabled does nothing - open files manually via the file explorer or quick switcher.",
       )
       .addDropdown((dropdown) => {
@@ -606,6 +607,7 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
         dropdown.addOption("tab", "Tab in active group");
         dropdown.addOption("navigate", "Navigate active leaf");
         dropdown.addOption("preview", "Preview in Work Terminal panel");
+        dropdown.addOption("embedded", "Embedded in terminal panel (experimental)");
         dropdown.addOption("disabled", "Disabled");
         dropdown.setValue(placement).onChange(async (newValue) => {
           await this.saveSettings((s) => {
@@ -615,6 +617,18 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
           this.display();
         });
       });
+
+    // Embedded placement is experimental - surface a warning so users know
+    // what they are opting into. Only shown when this placement is selected.
+    if (placement === "embedded") {
+      const warning = containerEl.createDiv({ cls: "wt-setting-experimental-note" });
+      warning.createSpan({ text: "Experimental: ", cls: "wt-setting-experimental-label" });
+      warning.appendText(
+        "the embedded placement reparents an Obsidian MarkdownView into a host element " +
+          "inside the terminal panel. It relies on internal Obsidian APIs and may break " +
+          "across Obsidian versions. If you hit issues, switch back to Split or Tab placement.",
+      );
+    }
 
     // Auto-close applies to any placement except "disabled" (where nothing is
     // opened anyway). It's a general behaviour toggle, not split-specific.

--- a/src/framework/TerminalPanelView.test.ts
+++ b/src/framework/TerminalPanelView.test.ts
@@ -379,7 +379,7 @@ function createView(
   );
   createdViews.push(view);
 
-  return { panelEl, plugin, view };
+  return { panelEl, terminalWrapperEl, plugin, view };
 }
 
 async function flushAsync(ticks = 3) {
@@ -1412,6 +1412,187 @@ describe("TerminalPanelView", () => {
     expect(openFile).toHaveBeenCalledWith(fakeFile);
     expect(getLeaf).not.toHaveBeenCalled();
     expect(workTerminalLeaf.openFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("embedded detail placement", () => {
+  let dom: JSDOM;
+
+  beforeEach(() => {
+    dom = new JSDOM("<!doctype html><html><body></body></html>");
+    vi.stubGlobal("window", dom.window);
+    vi.stubGlobal("document", dom.window.document);
+    vi.stubGlobal("HTMLElement", dom.window.HTMLElement);
+    vi.stubGlobal("Element", dom.window.Element);
+    vi.stubGlobal("Node", dom.window.Node);
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    installDomHelpers({
+      window: dom.window,
+      document: dom.window.document,
+      HTMLElement: dom.window.HTMLElement,
+      Element: dom.window.Element,
+      Node: dom.window.Node,
+    });
+
+    mockState.activeSessions = new Map();
+    mockState.activeTabs = [];
+    mockState.activeItemId = null;
+    mockState.tabsByItem = new Map();
+    mockState.activeTabIndex = 0;
+    mockState.tabDiagnostics = [];
+    mockState.idleSinceByItem = new Map();
+    mockState.menuTitles = [];
+    mockState.menuActions = new Map();
+    mockState.notices = [];
+    mockState.clipboardWriteText.mockClear();
+    mockState.latestCreateTabArgs = null;
+    mockState.tabManagerCalls = [];
+    mockState.openExternal.mockClear();
+    mockState.latestTabManager = null;
+    mockState.latestTabManagerCtorArgs = null;
+  });
+
+  afterEach(() => {
+    while (createdViews.length > 0) {
+      createdViews.pop()?.disposeAll();
+    }
+    vi.unstubAllGlobals();
+    dom.window.close();
+  });
+
+  function setupSingleTab() {
+    mockState.tabsByItem = new Map([
+      [
+        "task-1",
+        [
+          {
+            label: "Shell",
+            sessionType: "shell",
+            isResumableAgent: false,
+            agentState: "inactive",
+          },
+        ],
+      ],
+    ]);
+  }
+
+  it("renders the Detail pseudo-tab only when placement is embedded", async () => {
+    setupSingleTab();
+    const { panelEl, view } = createView({ "core.detailViewPlacement": "split" });
+    await flushAsync();
+    view.setActiveItem("task-1");
+
+    expect(panelEl.querySelector(".wt-tab-detail")).toBeNull();
+
+    // Switch to embedded placement - the pseudo-tab should appear
+    window.dispatchEvent(
+      new dom.window.CustomEvent("work-terminal:settings-changed", {
+        detail: {
+          "core.defaultTerminalCwd": "~",
+          "core.detailViewPlacement": "embedded",
+        },
+      }),
+    );
+
+    expect(panelEl.querySelector(".wt-tab-detail")).not.toBeNull();
+  });
+
+  it("does not render the Detail pseudo-tab when no item is active", async () => {
+    const { panelEl } = createView({ "core.detailViewPlacement": "embedded" });
+    await flushAsync();
+
+    // No active item set, so no Detail tab either
+    expect(panelEl.querySelector(".wt-tab-detail")).toBeNull();
+  });
+
+  it("hides the terminal wrapper when the Detail pseudo-tab is clicked", async () => {
+    setupSingleTab();
+    const { panelEl, terminalWrapperEl, view } = createView({
+      "core.detailViewPlacement": "embedded",
+    });
+    await flushAsync();
+    view.setActiveItem("task-1");
+
+    // Create the embedded detail host (MainView would do this via
+    // getEmbeddedDetailHost before activating); here we invoke it directly.
+    view.getEmbeddedDetailHost();
+
+    const detailTab = panelEl.querySelector(".wt-tab-detail") as HTMLElement;
+    expect(detailTab).not.toBeNull();
+
+    detailTab.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
+
+    expect(view.isEmbeddedDetailActive()).toBe(true);
+    expect(terminalWrapperEl.style.display).toBe("none");
+    // Re-query: activateEmbeddedDetail re-renders the tab bar, replacing the
+    // original detailTab element with a fresh one that carries the active class.
+    const activeDetailTab = panelEl.querySelector(".wt-tab-detail") as HTMLElement;
+    expect(activeDetailTab.classList.contains("wt-tab-active")).toBe(true);
+  });
+
+  it("restores terminal wrapper visibility when a terminal tab is clicked", async () => {
+    setupSingleTab();
+    const { panelEl, terminalWrapperEl, view } = createView({
+      "core.detailViewPlacement": "embedded",
+    });
+    await flushAsync();
+    view.setActiveItem("task-1");
+
+    view.getEmbeddedDetailHost();
+
+    // Activate embedded detail first
+    const detailTab = panelEl.querySelector(".wt-tab-detail") as HTMLElement;
+    detailTab.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
+    expect(terminalWrapperEl.style.display).toBe("none");
+
+    // Now click the first terminal tab - should flip back
+    vi.useFakeTimers();
+    const terminalTab = panelEl.querySelector(".wt-tab:not(.wt-tab-detail)") as HTMLElement;
+    terminalTab.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
+    vi.advanceTimersByTime(250);
+    vi.useRealTimers();
+
+    expect(view.isEmbeddedDetailActive()).toBe(false);
+    expect(terminalWrapperEl.style.display).toBe("");
+  });
+
+  it("restores terminal wrapper when placement changes away from embedded", async () => {
+    setupSingleTab();
+    const { panelEl, terminalWrapperEl, view } = createView({
+      "core.detailViewPlacement": "embedded",
+    });
+    await flushAsync();
+    view.setActiveItem("task-1");
+
+    view.getEmbeddedDetailHost();
+
+    // Activate embedded detail
+    const detailTab = panelEl.querySelector(".wt-tab-detail") as HTMLElement;
+    detailTab.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
+    expect(terminalWrapperEl.style.display).toBe("none");
+    expect(view.isEmbeddedDetailActive()).toBe(true);
+
+    // Dispatch settings change flipping placement away from embedded
+    window.dispatchEvent(
+      new dom.window.CustomEvent("work-terminal:settings-changed", {
+        detail: {
+          "core.defaultTerminalCwd": "~",
+          "core.detailViewPlacement": "split",
+        },
+      }),
+    );
+
+    expect(view.isEmbeddedDetailActive()).toBe(false);
+    expect(terminalWrapperEl.style.display).toBe("");
+    // Detail pseudo-tab should no longer be in the tab bar
+    expect(panelEl.querySelector(".wt-tab-detail")).toBeNull();
   });
 });
 

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -116,6 +116,12 @@ export class TerminalPanelView {
   private titleEl: HTMLElement;
   private tabBarEl: HTMLElement;
   private terminalWrapperEl: HTMLElement;
+  // Slot for the experimental "embedded" detail view placement. Lazily
+  // created on first use so non-embedded users pay zero DOM cost.
+  private embeddedDetailHostEl: HTMLElement | null = null;
+  // Tracks whether the pseudo-"Detail" tab is currently selected. When true
+  // the terminal wrapper is hidden and the embedded detail host is visible.
+  private embeddedDetailActive = false;
 
   // Active items reference (for tab context menu "Move to Item")
   private allItems: WorkItem[] = [];
@@ -200,6 +206,64 @@ export class TerminalPanelView {
   }
 
   // ---------------------------------------------------------------------------
+  // Embedded detail host (experimental - see issue #479)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Return true when the current settings select the experimental
+   * "embedded" detail placement. Drives conditional tab-bar rendering.
+   */
+  private isEmbeddedPlacementActive(): boolean {
+    return this.settings["core.detailViewPlacement"] === "embedded";
+  }
+
+  /**
+   * Lazily create and return the host element for the embedded detail view.
+   * Adapters mount a reparented MarkdownView into this slot. The host sits
+   * next to the terminal wrapper and is hidden until activated.
+   */
+  getEmbeddedDetailHost(): HTMLElement {
+    if (!this.embeddedDetailHostEl) {
+      this.embeddedDetailHostEl = this.panelEl.createDiv({ cls: "wt-embedded-detail-host" });
+      // Start hidden - activateEmbeddedDetail() flips it on.
+      this.embeddedDetailHostEl.style.display = "none";
+      // Insert before the terminal wrapper so embedded + terminal occupy the
+      // same DOM slot; show one at a time based on activation state.
+      this.panelEl.insertBefore(this.embeddedDetailHostEl, this.terminalWrapperEl);
+    }
+    return this.embeddedDetailHostEl;
+  }
+
+  /**
+   * Show the embedded detail host and hide the terminal wrapper. Safe to call
+   * when no host exists yet (it becomes a no-op).
+   */
+  activateEmbeddedDetail(): void {
+    if (!this.embeddedDetailHostEl) return;
+    this.embeddedDetailActive = true;
+    this.embeddedDetailHostEl.style.display = "";
+    this.terminalWrapperEl.style.display = "none";
+    this.renderTabBar();
+  }
+
+  /**
+   * Hide the embedded detail host and restore the terminal wrapper. Used when
+   * the user switches back to a terminal tab or when placement changes.
+   */
+  deactivateEmbeddedDetail(): void {
+    this.embeddedDetailActive = false;
+    if (this.embeddedDetailHostEl) {
+      this.embeddedDetailHostEl.style.display = "none";
+    }
+    this.terminalWrapperEl.style.display = "";
+  }
+
+  /** True when the pseudo "Detail" tab is currently showing. */
+  isEmbeddedDetailActive(): boolean {
+    return this.embeddedDetailActive;
+  }
+
+  // ---------------------------------------------------------------------------
   // Tab bar rendering
   // ---------------------------------------------------------------------------
 
@@ -213,6 +277,20 @@ export class TerminalPanelView {
     });
 
     const activeItemId = this.tabManager.getActiveItemId();
+
+    // Render the experimental "Detail" pseudo-tab when the embedded placement
+    // is selected and an item is active. This tab toggles visibility of the
+    // embedded detail host vs the terminal wrapper.
+    if (activeItemId && this.isEmbeddedPlacementActive()) {
+      const detailTabEl = tabsContainer.createDiv({ cls: "wt-tab wt-tab-detail" });
+      if (this.embeddedDetailActive) detailTabEl.addClass("wt-tab-active");
+      detailTabEl.setAttribute("data-wt-detail-tab", "true");
+      detailTabEl.createSpan({ cls: "wt-tab-label", text: "Detail" });
+      detailTabEl.addEventListener("click", () => {
+        this.activateEmbeddedDetail();
+      });
+    }
+
     if (activeItemId) {
       const tabs = this.tabManager.getTabs(activeItemId);
       const activeIdx = this.tabManager.getActiveTabIndex();
@@ -220,7 +298,9 @@ export class TerminalPanelView {
       for (let i = 0; i < tabs.length; i++) {
         const tab = tabs[i];
         const tabEl = tabsContainer.createDiv({ cls: "wt-tab" });
-        if (i === activeIdx) tabEl.addClass("wt-tab-active");
+        // Terminal tabs are "active" only when the embedded detail tab is not
+        // currently showing. Otherwise the highlight moves to the Detail tab.
+        if (i === activeIdx && !this.embeddedDetailActive) tabEl.addClass("wt-tab-active");
         if (tab.isAgentTab) {
           const state = tab.agentState;
           if (state !== "inactive") tabEl.addClass(`wt-tab-agent-${state}`);
@@ -241,7 +321,10 @@ export class TerminalPanelView {
         // Click to switch (delayed to allow double-click cancellation)
         tabEl.addEventListener("click", (event) => {
           if (this.isRenameActive()) return;
-          if (i === activeIdx) return;
+          // If we're showing the embedded detail view, any terminal-tab click
+          // should exit embedded mode even when the click lands on what was
+          // previously the active terminal tab.
+          if (i === activeIdx && !this.embeddedDetailActive) return;
           if ((event as MouseEvent).detail > 1) return;
           if (this.tabClickTimer !== null) {
             clearTimeout(this.tabClickTimer);
@@ -249,6 +332,7 @@ export class TerminalPanelView {
           }
           this.tabClickTimer = setTimeout(() => {
             this.tabClickTimer = null;
+            this.deactivateEmbeddedDetail();
             this.tabManager.switchToTab(i);
             this.renderTabBar();
           }, 250);

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -142,7 +142,15 @@ export class TerminalPanelView {
   private tabBarResizeObserver: ResizeObserver | null = null;
   private readonly handleSettingsChanged = (event: Event) => {
     this.settings = { ...(event as CustomEvent<Record<string, any>>).detail };
-    this.renderTabBar();
+    // If the user was viewing the embedded detail and then switched the
+    // placement away from "embedded", restore terminal wrapper visibility so
+    // they're not left staring at a hidden wrapper with no way back.
+    // `deactivateEmbeddedDetail` re-renders the tab bar itself.
+    if (this.embeddedDetailActive && !this.isEmbeddedPlacementActive()) {
+      this.deactivateEmbeddedDetail();
+    } else {
+      this.renderTabBar();
+    }
     // Re-render title so the "open task file" button reflects the current
     // detail view placement setting (only visible when placement is not split).
     this.setTitle(this.lastTitleItem);
@@ -249,6 +257,8 @@ export class TerminalPanelView {
   /**
    * Hide the embedded detail host and restore the terminal wrapper. Used when
    * the user switches back to a terminal tab or when placement changes.
+   * Always re-renders the tab bar so the Detail pseudo-tab loses its
+   * highlight and terminal tab highlights refresh to reflect the active tab.
    */
   deactivateEmbeddedDetail(): void {
     this.embeddedDetailActive = false;
@@ -256,6 +266,7 @@ export class TerminalPanelView {
       this.embeddedDetailHostEl.style.display = "none";
     }
     this.terminalWrapperEl.style.display = "";
+    this.renderTabBar();
   }
 
   /** True when the pseudo "Detail" tab is currently showing. */

--- a/styles.css
+++ b/styles.css
@@ -1039,6 +1039,49 @@ button.wt-spawn-claude-ctx:hover svg {
   position: relative;
 }
 
+/* =============================================================================
+   Embedded detail host (experimental - issue #479)
+   ============================================================================= */
+
+/* Sits in the terminal panel area next to .wt-terminal-wrapper. Only one of
+   the two is shown at a time; visibility is toggled inline by the "Detail"
+   pseudo-tab in the tab bar. */
+.wt-embedded-detail-host {
+  flex: 1;
+  overflow: auto;
+  position: relative;
+  min-height: 0;
+}
+
+.wt-embedded-detail-host.wt-embedded-detail-active {
+  display: flex;
+  flex-direction: column;
+}
+
+/* The "Detail" pseudo-tab inherits .wt-tab styling; nudge it visually so users
+   can spot the experimental slot. */
+.wt-tab-detail .wt-tab-label {
+  font-style: italic;
+}
+
+/* Experimental-option note rendered beneath the placement dropdown when the
+   embedded mode is selected. */
+.wt-setting-experimental-note {
+  margin: 0 0 12px 0;
+  padding: 8px 12px;
+  border-left: 3px solid var(--color-orange, #d97706);
+  background: var(--background-secondary);
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.wt-setting-experimental-label {
+  font-weight: 600;
+  color: var(--color-orange, #d97706);
+}
+
 .wt-terminal-instance {
   width: 100% !important;
   height: 100%;


### PR DESCRIPTION
## Summary

Adds a new experimental `embedded` detail view placement option that renders the task detail MarkdownView inside a pseudo-tab in the terminal panel, alongside shell and agent tabs - no separate workspace leaf required.

Closes #479.

## How it works

- `EmbeddedDetailView` creates a hidden workspace leaf via `workspace.getLeaf("window")`, opens the task file into it, and reparents the MarkdownView's `contentEl` into a host element owned by `TerminalPanelView`.
- `TerminalPanelView.getEmbeddedDetailHost()` lazily creates a DOM slot next to the terminal wrapper; `activateEmbeddedDetail` / `deactivateEmbeddedDetail` toggle visibility.
- A "Detail" pseudo-tab is rendered in the tab bar only when placement is `embedded`. Selecting a task auto-focuses it; clicking any terminal tab flips back to the shell.
- `TaskAgentAdapter.createDetailView` receives an optional `embeddedHost` from `MainView` and delegates to either the existing `TaskDetailView` (for leaf placements) or the new `EmbeddedDetailView`.
- The placement is marked experimental in the settings UI with a warning note, and in the user guide with a dedicated callout - it relies on internal Obsidian APIs (reparenting `contentEl`) that may break between Obsidian versions.

## Files touched

- `src/core/detailViewPlacement.ts` - add `"embedded"` to the union and validator
- `src/adapters/task-agent/EmbeddedDetailView.ts` (new) - reparent hack, lifecycle
- `src/adapters/task-agent/EmbeddedDetailView.test.ts` (new) - 6 tests covering show/reuse/host-swap/detach/rekey
- `src/adapters/task-agent/index.ts` - route to EmbeddedDetailView when placement is embedded, teardown the other direction
- `src/core/interfaces.ts` - extend `createDetailView` signature with optional host
- `src/framework/TerminalPanelView.ts` - embedded host slot, pseudo-tab, toggle helpers
- `src/framework/MainView.ts` - supply host to adapter + auto-activate on selection
- `src/framework/SettingsTab.ts` - new dropdown option + experimental warning note
- `styles.css` - `.wt-embedded-detail-host`, `.wt-tab-detail`, `.wt-setting-experimental-note`
- `docs/user-guide.md` - placement list + experimental callout

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm exec vitest run` passes (1262 tests, 57 files)
- [ ] Manual: switch placement to Embedded, select a task, confirm Detail tab appears and renders the task
- [ ] Manual: click a terminal tab, confirm it flips back to shell view
- [ ] Manual: select a different task, confirm the embedded view updates
- [ ] Manual: switch placement back to Split, confirm embedded host is gone and split reopens
- [ ] Manual: rename a task file while embedded placement is active, confirm tracking rekeys correctly
- [ ] Manual: close Work Terminal leaf, confirm hidden leaf is cleaned up