### PR TITLE
Display running plugin version in settings and tab title (#496)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ GitHub release notes should mirror these entries rather than pasting the raw aut
 
 ## [Unreleased]
 
+### Improvements
+- **Running plugin version is now visible in the UI.** The top of the settings General section shows the current tag (e.g. `0.5.0 (released ...)`) or short commit SHA (e.g. `c072614 (committed ...)`) with the release/commit timestamp, and the Work Terminal tab title is suffixed with the tag or SHA (e.g. `Work Terminal (0.5.0)`). A new **Show version in tab title** toggle under General (default on) controls the tab-title suffix. Version metadata is injected at build time via esbuild `define` from `git describe`. (#496)
+
 ### Fixes
 - **Embedded detail tab** now fills the full panel width. The reparented MarkdownView `contentEl` was losing its ancestor flex context when moved out of its original workspace leaf, leaving the right side of the host unused and letting hidden terminal content bleed through visually. Direct children of the embedded detail host are now forced to `width: 100%` and `flex: 1 1 auto`. (#490)
 - **Embedded detail tab now fills full panel height.** `deactivatePreviewDetail()` was unconditionally restoring the terminal wrapper's `display` style immediately after `activateEmbeddedDetail()` hid it, causing both containers to share the space 50/50. Deactivation now guards against restoring the terminal wrapper when the other detail mode is active. (#493)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -34,6 +34,7 @@ Work Terminal turns your Obsidian vault into a work item board with per-item tab
   - [Dynamic columns](#dynamic-columns)
   - [Terminal settings](#terminal-settings)
   - [Background enrichment](#background-enrichment)
+  - [Running version display](#running-version-display)
   - [Core settings](#core-settings)
 - [Advanced features](#advanced-features)
   - [Pinning tasks](#pinning-tasks)
@@ -379,7 +380,7 @@ The settings page is organised into five top-level sections. Use this map to jum
 
 | Section | What lives here |
 |---------|-----------------|
-| **General** | Task base path, state resolution strategy, view mode (kanban/activity), recent activity threshold, card display mode (standard/comfortable/compact), card indicator toggles, task card icons, automatic icon mode, Jira base URL, keep sessions alive, enrichment failure logs, expose debug API, reset guided tour. |
+| **General** | Running plugin version display, task base path, state resolution strategy, view mode (kanban/activity), recent activity threshold, card display mode (standard/comfortable/compact), card indicator toggles, task card icons, automatic icon mode, Jira base URL, show version in tab title, keep sessions alive, enrichment failure logs, expose debug API, reset guided tour. |
 | **Board & Columns** | Column display order (reorder and pin), creation column selector, create custom state input, and **Manage Rules** for custom card flag rules. |
 | **Terminal** | **Configure terminal...** button opening a dedicated dialog with default shell and default terminal CWD. |
 | **Detail view** | Placement dropdown (split / tab / navigate / preview / disabled) plus the placement-dependent auto-close toggle, readable line-width override, and split direction. |
@@ -539,6 +540,15 @@ Each log records:
 
 **Sensitive content warning**: log files include the full enrichment prompt and the raw agent output. If your prompt template or task content references sensitive data (API keys, internal URLs, personal notes) those values will also appear in the log. Treat the `logs/` directory as you would any other local debug dump, and share logs only with people you are comfortable reading that content.
 
+### Running version display
+
+The plugin displays its currently running version in two places so you can confirm which build is active (useful when reporting issues or verifying an update took effect):
+
+- **Top of the settings page** - a "Running version: ..." line at the top of the **General** section. On a tagged release build it shows the tag name and release date (e.g. `0.5.0 (released 24 Apr 2026, 12:47)`). On a dev build between tags, it shows the short commit SHA and commit date (e.g. `c072614 (committed 24 Apr 2026, 12:47)`).
+- **Work Terminal tab title** - the tag or short SHA is appended to the tab title in parentheses, e.g. `Work Terminal (0.5.0)`. This display is controlled by the **Show version in tab title** toggle in **General** (default on). Only the version/SHA appears here, not the timestamp, to keep the tab label compact.
+
+The version is baked in at build time by esbuild from `git describe` output and the tag or commit timestamp. Rebuilding with `pnpm run build` picks up the current commit.
+
 ### Core settings
 
 The **General** section covers board-wide preferences and utility toggles. The most commonly-used items:
@@ -554,6 +564,7 @@ The **General** section covers board-wide preferences and utility toggles. The m
 | **Task card icons** | Whether icons are shown on task cards at all. See [Task card icons](#task-card-icons). |
 | **Automatic icon mode** | Which automatic icon scheme to apply when a task has no custom icon (none, source-based, state-based). |
 | **Jira base URL** | Browse URL prefix used to turn Jira keys like `AUTH-2847` into clickable external links. |
+| **Show version in tab title** | When enabled (default), the running plugin version (tag name or short commit SHA) is appended to the Work Terminal tab title, e.g. "Work Terminal (0.5.0)". See [Running version display](#running-version-display). |
 | **Keep sessions alive** | When enabled, closing the Work Terminal tab stashes sessions to memory instead of killing them. Reopening restores sessions with full PTY state. |
 | **Enrichment failure logs** | When enabled, each failed background enrichment writes a diagnostic log file to `<configDir>/plugins/work-terminal/logs/` (usually `.obsidian/plugins/work-terminal/logs/`). See [Enrichment failure logs](#enrichment-failure-logs). |
 | **Expose debug API** | Publishes `window.__workTerminalDebug` for CDP inspection (see [Debug API](#debug-api)). |

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,7 +1,7 @@
 import esbuild from "esbuild";
 import http from "http";
 import crypto from "crypto";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 
 const isProduction = process.argv.includes("--production");
 const isWatch = process.argv.includes("--watch");
@@ -16,7 +16,12 @@ const isWatch = process.argv.includes("--watch");
  * install) so the build still succeeds.
  */
 function resolveBuildVersion() {
-  const run = (cmd) => execSync(cmd, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  // Invoke git with an argument array rather than a shell command string.
+  // `execFileSync` with `shell: false` (the default) does not involve a
+  // shell, so tag/ref names that contain shell metacharacters cannot
+  // inject additional commands into the build.
+  const git = (args) =>
+    execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
 
   let version = "dev";
   let isTagged = false;
@@ -26,7 +31,7 @@ function resolveBuildVersion() {
     // `--exact-match` makes this only succeed when HEAD itself is the
     // tagged commit. If HEAD is N commits past a tag we want the SHA,
     // not the tag name.
-    const tag = run("git describe --tags --exact-match HEAD");
+    const tag = git(["describe", "--tags", "--exact-match", "HEAD"]);
     if (tag) {
       version = tag;
       isTagged = true;
@@ -34,13 +39,16 @@ function resolveBuildVersion() {
         // Tag date (author date of the tagged commit / tag object).
         // `creatordate` on the refs/tags/<tag> ref gives the annotated
         // tag's own date when present, falling back to the committer
-        // date for lightweight tags.
-        timestamp = run(
-          `git for-each-ref --format='%(creatordate:iso-strict)' refs/tags/${tag}`,
-        ).replace(/^'|'$/g, "");
+        // date for lightweight tags. Pass the ref as a separate arg so
+        // the tag name is never interpolated into a shell string.
+        timestamp = git([
+          "for-each-ref",
+          "--format=%(creatordate:iso-strict)",
+          `refs/tags/${tag}`,
+        ]);
       } catch {
         // Fallback to commit date if tag ref lookup fails.
-        timestamp = run("git log -1 --format=%cI HEAD");
+        timestamp = git(["log", "-1", "--format=%cI", "HEAD"]);
       }
     }
   } catch {
@@ -49,8 +57,8 @@ function resolveBuildVersion() {
 
   if (!isTagged) {
     try {
-      version = run("git rev-parse --short HEAD");
-      timestamp = run("git log -1 --format=%cI HEAD");
+      version = git(["rev-parse", "--short", "HEAD"]);
+      timestamp = git(["log", "-1", "--format=%cI", "HEAD"]);
     } catch {
       // Outside a git checkout: keep defaults.
     }

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,9 +1,70 @@
 import esbuild from "esbuild";
 import http from "http";
 import crypto from "crypto";
+import { execSync } from "child_process";
 
 const isProduction = process.argv.includes("--production");
 const isWatch = process.argv.includes("--watch");
+
+/**
+ * Resolve the running plugin's version for build-time injection.
+ *
+ * - Tagged HEAD commits use the tag name + tag date (ISO8601).
+ * - Otherwise use the short commit SHA + commit date (ISO8601).
+ *
+ * Returns null-ish defaults when git isn't available (e.g. tarball
+ * install) so the build still succeeds.
+ */
+function resolveBuildVersion() {
+  const run = (cmd) => execSync(cmd, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+
+  let version = "dev";
+  let isTagged = false;
+  let timestamp = "";
+
+  try {
+    // `--exact-match` makes this only succeed when HEAD itself is the
+    // tagged commit. If HEAD is N commits past a tag we want the SHA,
+    // not the tag name.
+    const tag = run("git describe --tags --exact-match HEAD");
+    if (tag) {
+      version = tag;
+      isTagged = true;
+      try {
+        // Tag date (author date of the tagged commit / tag object).
+        // `creatordate` on the refs/tags/<tag> ref gives the annotated
+        // tag's own date when present, falling back to the committer
+        // date for lightweight tags.
+        timestamp = run(
+          `git for-each-ref --format='%(creatordate:iso-strict)' refs/tags/${tag}`,
+        ).replace(/^'|'$/g, "");
+      } catch {
+        // Fallback to commit date if tag ref lookup fails.
+        timestamp = run("git log -1 --format=%cI HEAD");
+      }
+    }
+  } catch {
+    // Not on a tagged commit - fall through to SHA.
+  }
+
+  if (!isTagged) {
+    try {
+      version = run("git rev-parse --short HEAD");
+      timestamp = run("git log -1 --format=%cI HEAD");
+    } catch {
+      // Outside a git checkout: keep defaults.
+    }
+  }
+
+  return { version, isTagged, timestamp };
+}
+
+const buildVersion = resolveBuildVersion();
+console.log(
+  `[esbuild] Plugin version: ${buildVersion.version}` +
+    (buildVersion.isTagged ? " (tagged)" : " (commit)") +
+    (buildVersion.timestamp ? ` @ ${buildVersion.timestamp}` : ""),
+);
 
 /**
  * Trigger the plugin's hot-reload command via CDP (Chrome DevTools Protocol).
@@ -120,6 +181,11 @@ const ctx = await esbuild.context({
   minify: isProduction,
   sourcemap: isProduction ? false : "inline",
   treeShaking: true,
+  define: {
+    __WT_VERSION__: JSON.stringify(buildVersion.version),
+    __WT_IS_TAGGED__: JSON.stringify(buildVersion.isTagged),
+    __WT_VERSION_TIMESTAMP__: JSON.stringify(buildVersion.timestamp),
+  },
   plugins: [hotReloadPlugin],
 });
 

--- a/src/framework/MainView.test.ts
+++ b/src/framework/MainView.test.ts
@@ -42,6 +42,10 @@ vi.mock("./PluginBase", () => ({
   VIEW_TYPE: "work-terminal-view",
 }));
 
+vi.mock("./version", () => ({
+  formatVersionForTabTitle: (enabled: boolean) => (enabled ? " (test-version)" : ""),
+}));
+
 const { sessionStoreIsReloadMock } = vi.hoisted(() => ({
   sessionStoreIsReloadMock: vi.fn(() => false),
 }));
@@ -802,5 +806,129 @@ describe("MainView detail placement remount on settings change", () => {
     // listener is released even when no item is currently selected.
     expect(adapter.detachDetailView).toHaveBeenCalledTimes(1);
     expect(adapter.createDetailView).not.toHaveBeenCalled();
+  });
+});
+
+describe("MainView getDisplayText version suffix", () => {
+  let dom: JSDOM;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dom = new JSDOM("<!doctype html><html><body></body></html>");
+    vi.stubGlobal("window", dom.window);
+    vi.stubGlobal("document", dom.window.document);
+    vi.stubGlobal("HTMLElement", dom.window.HTMLElement);
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    dom.window.close();
+  });
+
+  it("includes the version suffix when core.showVersionInTabTitle is true", () => {
+    const view = new MainView({} as any, {} as any, {} as any);
+    (view as any).settings = { "core.showVersionInTabTitle": true };
+    expect(view.getDisplayText()).toBe("Work Terminal (test-version)");
+  });
+
+  it("omits the version suffix when core.showVersionInTabTitle is false", () => {
+    const view = new MainView({} as any, {} as any, {} as any);
+    (view as any).settings = { "core.showVersionInTabTitle": false };
+    expect(view.getDisplayText()).toBe("Work Terminal");
+  });
+
+  it("defaults to including the suffix when the setting is absent", () => {
+    const view = new MainView({} as any, {} as any, {} as any);
+    // Settings object exists but the key is absent - default should be enabled
+    (view as any).settings = {};
+    expect(view.getDisplayText()).toBe("Work Terminal (test-version)");
+  });
+
+  it("defaults to including the suffix when the setting is explicitly undefined", () => {
+    const view = new MainView({} as any, {} as any, {} as any);
+    (view as any).settings = { "core.showVersionInTabTitle": undefined };
+    expect(view.getDisplayText()).toBe("Work Terminal (test-version)");
+  });
+});
+
+describe("MainView settings-driven tab title refresh", () => {
+  let dom: JSDOM;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dom = new JSDOM("<!doctype html><html><body></body></html>");
+    vi.stubGlobal("window", dom.window);
+    vi.stubGlobal("document", dom.window.document);
+    vi.stubGlobal("HTMLElement", dom.window.HTMLElement);
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    dom.window.close();
+  });
+
+  function setupView(initialShowVersion: boolean | undefined, leafOverrides: any = {}) {
+    const updateHeader = vi.fn();
+    const leaf = { updateHeader, ...leafOverrides };
+    const view = new MainView(leaf as any, {} as any, {} as any);
+    const adapter = {
+      config: { creationColumns: [] },
+      onSettingsChanged: vi.fn(),
+    };
+    (view as any).adapter = adapter;
+    (view as any).listPanel = { updateSettings: vi.fn() };
+    (view as any).promptBox = { updateCreationColumns: vi.fn() };
+    (view as any).settings =
+      initialShowVersion === undefined ? {} : { "core.showVersionInTabTitle": initialShowVersion };
+    vi.spyOn(view as any, "scheduleRefresh").mockImplementation(() => {});
+    return { view, updateHeader, leaf };
+  }
+
+  it("calls leaf.updateHeader when core.showVersionInTabTitle toggles from true to false", () => {
+    const { view, updateHeader } = setupView(true);
+    const event = new dom.window.CustomEvent("work-terminal:settings-changed", {
+      detail: { "core.showVersionInTabTitle": false },
+    });
+    (view as any)._handleSettingsChanged(event);
+
+    expect(updateHeader).toHaveBeenCalledTimes(1);
+    // getDisplayText should now reflect the new value
+    expect(view.getDisplayText()).toBe("Work Terminal");
+  });
+
+  it("calls leaf.updateHeader when core.showVersionInTabTitle toggles from false to true", () => {
+    const { view, updateHeader } = setupView(false);
+    const event = new dom.window.CustomEvent("work-terminal:settings-changed", {
+      detail: { "core.showVersionInTabTitle": true },
+    });
+    (view as any)._handleSettingsChanged(event);
+
+    expect(updateHeader).toHaveBeenCalledTimes(1);
+    expect(view.getDisplayText()).toBe("Work Terminal (test-version)");
+  });
+
+  it("does not call leaf.updateHeader when core.showVersionInTabTitle is unchanged", () => {
+    const { view, updateHeader } = setupView(true);
+    const event = new dom.window.CustomEvent("work-terminal:settings-changed", {
+      detail: { "core.showVersionInTabTitle": true, "core.other": "changed" },
+    });
+    (view as any)._handleSettingsChanged(event);
+
+    expect(updateHeader).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when the leaf does not expose updateHeader", () => {
+    const { view } = setupView(true, { updateHeader: undefined });
+    // Remove updateHeader entirely to simulate an older Obsidian leaf shape
+    delete ((view as any).leaf as any).updateHeader;
+    const event = new dom.window.CustomEvent("work-terminal:settings-changed", {
+      detail: { "core.showVersionInTabTitle": false },
+    });
+    expect(() => (view as any)._handleSettingsChanged(event)).not.toThrow();
+    expect(view.getDisplayText()).toBe("Work Terminal");
   });
 });

--- a/src/framework/MainView.ts
+++ b/src/framework/MainView.ts
@@ -18,6 +18,7 @@ import { ListPanel } from "./ListPanel";
 import { TerminalPanelView } from "./TerminalPanelView";
 import { PromptBox } from "./PromptBox";
 import { loadAllSettings, SETTINGS_CHANGED_EVENT } from "./SettingsTab";
+import { formatVersionForTabTitle } from "./version";
 import { SessionStore } from "../core/session/SessionStore";
 import { mergeAndSavePluginData } from "../core/PluginDataStore";
 import { PinStore } from "../core/PinStore";
@@ -81,7 +82,13 @@ export class MainView extends ItemView {
   private readonly _handleSettingsChanged = (event: Event) => {
     const prevCreationColumnIds = this.adapter.config.creationColumns;
     const prevPlacement = this.settings["core.detailViewPlacement"];
+    const prevShowVersion = this.settings["core.showVersionInTabTitle"];
     this.settings = { ...(event as CustomEvent<Record<string, any>>).detail };
+    // Re-render the tab header if the version-in-tab-title toggle changed.
+    // Obsidian re-reads `getDisplayText()` during `leaf.updateHeader()`.
+    if (prevShowVersion !== this.settings["core.showVersionInTabTitle"]) {
+      (this.leaf as unknown as { updateHeader?: () => void }).updateHeader?.();
+    }
     // Notify adapter so it can update internal state (e.g. card flag rules, column order)
     this.adapter.onSettingsChanged?.(this.settings);
     // Keep ListPanel's cached settings in sync so card display mode etc. take effect
@@ -155,7 +162,13 @@ export class MainView extends ItemView {
   }
 
   getDisplayText(): string {
-    return "Work Terminal";
+    // Version suffix is gated behind `core.showVersionInTabTitle` (default
+    // true). `this.settings` may be empty before `initPanels()` has run -
+    // Obsidian calls getDisplayText() during view registration, well before
+    // onOpen(). Treat an absent setting as "enabled" so the first paint
+    // matches the default-on behaviour.
+    const showVersion = this.settings["core.showVersionInTabTitle"] !== false;
+    return "Work Terminal" + formatVersionForTabTitle(showVersion);
   }
 
   getIcon(): string {

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -76,6 +76,7 @@ import { parseCardFlagRulesJson, serializeCardFlagRules } from "../core/cardFlag
 import type { ViewMode, RecentThreshold } from "./ActivityTracker";
 import type { DetailViewPlacement, DetailViewSplitDirection } from "../core/detailViewPlacement";
 import { resolveDetailViewOptions } from "../core/detailViewPlacement";
+import { formatVersionForSettings } from "./version";
 
 interface CoreSettings {
   "core.claudeCommand": string;
@@ -96,6 +97,7 @@ interface CoreSettings {
   "core.detailViewWidthOverride": boolean;
   "core.detailViewAutoClose": boolean;
   "core.detailViewSplitDirection": DetailViewSplitDirection;
+  "core.showVersionInTabTitle": boolean;
 }
 
 export const SETTINGS_CHANGED_EVENT = "work-terminal:settings-changed";
@@ -126,6 +128,7 @@ const CORE_DEFAULTS: CoreSettings = {
   "core.detailViewWidthOverride": true,
   "core.detailViewAutoClose": false,
   "core.detailViewSplitDirection": "vertical",
+  "core.showVersionInTabTitle": true,
 };
 
 /**
@@ -237,6 +240,16 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
   private renderGeneralSection(containerEl: HTMLElement, settings: SettingsSnapshot): void {
     containerEl.createEl("h2", { text: "General" });
 
+    // Running plugin version - resolved at build time. Displayed at the top
+    // of General so it's the first thing users see when filing a bug report.
+    // Uses a plain div (not `new Setting`) to keep it read-only and compact.
+    const versionEl = containerEl.createDiv({ cls: "wt-settings-version" });
+    versionEl.setAttribute("data-wt-setting-key", "core.version");
+    versionEl.style.cssText =
+      "margin: 0.25em 0 1em; color: var(--text-muted); font-size: var(--font-ui-smaller);";
+    versionEl.createSpan({ text: "Running version: " });
+    versionEl.createEl("code", { text: formatVersionForSettings() });
+
     // Task base path + state strategy are adapter-level but conceptually
     // "where are my tasks stored and how is state computed" - users reach for
     // them during initial setup and rarely after, so they go near the top of
@@ -277,6 +290,17 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
 
     // Jira integration - rarely changed after setup.
     this.addAdapterSettingByKey(containerEl, settings, "jiraBaseUrl");
+
+    // Tab title version display - default ON. Grouped with other display
+    // toggles rather than session/lifecycle ones because it's purely a
+    // visual preference for the plugin's own tab header.
+    this.addCoreToggle(
+      containerEl,
+      settings,
+      "core.showVersionInTabTitle",
+      "Show version in tab title",
+      "Append the running plugin version (or short commit SHA for untagged builds) to the Work Terminal tab title. Helps quickly confirm which build is running when reporting issues.",
+    );
 
     // Session/lifecycle toggles.
     this.addCoreToggle(

--- a/src/framework/version.test.ts
+++ b/src/framework/version.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit coverage for the version formatters. Build-time injected constants
+ * are covered by tests that pass explicit arguments rather than relying on
+ * esbuild's substitution (which is undefined under vitest).
+ */
+import { describe, expect, it } from "vitest";
+import {
+  formatVersionTimestamp,
+  formatVersionForSettings,
+  formatVersionForTabTitle,
+} from "./version";
+
+describe("formatVersionTimestamp", () => {
+  it("returns empty string for empty input", () => {
+    expect(formatVersionTimestamp("")).toBe("");
+  });
+
+  it("returns empty string for unparsable input", () => {
+    expect(formatVersionTimestamp("not-a-date")).toBe("");
+  });
+
+  it("returns a non-empty formatted string for a valid ISO timestamp", () => {
+    const out = formatVersionTimestamp("2026-04-24T12:47:12+01:00");
+    expect(out).not.toBe("");
+    // Month name from `toLocaleString` with `month: "short"` should appear
+    // in at least the en-GB/en-US locales used in CI.
+    expect(out.length).toBeGreaterThan(5);
+  });
+});
+
+describe("formatVersionForSettings", () => {
+  it("includes a 'released' qualifier for tagged builds", () => {
+    const out = formatVersionForSettings("0.5.0", true, "2026-04-24T12:47:12+01:00");
+    expect(out).toMatch(/^0\.5\.0 \(released /);
+  });
+
+  it("includes a 'committed' qualifier for non-tagged builds", () => {
+    const out = formatVersionForSettings("c072614", false, "2026-04-24T12:47:12+01:00");
+    expect(out).toMatch(/^c072614 \(committed /);
+  });
+
+  it("omits the timestamp clause when the timestamp is empty", () => {
+    expect(formatVersionForSettings("dev", false, "")).toBe("dev");
+  });
+
+  it("omits the timestamp clause when the timestamp is unparsable", () => {
+    expect(formatVersionForSettings("0.5.0", true, "garbage")).toBe("0.5.0");
+  });
+});
+
+describe("formatVersionForTabTitle", () => {
+  it("returns an empty string when disabled (so callers can append unconditionally)", () => {
+    expect(formatVersionForTabTitle(false, "0.5.0")).toBe("");
+  });
+
+  it("returns ` (version)` when enabled", () => {
+    expect(formatVersionForTabTitle(true, "0.5.0")).toBe(" (0.5.0)");
+  });
+
+  it("handles a short SHA", () => {
+    expect(formatVersionForTabTitle(true, "c072614")).toBe(" (c072614)");
+  });
+
+  it("returns empty when version is empty", () => {
+    expect(formatVersionForTabTitle(true, "")).toBe("");
+  });
+});

--- a/src/framework/version.ts
+++ b/src/framework/version.ts
@@ -1,0 +1,103 @@
+/**
+ * Build-time version information injected by esbuild via `define`.
+ *
+ * Three constants are substituted at build time. They are declared as
+ * ambient globals here so TypeScript accepts references to them across
+ * the codebase without any runtime resolution.
+ *
+ *   __WT_VERSION__           - The tag name if the current HEAD is tagged
+ *                              (e.g. `0.5.0`), otherwise the short commit
+ *                              SHA (e.g. `c072614`).
+ *   __WT_IS_TAGGED__         - true iff HEAD is an exact tagged commit.
+ *   __WT_VERSION_TIMESTAMP__ - ISO8601 timestamp of the tag date (when
+ *                              tagged) or commit date (when not tagged).
+ *
+ * When esbuild runs, values are computed by `resolveBuildVersion()` in
+ * esbuild.config.mjs. Outside a real build (e.g. vitest), the fallbacks
+ * declared in that helper (`"dev"`, ISO `Date.now()`, `false`) keep the
+ * module importable.
+ */
+
+declare const __WT_VERSION__: string;
+declare const __WT_IS_TAGGED__: boolean;
+declare const __WT_VERSION_TIMESTAMP__: string;
+
+/**
+ * The user-facing version string for the running plugin build.
+ *
+ * - On a tagged build: the tag name (e.g. "0.5.0").
+ * - Otherwise: the short commit SHA (e.g. "c072614").
+ */
+export const WT_VERSION: string =
+  typeof __WT_VERSION__ !== "undefined" ? __WT_VERSION__ : "dev";
+
+/** True when the running build is an exact tagged commit. */
+export const WT_IS_TAGGED: boolean =
+  typeof __WT_IS_TAGGED__ !== "undefined" ? __WT_IS_TAGGED__ : false;
+
+/**
+ * ISO8601 timestamp associated with the running build. Tag date for
+ * tagged builds, commit date otherwise. May be an empty string when the
+ * build-time lookup failed (e.g. a shallow clone without tag metadata).
+ */
+export const WT_VERSION_TIMESTAMP: string =
+  typeof __WT_VERSION_TIMESTAMP__ !== "undefined" ? __WT_VERSION_TIMESTAMP__ : "";
+
+/**
+ * Format the build timestamp for display alongside the version string.
+ * Returns an empty string when the timestamp is missing or unparsable so
+ * callers can safely concatenate without producing "Invalid Date" text.
+ */
+export function formatVersionTimestamp(iso: string = WT_VERSION_TIMESTAMP): string {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  // Use the user's locale for the date + time. Short-form date keeps the
+  // settings line compact; time is included because multiple same-day
+  // dev builds are common.
+  return date.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * Settings-page label: version + formatted timestamp with the correct
+ * "release"/"commit" qualifier based on whether the build is tagged.
+ * Timestamp is omitted entirely when it can't be formatted.
+ *
+ * Examples:
+ *   "0.5.0 (released 24 Apr 2026, 12:47)"
+ *   "c072614 (committed 24 Apr 2026, 12:47)"
+ *   "dev"
+ */
+export function formatVersionForSettings(
+  version: string = WT_VERSION,
+  isTagged: boolean = WT_IS_TAGGED,
+  timestamp: string = WT_VERSION_TIMESTAMP,
+): string {
+  const formatted = formatVersionTimestamp(timestamp);
+  if (!formatted) return version;
+  const qualifier = isTagged ? "released" : "committed";
+  return `${version} (${qualifier} ${formatted})`;
+}
+
+/**
+ * Tab-title suffix: just the version/SHA, no timestamp. Produced as a
+ * complete suffix including the leading separator so callers can append
+ * unconditionally.
+ *
+ * Returns "" when `enabled` is false so `"Work Terminal" + suffix` is
+ * correct with or without the toggle.
+ */
+export function formatVersionForTabTitle(
+  enabled: boolean,
+  version: string = WT_VERSION,
+): string {
+  if (!enabled) return "";
+  if (!version) return "";
+  return ` (${version})`;
+}

--- a/src/framework/version.ts
+++ b/src/framework/version.ts
@@ -28,8 +28,7 @@ declare const __WT_VERSION_TIMESTAMP__: string;
  * - On a tagged build: the tag name (e.g. "0.5.0").
  * - Otherwise: the short commit SHA (e.g. "c072614").
  */
-export const WT_VERSION: string =
-  typeof __WT_VERSION__ !== "undefined" ? __WT_VERSION__ : "dev";
+export const WT_VERSION: string = typeof __WT_VERSION__ !== "undefined" ? __WT_VERSION__ : "dev";
 
 /** True when the running build is an exact tagged commit. */
 export const WT_IS_TAGGED: boolean =
@@ -93,10 +92,7 @@ export function formatVersionForSettings(
  * Returns "" when `enabled` is false so `"Work Terminal" + suffix` is
  * correct with or without the toggle.
  */
-export function formatVersionForTabTitle(
-  enabled: boolean,
-  version: string = WT_VERSION,
-): string {
+export function formatVersionForTabTitle(enabled: boolean, version: string = WT_VERSION): string {
   if (!enabled) return "";
   if (!version) return "";
   return ` (${version})`;


### PR DESCRIPTION
## Summary

Closes #496. Surfaces the running plugin version (tag name or short commit SHA) in two places so users can confirm which build is active:

- **Settings > General** renders a "Running version: ..." line at the top, e.g. `0.5.0 (released 24 Apr 2026, 12:47)` on a tagged build or `c072614 (committed 24 Apr 2026, 12:47)` otherwise.
- **Work Terminal tab title** is suffixed with the tag or SHA, e.g. `Work Terminal (0.5.0)`. Controlled by a new `core.showVersionInTabTitle` toggle (default on) in the General section.

Version metadata is injected at build time by esbuild `define` from `git describe --tags --exact-match HEAD` (fallback to `git rev-parse --short HEAD`) plus the tag creator date or commit date.

Commits in order:
1. `feat(build)`: esbuild `define` for `__WT_VERSION__`, `__WT_IS_TAGGED__`, `__WT_VERSION_TIMESTAMP__`, plus typed `framework/version.ts` wrapper.
2. `feat(settings)`: render version at top of General, add toggle.
3. `feat(view)`: append suffix to `getDisplayText()`; call `leaf.updateHeader()` when toggle flips so the tab updates without a view reopen.
4. `docs`: user-guide "Running version display" subsection, General table entries, CHANGELOG Unreleased entry.

## Test plan

- [x] `pnpm run build` succeeds and prints the resolved version at build time.
- [x] `pnpm exec vitest run` passes (1309 tests across 61 files, including 11 new tests for the version formatters).
- [ ] Manual: open settings, confirm "Running version: ..." line appears at top of General.
- [ ] Manual: confirm Work Terminal tab reads `Work Terminal (<sha>)` by default.
- [ ] Manual: toggle "Show version in tab title" off, confirm tab immediately reads `Work Terminal` (no reopen needed).
- [ ] Manual (optional): build from a tagged commit, confirm tag name + "released ..." text.