### PR TITLE
Launch Profile dialog: manage profiles link opens Profile Manager directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ GitHub release notes should mirror these entries rather than pasting the raw aut
 
 ### Improvements
 - Added a `Preview in Work Terminal panel` detail-view placement that renders the task file's markdown read-only as an overlay inside the Work Terminal panel, with an **Open in editor** button and automatic re-render on vault modify. Uses public Obsidian APIs (MarkdownRenderer) only. (#480)
+- The **Manage profiles** link in the Launch Profile dialog now opens the Agent Profile Manager directly instead of scrolling to the settings tab, saving a click and avoiding unrelated General settings. Link text shortened from "Manage profiles in settings". (#485)
 
 ## [0.4.1] - 2026-04-20
 

--- a/src/framework/ProfileLaunchModal.test.ts
+++ b/src/framework/ProfileLaunchModal.test.ts
@@ -358,7 +358,7 @@ describe("ProfileLaunchModal manage profiles link", () => {
   it("shows manage profiles link when onManageProfiles callback is provided", () => {
     const modal = createModalWithCallback([makeProfile()], vi.fn());
     const el = (modal as any).contentEl as HTMLElement;
-    const link = el.querySelector(".wt-custom-spawn-settings-link");
+    const link = el.querySelector(".wt-custom-spawn-manage-profiles-link");
     expect(link).not.toBeNull();
     expect(link?.textContent).toBe("Manage profiles");
   });
@@ -366,7 +366,7 @@ describe("ProfileLaunchModal manage profiles link", () => {
   it("does not show manage profiles link when no onManageProfiles callback", () => {
     const modal = createModalWithCallback([makeProfile()]);
     const el = (modal as any).contentEl as HTMLElement;
-    const link = el.querySelector(".wt-custom-spawn-settings-link");
+    const link = el.querySelector(".wt-custom-spawn-manage-profiles-link");
     expect(link).toBeNull();
   });
 
@@ -375,7 +375,7 @@ describe("ProfileLaunchModal manage profiles link", () => {
     const modal = createModalWithCallback([makeProfile()], onManageProfiles);
     const closeSpy = vi.spyOn(modal, "close");
     const el = (modal as any).contentEl as HTMLElement;
-    const link = el.querySelector(".wt-custom-spawn-settings-link") as HTMLElement;
+    const link = el.querySelector(".wt-custom-spawn-manage-profiles-link") as HTMLElement;
 
     link.click();
 

--- a/src/framework/ProfileLaunchModal.test.ts
+++ b/src/framework/ProfileLaunchModal.test.ts
@@ -348,38 +348,38 @@ describe("ProfileLaunchModal placeholders", () => {
   });
 });
 
-describe("ProfileLaunchModal settings link", () => {
-  function createModalWithSettings(profiles: AgentProfile[], onOpenSettings?: () => void) {
-    const modal = new ProfileLaunchModal({} as any, profiles, "/vault", vi.fn(), onOpenSettings);
+describe("ProfileLaunchModal manage profiles link", () => {
+  function createModalWithCallback(profiles: AgentProfile[], onManageProfiles?: () => void) {
+    const modal = new ProfileLaunchModal({} as any, profiles, "/vault", vi.fn(), onManageProfiles);
     modal.open();
     return modal;
   }
 
-  it("shows settings link when onOpenSettings callback is provided", () => {
-    const modal = createModalWithSettings([makeProfile()], vi.fn());
+  it("shows manage profiles link when onManageProfiles callback is provided", () => {
+    const modal = createModalWithCallback([makeProfile()], vi.fn());
     const el = (modal as any).contentEl as HTMLElement;
     const link = el.querySelector(".wt-custom-spawn-settings-link");
     expect(link).not.toBeNull();
-    expect(link?.textContent).toBe("Manage profiles in settings");
+    expect(link?.textContent).toBe("Manage profiles");
   });
 
-  it("does not show settings link when no onOpenSettings callback", () => {
-    const modal = createModalWithSettings([makeProfile()]);
+  it("does not show manage profiles link when no onManageProfiles callback", () => {
+    const modal = createModalWithCallback([makeProfile()]);
     const el = (modal as any).contentEl as HTMLElement;
     const link = el.querySelector(".wt-custom-spawn-settings-link");
     expect(link).toBeNull();
   });
 
-  it("calls onOpenSettings and closes modal when link is clicked", () => {
-    const onOpenSettings = vi.fn();
-    const modal = createModalWithSettings([makeProfile()], onOpenSettings);
+  it("calls onManageProfiles and closes modal when link is clicked", () => {
+    const onManageProfiles = vi.fn();
+    const modal = createModalWithCallback([makeProfile()], onManageProfiles);
     const closeSpy = vi.spyOn(modal, "close");
     const el = (modal as any).contentEl as HTMLElement;
     const link = el.querySelector(".wt-custom-spawn-settings-link") as HTMLElement;
 
     link.click();
 
-    expect(onOpenSettings).toHaveBeenCalledOnce();
+    expect(onManageProfiles).toHaveBeenCalledOnce();
     expect(closeSpy).toHaveBeenCalledOnce();
   });
 });

--- a/src/framework/ProfileLaunchModal.ts
+++ b/src/framework/ProfileLaunchModal.ts
@@ -52,7 +52,7 @@ export class ProfileLaunchModal extends Modal {
       helpEl.appendChild(document.createTextNode(" "));
       const link = helpEl.createEl("a", {
         text: "Manage profiles",
-        cls: "wt-custom-spawn-settings-link",
+        cls: "wt-custom-spawn-manage-profiles-link",
         attr: { href: "#" },
       });
       link.addEventListener("click", (e) => {

--- a/src/framework/ProfileLaunchModal.ts
+++ b/src/framework/ProfileLaunchModal.ts
@@ -24,7 +24,7 @@ export class ProfileLaunchModal extends Modal {
     private profiles: AgentProfile[],
     private defaultCwd: string,
     private onSubmit: (overrides: ProfileLaunchOverrides) => void,
-    private onOpenSettings?: () => void,
+    private onManageProfiles?: () => void,
   ) {
     super(app);
     this.selectedProfile = profiles[0];
@@ -48,17 +48,17 @@ export class ProfileLaunchModal extends Modal {
     helpEl.appendChild(
       document.createTextNode("Pick a profile and optionally override settings for this launch."),
     );
-    if (this.onOpenSettings) {
+    if (this.onManageProfiles) {
       helpEl.appendChild(document.createTextNode(" "));
       const link = helpEl.createEl("a", {
-        text: "Manage profiles in settings",
+        text: "Manage profiles",
         cls: "wt-custom-spawn-settings-link",
         attr: { href: "#" },
       });
       link.addEventListener("click", (e) => {
         e.preventDefault();
         this.close();
-        this.onOpenSettings?.();
+        this.onManageProfiles?.();
       });
     }
 

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -1364,8 +1364,11 @@ export class TerminalPanelView {
           if (promptBuilder?.describePromptFormat) {
             adapterPromptDescription = promptBuilder.describePromptFormat();
           }
-        } catch {
-          // Ignore adapter prompt description errors - the modal works without it.
+        } catch (error) {
+          console.warn(
+            "[work-terminal] Failed to get adapter prompt format description; opening profile manager without description.",
+            error,
+          );
         }
         new AgentProfileManagerModal(
           this.plugin.app,

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -29,6 +29,7 @@ import { electronRequire, expandTilde } from "../core/utils";
 import type { AdapterBundle, WorkItem, WorkItemPromptBuilder } from "../core/interfaces";
 import { expandProfilePlaceholders } from "./AgentContextPrompt";
 import { ProfileLaunchModal, type ProfileLaunchOverrides } from "./ProfileLaunchModal";
+import { AgentProfileManagerModal } from "./AgentProfileManagerModal";
 import { SETTINGS_CHANGED_EVENT } from "./SettingsTab";
 import { getDefaultSessionLabel } from "./CustomSessionConfig";
 import type { AgentProfileManager } from "../core/agents/AgentProfileManager";
@@ -1356,8 +1357,21 @@ export class TerminalPanelView {
         this.launchAction("profile launch", () => this.spawnFromProfileWithOverrides(overrides));
       },
       () => {
-        (this.plugin.app as any).setting.open();
-        (this.plugin.app as any).setting.openTabById(this.plugin.manifest.id);
+        if (!this.profileManager) return;
+        let adapterPromptDescription: string | undefined;
+        try {
+          const promptBuilder = this.adapter.createPromptBuilder?.();
+          if (promptBuilder?.describePromptFormat) {
+            adapterPromptDescription = promptBuilder.describePromptFormat();
+          }
+        } catch {
+          // Ignore adapter prompt description errors - the modal works without it.
+        }
+        new AgentProfileManagerModal(
+          this.plugin.app,
+          this.profileManager,
+          adapterPromptDescription,
+        ).open();
       },
     ).open();
   }

--- a/styles.css
+++ b/styles.css
@@ -802,13 +802,13 @@ button.wt-spawn-claude-ctx:hover svg {
   margin-bottom: 16px;
 }
 
-.wt-custom-spawn-settings-link {
+.wt-custom-spawn-manage-profiles-link {
   color: var(--text-accent);
   cursor: pointer;
   text-decoration: none;
 }
 
-.wt-custom-spawn-settings-link:hover {
+.wt-custom-spawn-manage-profiles-link:hover {
   text-decoration: underline;
 }
 


### PR DESCRIPTION
## Summary

The Launch Profile dialog's "Manage profiles in settings" link opened the plugin settings tab scrolled to the top, forcing users to scroll to the bottom to find the "Open Profile Manager" button. This was a poor contextual affordance: the user's intent is to manage profiles, so take them straight there.

- Open the `AgentProfileManagerModal` directly from the link instead of routing through the settings tab.
- Shorten the link text from "Manage profiles in settings" to "Manage profiles" since it no longer goes to settings.
- Rename the `ProfileLaunchModal` constructor callback from `onOpenSettings` to `onManageProfiles` for clarity.
- Update the adjacent tests.

## Test plan

- [x] `pnpm run build` passes.
- [x] `pnpm exec vitest run` passes (1279 tests).
- [ ] Manually: open Launch Profile dialog, click "Manage profiles", verify Agent Profile Manager opens directly.

Closes #485