### PR TITLE
docs: fact-check corrections across all documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,4 +138,4 @@ All new placeholder variables must use the `$name` form (camelCase, dollar prefi
 - **Node builtins**: Use `window.require` for `child_process`, `fs`, `path`, `os` in Electron. Externalized in esbuild.
 - **Resize protocol**: `ESC]777;resize;COLS;ROWS BEL` through stdin; pty-wrapper.py intercepts and applies.
 - **Keyboard capture**: Two layers (bubble + capture phase) intercept keys before Obsidian. Option+Arrow, Option+B/F/D, Shift+Enter, Option+Backspace, Cmd+Left/Right. xterm keeps Meta behavior by default, while Option+digit printable combos are preserved for layout-specific characters.
-- **State detection reads xterm buffer, not stdout**: Immune to status line redraws. Checks last 6 visual lines. Handles narrow terminal wrapping via joined-tail fallback.
+- **State detection reads xterm buffer, not stdout**: Immune to status line redraws. Reads last 30 buffer lines and pattern-matches the tail for waiting/active detection. Handles narrow terminal wrapping via joined-tail fallback.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If `work-terminal` already exists in `.obsidian/plugins`, remove that directory 
 
 ## Process spawning & security
 
-This plugin spawns external processes to provide terminal and AI agent functionality. All commands are user-configured and resolved against `$PATH`. Arguments are passed as arrays via `child_process.spawn()` (no shell interpretation). The plugin makes zero outbound network requests. Vault files are only modified through the Obsidian API, never via direct filesystem writes.
+This plugin spawns external processes to provide terminal and AI agent functionality. All commands are user-configured and resolved against `$PATH` (augmented with login shell and version-manager paths). Arguments are passed as arrays via `child_process.spawn()` (no shell interpretation, with one exception: Cmd+clicking a file path in terminal output runs `code --goto` via `exec()` to open the file in VS Code). The plugin makes zero outbound network requests. Vault files are modified through the Obsidian API (`app.vault.*` and `app.vault.adapter.*`), not raw `fs.*` writes.
 
 For a complete, source-verified inventory of every process spawned, every file read or written, and all security properties, see **[Process Spawning & Filesystem Disclosure](docs/process-spawning.md)**.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,7 +69,7 @@ src/
 
 ## Extension model
 
-The adapter provides 5 required implementations (parser, mover, card renderer, prompt builder, config) plus optional hooks (detail view, preview view, embedded view, item creation, session label transform, icon modal, enrichment logging). The framework handles everything else: terminals, agent integration, hot-reload session stash, drag-drop, state detection, keyboard capture, activity tracking, pinning, and card flag rules.
+The adapter provides 5 required implementations (parser, mover, card renderer, prompt builder, config) plus optional hooks (detail view, detach, rekey, item creation, split item, session label transform, settings change, retry enrichment, delete, custom styles). The framework handles everything else: terminals, agent integration, hot-reload session stash, drag-drop, state detection, keyboard capture, activity tracking, pinning, and card flag rules.
 
 To create a custom adapter: extend `BaseAdapter`, implement the abstract methods, change the import in `main.ts`. See [Creating an Adapter](creating-an-adapter.md) for a full walkthrough.
 

--- a/docs/creating-an-adapter.md
+++ b/docs/creating-an-adapter.md
@@ -109,10 +109,13 @@ Your adapter inherits all of this without writing any terminal code:
 
 Override these in your adapter for extra functionality:
 
-- `createDetailView(item, app, ownerLeaf)` - Open a detail panel (e.g. MarkdownView) when an item is selected
-- `createPreviewView(item, app, containerEl)` - Render a read-only preview as a pseudo-tab in the terminal panel
-- `createEmbeddedView(item, app, containerEl)` - Reparent a full MarkdownView into a pseudo-tab (experimental)
+- `createDetailView(item, app, ownerLeaf, embeddedHost?, previewHost?)` - Open a detail panel when an item is selected. The `embeddedHost` and `previewHost` params receive DOM elements for the embedded and preview placements respectively
 - `detachDetailView()` - Clean up the detail panel on close/reload
-- `onItemCreated(path, settings)` - Run post-creation logic (e.g. background AI enrichment)
+- `rekeyDetailPath(oldPath, newPath)` - Update detail view tracking when an item file is renamed
+- `onItemCreated(title, settings)` - Create the file and run post-creation logic (e.g. background enrichment). Returns `{ id, columnId, enrichmentDone? }`
+- `onSplitItem(sourceItem, columnId, settings)` - Split an existing item into a new linked task
 - `transformSessionLabel(oldLabel, detectedLabel)` - Transform detected agent session labels
-- `createStateResolver(strategy, app, basePath, columns)` - Return a state resolver for the configured strategy
+- `onSettingsChanged(settings)` - React to plugin settings changes (e.g. update card flag rules)
+- `getRetryEnrichPrompt(item)` - Prepare a retry enrichment prompt for a failed enrichment
+- `onDelete(item)` - Called before deletion; return false to prevent the default `vault.trash()` behaviour
+- `getStyles()` - Return adapter-specific CSS to inject into the document

--- a/docs/development.md
+++ b/docs/development.md
@@ -347,4 +347,4 @@ Follow [Release Process](release-process.md) for:
 - **Node builtins**: Use `window.require` for `child_process`, `fs`, `path`, `os` in Electron. Externalized in esbuild.
 - **Resize protocol**: `ESC]777;resize;COLS;ROWS BEL` through stdin; pty-wrapper.py intercepts and applies.
 - **Keyboard capture**: Two layers (bubble + capture phase) intercept keys before Obsidian. Option+Arrow, Option+B/F/D, Shift+Enter, Option+Backspace, Cmd+Left/Right. xterm keeps Meta behavior by default, while Option+digit printable combos are preserved for layout-specific characters.
-- **State detection reads xterm buffer, not stdout**: Immune to status line redraws. Checks last 6 visual lines. Handles narrow terminal wrapping via joined-tail fallback.
+- **State detection reads xterm buffer, not stdout**: Immune to status line redraws. Reads last 30 buffer lines and pattern-matches the tail for waiting/active detection. Handles narrow terminal wrapping via joined-tail fallback.

--- a/docs/process-spawning.md
+++ b/docs/process-spawning.md
@@ -80,7 +80,9 @@ All vault operations use Obsidian's `app.vault.*` API, never direct `fs.*` write
 | UUID backfill into task frontmatter | `src/adapters/task-agent/TaskParser.ts` | `app.vault.read()`, `app.vault.modify()` |
 | Task file metadata reading | `src/adapters/task-agent/TaskParser.ts` | `app.metadataCache.getFileCache()` |
 | Detail view opening | `src/adapters/task-agent/TaskDetailView.ts` | `app.vault.getAbstractFileByPath()` |
-| Icon frontmatter update | `src/adapters/task-agent/SetIconModal.ts` | `app.vault.read()`, `app.vault.modify()` |
+| Icon frontmatter update | `src/adapters/task-agent/index.ts` | `app.vault.read()`, `app.vault.modify()` |
+| Activity timestamp (`last-active`) write | `src/framework/MainView.ts` | `app.vault.read()`, `app.vault.modify()` |
+| Task file deletion | `src/framework/ListPanel.ts` | `app.vault.trash()` |
 
 ### Plugin data (Obsidian plugin API)
 
@@ -111,9 +113,9 @@ Enrichment failure logs are written to `<vault>/<configDir>/plugins/work-termina
 
 ## Security properties
 
-- **All external commands are user-configured** - Shell, Claude, Copilot, and Strands commands are set in plugin settings, not hardcoded. The plugin resolves them against `$PATH` via `resolveCommandInfo()` and validates they exist before spawning. (`src/core/agents/AgentLauncher.ts`)
+- **All external commands are user-configured** - Shell, Claude, Copilot, and Strands commands are set in plugin settings, not hardcoded. The plugin resolves them via `resolveCommandInfo()`, which searches an augmented PATH that includes `$PATH`, the user's login shell PATH (via `$SHELL -lc 'echo $PATH'`), and nvm/fnm version-manager directories as a fallback. It validates commands exist before spawning. (`src/core/agents/AgentLauncher.ts`)
 - **`child_process.spawn()` array form - no shell interpretation** - Arguments are constructed as arrays and passed to `spawn()`, which invokes executables directly without a shell. This prevents command injection. The one exception is the VS Code `code --goto` call which uses `exec()` with a quoted path. (`src/core/terminal/TerminalTab.ts`, `src/core/claude/HeadlessClaude.ts`)
 - **Zero outbound network requests from the plugin itself** - The plugin makes no network calls. Any network activity comes from the spawned processes (e.g. Claude CLI communicating with Anthropic's API).
-- **Vault modifications exclusively through Obsidian API** - Vault file operations use `app.vault.create()` / `app.vault.modify()` / `app.vault.rename()`, never direct `fs.*` writes to vault files.
+- **Vault modifications exclusively through Obsidian API** - Vault file operations use `app.vault.create()` / `app.vault.modify()` / `app.vault.rename()` / `app.vault.trash()`, never direct `fs.*` writes to vault files. Enrichment logs use the lower-level `app.vault.adapter.write()` but this is still within the Obsidian API surface.
 - **Minimal direct filesystem access** - Direct `fs.*` calls are limited to read-only checks on `pty-wrapper.py` and command binary paths. Enrichment failure logs are written via `app.vault.adapter`, not raw `fs.*`. All other filesystem operations go through Obsidian's API.
 - **Plugin data via Obsidian API** - Settings use `plugin.loadData()` / `plugin.saveData()`, stored in the vault's `.obsidian/plugins/work-terminal/data.json`.

--- a/docs/regression-tests.md
+++ b/docs/regression-tests.md
@@ -172,7 +172,7 @@
 | UD-02 | StringDecoder for UTF-8 | Verify rename detection handles multi-byte chars split across chunks | StringDecoder used to handle split UTF-8 characters. Pattern checked on both complete lines AND incomplete buffer. | | |
 | UD-03 | Multi-line question detection | Claude asks a numbered question | State detector finds numbered options preceded by `?` within 5 lines. Reports "waiting". | | |
 | UD-04 | State aggregation priority | Task with multiple tabs in different states | Aggregation: waiting > active > idle > inactive. Short-circuits on first "waiting". | | |
-| UD-05 | Last 6 lines only for active detection | Claude outputs `*` + ellipsis in response body (not at bottom) | Only last 6 screen lines checked for active indicators. Mid-response content doesn't false-positive. | | |
+| UD-05 | Tail lines only for active detection | Claude outputs `*` + ellipsis in response body (not at bottom) | Only tail screen lines checked for active indicators. Mid-response content doesn't false-positive. | | |
 | UD-06 | MetadataCache "changed" fallback | Create a new task file programmatically | MetadataCache "changed" event used as fallback for vault "create" (frontmatter not parsed when create fires). | | |
 | UD-07 | Delete event session check | Delete a task file without terminal sessions | Delete event only buffers rename if task has terminal sessions (avoids polluting pending renames map). | | |
 | UD-08 | UUID captured on delete | Delete a task file (part of rename) | UUID captured from metadata cache immediately on delete (cache is about to be cleared). | | |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -211,7 +211,7 @@ Right-click any task card to open the context menu with these options:
 - **Copy Context Prompt** - copies the generated context prompt for this task
 - **Set Icon...** - opens a modal to set a custom icon for this task (shown when icons are enabled)
 - **Clear Icon** - removes the custom icon from this task (shown when the task has a custom icon and icons are enabled)
-- **Delete Task** - permanently deletes the task file (shown in red as a destructive action)
+- **Delete Task** - moves the task file to the system trash (shown in red as a destructive action)
 
 ### Detail panel
 
@@ -325,6 +325,8 @@ Shell sessions:
 
 The terminal panel is resizable - drag the divider between the kanban board and the terminal area to adjust the split.
 
+**File-path links**: Terminal output containing file paths (e.g. stack traces, compiler errors) is automatically detected and made clickable. Cmd+click a file path to open it in VS Code at the referenced line and column (`code --goto`). If VS Code is not available, the file opens with the system default handler instead.
+
 ### Agent sessions
 
 Work Terminal integrates with AI coding agents. The built-in session types are:
@@ -359,7 +361,7 @@ Work Terminal monitors agent sessions and displays their current state:
 - **Waiting** (amber/yellow) - the agent is waiting for user input
 - **Idle** (grey) - the session is idle with no recent activity
 
-State detection works by reading the xterm buffer (not stdout), which makes it immune to status line redraws. It checks the last 6 visual lines of the terminal and handles narrow terminal wrapping via a joined-tail fallback.
+State detection works by reading the xterm buffer (not stdout), which makes it immune to status line redraws. It reads the last 30 lines from the buffer and applies pattern matching against the tail for waiting/active detection. Narrow terminal wrapping is handled via a joined-tail fallback.
 
 The state indicator appears both on the tab and on the task card, giving you visibility into agent activity even when viewing a different tab.
 
@@ -417,7 +419,7 @@ The per-profile **Context prompt** field is the place to configure additional co
 
 For example, an argument string like `--file $absoluteFilePath --task $title` would expand to something like `--file /Users/me/vault/Tasks/active/my-task.md --task My Task`.
 
-**Login shell wrapping**: Each profile has an optional **Login shell wrap** toggle. When enabled, the agent command is launched through a login shell (`$SHELL -lc ...`), which ensures shell startup files (`~/.zshrc`, `~/.bash_profile`, etc.) are sourced before the command runs. This is important when your agent binary is managed by a version manager like nvm or fnm - without login shell wrapping, the agent command may not be found because the version manager's PATH entries are not loaded. The toggle defaults to on for new profiles.
+**Login shell wrapping**: Each profile has an optional **Login shell wrap** toggle. When enabled, the agent command is launched through a login shell (`$SHELL -lc ...`), which ensures shell startup files (`~/.zshrc`, `~/.bash_profile`, etc.) are sourced before the command runs. This is important when your agent binary is managed by a version manager like nvm or fnm - without login shell wrapping, the agent command may not be found because the version manager's PATH entries are not loaded. The toggle defaults to off for new profiles.
 
 **Import/Export**: Profiles can be exported as JSON for sharing or backup, and imported from JSON to quickly set up a new installation.
 


### PR DESCRIPTION
Source-verified fact-check of all documentation files against the codebase.

## Corrections

### README
- **"never via direct filesystem writes"** - Enrichment logs use `app.vault.adapter.write()`, not the high-level `vault.create/modify` API. Reworded to accurately describe both API layers.
- **spawn() no shell interpretation** - Added note about VS Code `exec()` exception (already documented in process-spawning.md but omitted from README summary).
- **"resolved against \$PATH"** - Actually uses an augmented PATH including login shell and nvm/fnm fallbacks.

### User guide
- **Login shell wrap default** - Said "defaults to on"; code shows `loginShellWrap ?? false` (defaults to OFF).
- **"permanently deletes"** - `vault.trash(file, false)` moves to system trash, not permanent deletion.
- **State detection "last 6 visual lines"** - Actually reads last 30 buffer lines. The "6" is `HIDDEN_CLAUDE_PROMPT_CHROME_SCAN_LINES`, one sub-check constant.

### Process spawning
- **Icon frontmatter source file** - Was `SetIconModal.ts` (just a UI modal); actual vault writes happen in `adapters/task-agent/index.ts`.
- **Missing operations** - Added `last-active` writes (`MainView.ts`) and task deletion (`ListPanel.ts` via `vault.trash()`).
- **Security properties** - Added `vault.trash()` to API list, noted augmented PATH, clarified enrichment log adapter usage.

### Creating an adapter
- **Optional hooks list** - Replaced 3 fictional methods (`createPreviewView`, `createEmbeddedView`, `createStateResolver`) with 10 actual `AdapterBundle` interface methods. Updated `createDetailView` signature to show `embeddedHost`/`previewHost` params.

### Architecture / Development / CLAUDE.md / regression-tests
- Fixed "last 6 visual lines" -> "last 30 buffer lines" everywhere.