### PR TITLE
fix: embedded detail fills full height, no pop-out window, spawn switches tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ GitHub release notes should mirror these entries rather than pasting the raw aut
 
 ### Fixes
 - **Embedded detail tab** now fills the full panel width. The reparented MarkdownView `contentEl` was losing its ancestor flex context when moved out of its original workspace leaf, leaving the right side of the host unused and letting hidden terminal content bleed through visually. Direct children of the embedded detail host are now forced to `width: 100%` and `flex: 1 1 auto`. (#490)
+- **Embedded detail tab now fills full panel height.** `deactivatePreviewDetail()` was unconditionally restoring the terminal wrapper's `display` style immediately after `activateEmbeddedDetail()` hid it, causing both containers to share the space 50/50. Deactivation now guards against restoring the terminal wrapper when the other detail mode is active. (#493)
+- **Embedded detail no longer spawns a pop-out window.** `getLeaf("window")` was creating a visible Electron BrowserWindow that lingered after the content element was reparented. Replaced with a hidden off-screen workspace split that hosts the leaf without any visible window artifact. (#493)
+- **Spawning a session from the Detail tab now switches to the new tab.** Clicking a spawn button (Shell, Claude, etc.) while the Detail or Preview pseudo-tab was active left the detail view showing instead of switching to the newly created terminal tab. (#493)
 
 ## [0.5.0] - 2026-04-21
 

--- a/src/adapters/task-agent/EmbeddedDetailView.test.ts
+++ b/src/adapters/task-agent/EmbeddedDetailView.test.ts
@@ -148,6 +148,84 @@ describe("EmbeddedDetailView", () => {
     expect(host.children.length).toBe(0);
   });
 
+  it("attaches a hidden off-screen container to document.body on show() and removes it on detach()", async () => {
+    const contentEl = document.createElement("div");
+    const { app } = makeApp({ contentEl });
+    const view = new EmbeddedDetailView(app);
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+
+    const bodyChildrenBefore = document.body.children.length;
+
+    await view.show("a.md", host);
+
+    // After show(), a new hidden container should be attached directly to
+    // document.body (positioned off-screen so it never renders for the user).
+    expect(document.body.children.length).toBe(bodyChildrenBefore + 1);
+    const hiddenContainer = Array.from(document.body.children).find(
+      (el) => el !== host && (el as HTMLElement).style.position === "fixed",
+    ) as HTMLElement | undefined;
+    expect(hiddenContainer).toBeDefined();
+    expect(hiddenContainer!.style.left).toBe("-9999px");
+
+    view.detach();
+
+    // After detach(), the hidden container should be gone from document.body.
+    expect(document.body.contains(hiddenContainer!)).toBe(false);
+    expect(document.body.children.length).toBe(bodyChildrenBefore);
+  });
+
+  it("does not accumulate hidden containers across repeated show() calls", async () => {
+    const contentEl = document.createElement("div");
+    const { app } = makeApp({ contentEl });
+    const view = new EmbeddedDetailView(app);
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+
+    const countHiddenContainers = () =>
+      Array.from(document.body.children).filter(
+        (el) => el !== host && (el as HTMLElement).style.position === "fixed",
+      ).length;
+
+    await view.show("a.md", host);
+    expect(countHiddenContainers()).toBe(1);
+
+    await view.show("b.md", host);
+    await view.show("c.md", host);
+    await view.show("d.md", host);
+
+    // Repeated shows on the same host must reuse the existing leaf and
+    // hidden container - they must not accumulate.
+    expect(countHiddenContainers()).toBe(1);
+  });
+
+  it("cleans up the hidden container when createLeafInParent returns falsy", async () => {
+    const contentEl = document.createElement("div");
+    const { app, createLeafInParent } = makeApp({ contentEl });
+    // Simulate the Obsidian internal API returning no leaf.
+    createLeafInParent.mockReturnValueOnce(null);
+
+    const view = new EmbeddedDetailView(app);
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const bodyChildrenBefore = document.body.children.length;
+
+    await view.show("a.md", host);
+
+    expect(createLeafInParent).toHaveBeenCalled();
+    // No leak: hidden container and split should have been torn down.
+    expect(document.body.children.length).toBe(bodyChildrenBefore);
+    expect(host.children.length).toBe(0);
+
+    // A second show() should be able to retry cleanly (not throw, no
+    // accumulated container from the failed attempt).
+    await view.show("a.md", host);
+    const hiddenCount = Array.from(document.body.children).filter(
+      (el) => el !== host && (el as HTMLElement).style.position === "fixed",
+    ).length;
+    expect(hiddenCount).toBe(1);
+  });
+
   it("handles show() on a new path after rename without tracking internal path state", async () => {
     const contentEl = document.createElement("div");
     document.body.appendChild(document.createElement("div")).appendChild(contentEl);

--- a/src/adapters/task-agent/EmbeddedDetailView.test.ts
+++ b/src/adapters/task-agent/EmbeddedDetailView.test.ts
@@ -26,13 +26,13 @@ beforeAll(() => {
 
 /**
  * Fabricate a minimal Obsidian App/Workspace/Leaf shape for EmbeddedDetailView.
- * The class reaches into `workspace.getLeaf("window")`, the leaf's `openFile`,
- * `view.contentEl`, and `leaf.detach` only.
+ * The class uses `workspace.createLeafInParent` with a hidden off-screen
+ * WorkspaceSplit, then `leaf.openFile` / `leaf.view.contentEl` / `leaf.detach`.
  */
 function makeApp(opts: { fileExists?: boolean; contentEl?: HTMLElement | null } = {}): {
   app: App;
   leaf: { openFile: ReturnType<typeof vi.fn>; detach: ReturnType<typeof vi.fn>; view: any };
-  getLeaf: ReturnType<typeof vi.fn>;
+  createLeafInParent: ReturnType<typeof vi.fn>;
 } {
   const contentEl = opts.contentEl === undefined ? document.createElement("div") : opts.contentEl;
   if (contentEl) {
@@ -45,17 +45,22 @@ function makeApp(opts: { fileExists?: boolean; contentEl?: HTMLElement | null } 
     detach: vi.fn(),
     view: contentEl ? { contentEl } : null,
   };
-  const getLeaf = vi.fn().mockReturnValue(leaf);
+  const createLeafInParent = vi.fn().mockReturnValue(leaf);
+  // Minimal WorkspaceSplit constructor mock - creates a containerEl
+  function FakeSplit() {
+    (this as any).containerEl = document.createElement("div");
+  }
   const app = {
     vault: {
       getAbstractFileByPath: (p: string) =>
         opts.fileExists === false ? null : ({ path: p } as unknown),
     },
     workspace: {
-      getLeaf,
+      createLeafInParent,
+      rootSplit: { constructor: FakeSplit },
     },
   } as unknown as App;
-  return { app, leaf, getLeaf };
+  return { app, leaf, createLeafInParent };
 }
 
 describe("EmbeddedDetailView", () => {
@@ -64,11 +69,11 @@ describe("EmbeddedDetailView", () => {
   });
 
   it("does nothing when the file does not exist", async () => {
-    const { app, getLeaf } = makeApp({ fileExists: false });
+    const { app, createLeafInParent } = makeApp({ fileExists: false });
     const view = new EmbeddedDetailView(app);
     const host = document.createElement("div");
     await view.show("missing.md", host);
-    expect(getLeaf).not.toHaveBeenCalled();
+    expect(createLeafInParent).not.toHaveBeenCalled();
     expect(host.children.length).toBe(0);
   });
 
@@ -77,14 +82,14 @@ describe("EmbeddedDetailView", () => {
     contentEl.className = "markdown-source-view";
     document.body.appendChild(document.createElement("div")).appendChild(contentEl);
 
-    const { app, leaf, getLeaf } = makeApp({ contentEl });
+    const { app, leaf, createLeafInParent } = makeApp({ contentEl });
     const view = new EmbeddedDetailView(app);
     const host = document.createElement("div");
     document.body.appendChild(host);
 
     await view.show("task.md", host);
 
-    expect(getLeaf).toHaveBeenCalledWith("window");
+    expect(createLeafInParent).toHaveBeenCalled();
     expect(leaf.openFile).toHaveBeenCalled();
     expect(contentEl.parentElement).toBe(host);
     expect(host.classList.contains("wt-embedded-detail-active")).toBe(true);
@@ -93,14 +98,14 @@ describe("EmbeddedDetailView", () => {
   it("reuses the existing leaf on subsequent shows and does not re-create one", async () => {
     const contentEl = document.createElement("div");
     document.body.appendChild(document.createElement("div")).appendChild(contentEl);
-    const { app, leaf, getLeaf } = makeApp({ contentEl });
+    const { app, leaf, createLeafInParent } = makeApp({ contentEl });
     const view = new EmbeddedDetailView(app);
     const host = document.createElement("div");
 
     await view.show("a.md", host);
     await view.show("b.md", host);
 
-    expect(getLeaf).toHaveBeenCalledTimes(1);
+    expect(createLeafInParent).toHaveBeenCalledTimes(1);
     expect(leaf.openFile).toHaveBeenCalledTimes(2);
     expect(contentEl.parentElement).toBe(host);
   });

--- a/src/adapters/task-agent/EmbeddedDetailView.ts
+++ b/src/adapters/task-agent/EmbeddedDetailView.ts
@@ -79,7 +79,22 @@ export class EmbeddedDetailView {
       this.hiddenContainer.appendChild(hiddenSplit.containerEl);
 
       this.leaf = ws.createLeafInParent(hiddenSplit, 0);
-      if (!this.leaf) return;
+      if (!this.leaf) {
+        // Leaf creation failed - tear down the hidden container we
+        // already attached so we don't leak DOM nodes (or the created
+        // split) across repeated show() calls.
+        console.warn(
+          "[work-terminal] EmbeddedDetailView: createLeafInParent returned no leaf",
+        );
+        try {
+          hiddenSplit.containerEl?.remove?.();
+        } catch {
+          // Best-effort cleanup; ignore if the split has no removable element.
+        }
+        this.hiddenContainer.remove();
+        this.hiddenContainer = null;
+        return;
+      }
     }
 
     await this.leaf.openFile(file);

--- a/src/adapters/task-agent/EmbeddedDetailView.ts
+++ b/src/adapters/task-agent/EmbeddedDetailView.ts
@@ -8,9 +8,9 @@
  * requiring a dedicated workspace leaf.
  *
  * This relies on two undocumented / internal Obsidian behaviours:
- *   1. `workspace.getLeaf("window")` returns a leaf whose root element is
- *      detached from the workspace split. We keep the leaf alive but move
- *      its content element into our own host.
+ *   1. A hidden off-screen workspace split hosts a leaf whose content
+ *      element we reparent into our own host. The split is never added
+ *      to the visible workspace layout.
  *   2. MarkdownView renders into `leaf.view.contentEl`. Reparenting that
  *      element preserves its internal editor state because CodeMirror is
  *      content-agnostic about its mount location.
@@ -25,6 +25,10 @@ export class EmbeddedDetailView {
   private reparentedEl: HTMLElement | null = null;
   private host: HTMLElement | null = null;
   private originalParent: HTMLElement | null = null;
+  // Off-screen container for the hidden workspace split that hosts our
+  // leaf. Kept alive for the lifetime of the view so Obsidian doesn't
+  // garbage-collect the split or its children.
+  private hiddenContainer: HTMLElement | null = null;
 
   constructor(private app: App) {}
 
@@ -43,16 +47,38 @@ export class EmbeddedDetailView {
     }
 
     if (!this.leaf) {
-      // "window" leaves are created detached from the workspace split which
-      // lets us reparent their content element without Obsidian fighting us
-      // for layout. We never actually pop it out into a window - we reparent
-      // immediately.
-      const createLeaf = (
-        this.app.workspace as unknown as {
-          getLeaf: (how: "window" | "tab" | "split" | boolean) => WorkspaceLeaf;
-        }
-      ).getLeaf;
-      this.leaf = createLeaf.call(this.app.workspace, "window");
+      // Create a leaf inside a hidden off-screen workspace split. This
+      // avoids getLeaf("window") which spawns a visible pop-out
+      // Electron BrowserWindow that lingers after reparenting.
+      const ws = this.app.workspace as any;
+      if (typeof ws.createLeafInParent !== "function") {
+        console.warn(
+          "[work-terminal] EmbeddedDetailView: workspace.createLeafInParent not available",
+        );
+        return;
+      }
+      // Build a hidden container that Obsidian's layout won't touch.
+      this.hiddenContainer = document.createElement("div");
+      this.hiddenContainer.style.cssText =
+        "position:fixed;left:-9999px;top:-9999px;width:1px;height:1px;overflow:hidden;pointer-events:none;";
+      document.body.appendChild(this.hiddenContainer);
+
+      // Create a root-level split inside the hidden container. The
+      // WorkspaceSplit constructor is on the workspace module; fall back
+      // to duplicating the rootSplit's constructor if available.
+      const SplitCtor = ws.rootSplit?.constructor;
+      if (!SplitCtor) {
+        console.warn(
+          "[work-terminal] EmbeddedDetailView: cannot resolve WorkspaceSplit constructor",
+        );
+        this.hiddenContainer.remove();
+        this.hiddenContainer = null;
+        return;
+      }
+      const hiddenSplit = new SplitCtor(ws, "vertical");
+      this.hiddenContainer.appendChild(hiddenSplit.containerEl);
+
+      this.leaf = ws.createLeafInParent(hiddenSplit, 0);
       if (!this.leaf) return;
     }
 
@@ -97,6 +123,10 @@ export class EmbeddedDetailView {
       } catch (err) {
         console.warn("[work-terminal] EmbeddedDetailView: leaf detach failed", err);
       }
+    }
+    if (this.hiddenContainer) {
+      this.hiddenContainer.remove();
+      this.hiddenContainer = null;
     }
     this.leaf = null;
     this.reparentedEl = null;

--- a/src/adapters/task-agent/EmbeddedDetailView.ts
+++ b/src/adapters/task-agent/EmbeddedDetailView.ts
@@ -83,9 +83,7 @@ export class EmbeddedDetailView {
         // Leaf creation failed - tear down the hidden container we
         // already attached so we don't leak DOM nodes (or the created
         // split) across repeated show() calls.
-        console.warn(
-          "[work-terminal] EmbeddedDetailView: createLeafInParent returned no leaf",
-        );
+        console.warn("[work-terminal] EmbeddedDetailView: createLeafInParent returned no leaf");
         try {
           hiddenSplit.containerEl?.remove?.();
         } catch {

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -287,7 +287,14 @@ export class TerminalPanelView {
     if (this.embeddedDetailHostEl) {
       this.embeddedDetailHostEl.style.display = "none";
     }
-    this.terminalWrapperEl.style.display = "";
+    // Only restore the terminal wrapper if the preview detail is not
+    // currently active. Without this guard, deactivating embedded while
+    // preview is active (or vice-versa in deactivatePreviewDetail) would
+    // make the terminal wrapper visible alongside the active detail host,
+    // causing the detail view to fill only half the panel height.
+    if (!this.previewDetailActive) {
+      this.terminalWrapperEl.style.display = "";
+    }
     this.renderTabBar();
   }
 
@@ -351,13 +358,31 @@ export class TerminalPanelView {
     if (this.previewDetailHostEl) {
       this.previewDetailHostEl.style.display = "none";
     }
-    this.terminalWrapperEl.style.display = "";
+    // Only restore the terminal wrapper if the embedded detail is not
+    // currently active. See symmetrical guard in deactivateEmbeddedDetail.
+    if (!this.embeddedDetailActive) {
+      this.terminalWrapperEl.style.display = "";
+    }
     this.renderTabBar();
   }
 
   /** True when the pseudo "Preview" tab is currently showing. */
   isPreviewDetailActive(): boolean {
     return this.previewDetailActive;
+  }
+
+  /**
+   * Switch away from any active detail pseudo-tab (embedded or preview)
+   * back to the terminal wrapper. Called when spawning a new terminal tab
+   * so the user sees the newly-created session immediately.
+   */
+  private exitDetailView(): void {
+    if (this.embeddedDetailActive) {
+      this.deactivateEmbeddedDetail();
+    }
+    if (this.previewDetailActive) {
+      this.deactivatePreviewDetail();
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -927,6 +952,7 @@ export class TerminalPanelView {
       }
       const commandArgs = expandedArgs ? parseExtraArgs(expandedArgs) : [];
       const expandedCwd = expandTilde(cwd);
+      this.exitDetailView();
       const tab = this.tabManager.createTab(
         command,
         expandedCwd,
@@ -1032,6 +1058,7 @@ export class TerminalPanelView {
   }
 
   private async spawnShell(): Promise<void> {
+    this.exitDetailView();
     const fresh = await this.loadFreshSettings();
     const shell = this.getStringSetting(
       fresh,
@@ -1527,6 +1554,7 @@ export class TerminalPanelView {
     /** Create tab for a specific item instead of the active item. */
     targetItemId?: string;
   }): Promise<TerminalTab | null> {
+    this.exitDetailView();
     const launchConfig = options.launchConfigOverrides ?? getLaunchConfig(options.agentType);
     const { withContext } = sessionTypeToAgentType(options.sessionType);
 

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -282,7 +282,7 @@ export class TerminalPanelView {
    * Always re-renders the tab bar so the Detail pseudo-tab loses its
    * highlight and terminal tab highlights refresh to reflect the active tab.
    */
-  deactivateEmbeddedDetail(): void {
+  deactivateEmbeddedDetail(opts: { skipRender?: boolean } = {}): void {
     this.embeddedDetailActive = false;
     if (this.embeddedDetailHostEl) {
       this.embeddedDetailHostEl.style.display = "none";
@@ -295,7 +295,7 @@ export class TerminalPanelView {
     if (!this.previewDetailActive) {
       this.terminalWrapperEl.style.display = "";
     }
-    this.renderTabBar();
+    if (!opts.skipRender) this.renderTabBar();
   }
 
   /** True when the pseudo "Detail" tab is currently showing. */
@@ -353,7 +353,7 @@ export class TerminalPanelView {
    * Always re-renders the tab bar so the Preview pseudo-tab loses its
    * highlight and terminal tab highlights refresh.
    */
-  deactivatePreviewDetail(): void {
+  deactivatePreviewDetail(opts: { skipRender?: boolean } = {}): void {
     this.previewDetailActive = false;
     if (this.previewDetailHostEl) {
       this.previewDetailHostEl.style.display = "none";
@@ -363,7 +363,7 @@ export class TerminalPanelView {
     if (!this.embeddedDetailActive) {
       this.terminalWrapperEl.style.display = "";
     }
-    this.renderTabBar();
+    if (!opts.skipRender) this.renderTabBar();
   }
 
   /** True when the pseudo "Preview" tab is currently showing. */
@@ -377,12 +377,16 @@ export class TerminalPanelView {
    * so the user sees the newly-created session immediately.
    */
   private exitDetailView(): void {
+    const wasActive = this.embeddedDetailActive || this.previewDetailActive;
     if (this.embeddedDetailActive) {
-      this.deactivateEmbeddedDetail();
+      this.deactivateEmbeddedDetail({ skipRender: true });
     }
     if (this.previewDetailActive) {
-      this.deactivatePreviewDetail();
+      this.deactivatePreviewDetail({ skipRender: true });
     }
+    // Re-render once after both deactivations so we don't trigger up to
+    // two renderTabBar() calls (and the associated DOM work / flicker).
+    if (wasActive) this.renderTabBar();
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three fixes for the embedded detail view placement:

### 1. Detail tab now fills full panel height (was half)

**Root cause:** When `placement === "embedded"`, the `onSelect` callback called `activateEmbeddedDetail()` (setting `terminalWrapperEl.style.display = "none"`), then immediately called `deactivatePreviewDetail()` which unconditionally reset `terminalWrapperEl.style.display = ""`. Both the detail host and terminal wrapper ended up visible with `flex: 1`, splitting the space 50/50.

**Fix:** Both `deactivateEmbeddedDetail()` and `deactivatePreviewDetail()` now guard against restoring the terminal wrapper when the other detail mode is active.

### 2. No more lingering pop-out window

**Root cause:** `EmbeddedDetailView.show()` used `getLeaf("window")` which creates a visible Electron BrowserWindow. The contentEl was reparented, but the pop-out window shell remained.

**Fix:** Replaced with a hidden off-screen workspace split (`position: fixed; left: -9999px`) that hosts the leaf without any visible artifact. Uses the same `createLeafInParent` API already used by `TaskDetailView`.

### 3. Spawning a session switches away from Detail tab

**Root cause:** Clicking a spawn button (Shell, Claude, etc.) while the Detail or Preview pseudo-tab was active created the new terminal tab but didn't deactivate the detail view, so it stayed showing.

**Fix:** Added `exitDetailView()` helper that deactivates any active detail pseudo-tab. Called at the start of `spawnShell()`, `spawnAgentSession()`, and the shell-profile `createTab` path.

## Test plan
- [x] `pnpm exec vitest run` - 1295/1295 pass
- [x] `pnpm run build` - clean
- [x] `pnpm run lint` - clean
- [x] Isolated instance: embedded detail fills full height, no terminal bleed-through
- [x] Isolated instance: no pop-out window when selecting a task
- [x] Isolated instance: clicking + Shell while Detail tab is active switches to the new Shell tab
- [ ] Manual: confirm switching between Detail and terminal tabs works in both directions
- [ ] Manual: confirm preview placement still works correctly