### PR TITLE
fix(#504): respect Default terminal CWD for Split Task / Retry Enrichment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ GitHub release notes should mirror these entries rather than pasting the raw aut
 
 ## [Unreleased]
 
+### Fixes
+- **Split Task and Retry Enrichment now respect the configured Default terminal CWD.** These actions previously launched Claude in the parent folder of the task file (inside the vault), silently overriding the user's `core.defaultTerminalCwd` setting and any global working-directory configuration. Cwd resolution now delegates to the same path every other profile-driven launch uses (`profile.defaultCwd` -> `core.defaultTerminalCwd` -> `~`). The split-scope prompt already contains absolute paths for both task files, so Claude can resolve them from any cwd. (#504)
+
 ## [0.5.2] - 2026-04-27
 
 ### Fixes

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -596,7 +596,7 @@ Split a complex task into smaller pieces using the **Split Task** context menu o
 
 The split task includes metadata linking it to the parent task, making it easy to trace the relationship.
 
-The Claude session launched by Split Task runs through the same agent-profile pipeline as the **Claude (ctx)** tab bar button. This means the session inherits your configured command, arguments, login-shell wrapping, and any custom profile flags (e.g. `--dangerously-skip-permissions`, `--allowedTools`, `--model`). The working directory defaults to the **parent folder of the new task file**, so relative paths mentioned in the split scope prompt resolve against the task's own location. To override the profile for Split Task specifically, see [Agent actions settings](#agent-actions-settings).
+The Claude session launched by Split Task runs through the same agent-profile pipeline as the **Claude (ctx)** tab bar button. This means the session inherits your configured command, arguments, login-shell wrapping, working directory, and any custom profile flags (e.g. `--dangerously-skip-permissions`, `--allowedTools`, `--model`). The working directory resolves as `profile.defaultCwd` (if set) -> the global **Default terminal CWD** (Settings > Terminal) -> `~`, the same chain every other profile-driven launch uses. Both file paths in the split scope prompt are passed as absolute paths, so the session does not need to start in the task folder to resolve them. To override the profile for Split Task specifically, see [Agent actions settings](#agent-actions-settings).
 
 ### Retry enrichment
 

--- a/src/framework/ListPanel.ts
+++ b/src/framework/ListPanel.ts
@@ -20,11 +20,7 @@ import type { AgentProfileManager } from "../core/agents/AgentProfileManager";
 import type { AgentProfile } from "../core/agents/AgentProfile";
 import { DangerConfirm } from "./DangerConfirm";
 import { electronRequire, slugify, titleCase } from "../core/utils";
-import {
-  resolveRetryEnrichmentProfile,
-  resolveSplitTaskCwd,
-  resolveSplitTaskProfile,
-} from "./splitTaskProfile";
+import { resolveRetryEnrichmentProfile, resolveSplitTaskProfile } from "./splitTaskProfile";
 import {
   type ActivityTracker,
   type ViewMode,
@@ -789,7 +785,7 @@ export class ListPanel {
       // the user's Claude profile settings (command, args, cwd, login shell wrap).
       // resolveOverride returns null when no profile manager is wired, in which
       // case spawnClaudeWithPrompt falls back to the pre-448 non-profile path.
-      const override = this.resolveSplitLaunchOverride(newFullPath);
+      const override = this.resolveSplitLaunchOverride();
       this.terminalPanel.spawnClaudeWithPrompt(prompt, "Split scope", override ?? undefined);
     } catch (err) {
       console.error("[work-terminal] splitTask failed:", err);
@@ -814,10 +810,8 @@ export class ListPanel {
         // Retry-enrichment launches now follow the configured enrichment
         // profile (see splitTaskProfile.resolveRetryEnrichmentProfile for
         // the fallback chain) so they match what background enrichment
-        // would have used. Use path.resolve via resolveWorkItemAbsPath so
-        // the cwd is computed correctly on any platform.
-        const taskFullPath = this.resolveWorkItemAbsPath(item.path);
-        const override = this.resolveRetryLaunchOverride(taskFullPath);
+        // would have used.
+        const override = this.resolveRetryLaunchOverride();
         this.terminalPanel.spawnClaudeWithPrompt(prompt, "Enrich", override ?? undefined);
       } catch (err) {
         console.error("[work-terminal] retryEnrichment failed:", err);
@@ -830,24 +824,31 @@ export class ListPanel {
    * Resolve the profile + cwd override used when launching a Claude session
    * for Split Task. Returns null when no profile manager is wired so callers
    * fall back to the legacy non-profile path.
+   *
+   * Cwd resolution delegates to `AgentProfileManager.resolveCwd` so this path
+   * uses the same chain as every other profile-driven launch
+   * (profile.defaultCwd -> core.defaultTerminalCwd -> "~"). See issue #504
+   * for why the task file's parent directory is deliberately NOT considered.
    */
-  private resolveSplitLaunchOverride(
-    taskAbsPath: string | null,
-  ): { profile: AgentProfile; cwdOverride: string } | null {
+  private resolveSplitLaunchOverride(): {
+    profile: AgentProfile;
+    cwdOverride: string;
+  } | null {
     if (!this.profileManager) return null;
     const profile = resolveSplitTaskProfile(this.settings, this.profileManager.getProfiles());
     if (!profile) return null;
-    const cwdOverride = resolveSplitTaskCwd(profile, taskAbsPath, this.settings);
+    const cwdOverride = this.profileManager.resolveCwd(profile, this.settings);
     return { profile, cwdOverride };
   }
 
-  private resolveRetryLaunchOverride(
-    taskAbsPath: string | null,
-  ): { profile: AgentProfile; cwdOverride: string } | null {
+  private resolveRetryLaunchOverride(): {
+    profile: AgentProfile;
+    cwdOverride: string;
+  } | null {
     if (!this.profileManager) return null;
     const profile = resolveRetryEnrichmentProfile(this.settings, this.profileManager.getProfiles());
     if (!profile) return null;
-    const cwdOverride = resolveSplitTaskCwd(profile, taskAbsPath, this.settings);
+    const cwdOverride = this.profileManager.resolveCwd(profile, this.settings);
     return { profile, cwdOverride };
   }
 

--- a/src/framework/splitTaskProfile.test.ts
+++ b/src/framework/splitTaskProfile.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AgentProfile } from "../core/agents/AgentProfile";
-import {
-  resolveRetryEnrichmentProfile,
-  resolveSplitTaskCwd,
-  resolveSplitTaskProfile,
-} from "./splitTaskProfile";
+import { resolveRetryEnrichmentProfile, resolveSplitTaskProfile } from "./splitTaskProfile";
 
 function makeProfile(overrides: Partial<AgentProfile> & { id: string }): AgentProfile {
   return {
@@ -127,58 +123,7 @@ describe("resolveRetryEnrichmentProfile", () => {
   });
 });
 
-describe("resolveSplitTaskCwd", () => {
-  it("uses the profile defaultCwd when set", () => {
-    const cwd = resolveSplitTaskCwd(custom, "/vault/tasks/todo/foo.md", {
-      "core.defaultTerminalCwd": "~/work",
-    });
-    expect(cwd).toBe("/repos/app");
-  });
-
-  it("falls back to the task file parent directory when profile cwd is empty", () => {
-    const cwd = resolveSplitTaskCwd(claude, "/vault/tasks/todo/foo.md", {});
-    expect(cwd).toBe("/vault/tasks/todo");
-  });
-
-  it("uses core.defaultTerminalCwd when no task path is provided", () => {
-    const cwd = resolveSplitTaskCwd(claude, null, {
-      "core.defaultTerminalCwd": "~/work",
-    });
-    expect(cwd).toBe("~/work");
-  });
-
-  it('returns "~" when nothing else is available', () => {
-    const cwd = resolveSplitTaskCwd(null, null, {});
-    expect(cwd).toBe("~");
-  });
-
-  it("treats a profile with whitespace-only cwd as unset", () => {
-    const whitespaceProfile = makeProfile({ id: "ws", defaultCwd: "   " });
-    const cwd = resolveSplitTaskCwd(whitespaceProfile, "/vault/tasks/active/bar.md", {});
-    expect(cwd).toBe("/vault/tasks/active");
-  });
-
-  it("handles a single-segment absolute path by falling through to core cwd", () => {
-    const cwd = resolveSplitTaskCwd(null, "/toplevel.md", {
-      "core.defaultTerminalCwd": "~/work",
-    });
-    expect(cwd).toBe("~/work");
-  });
-
-  it("extracts the parent from a Windows-style path using backslashes", () => {
-    const cwd = resolveSplitTaskCwd(claude, "C:\\vault\\tasks\\todo\\foo.md", {});
-    expect(cwd).toBe("C:\\vault\\tasks\\todo");
-  });
-
-  it("extracts the parent from a UNC path", () => {
-    const cwd = resolveSplitTaskCwd(claude, "\\\\server\\share\\tasks\\foo.md", {});
-    expect(cwd).toBe("\\\\server\\share\\tasks");
-  });
-
-  it("strips trailing separators before splitting (POSIX and Windows)", () => {
-    const posix = resolveSplitTaskCwd(claude, "/vault/tasks/todo/foo.md///", {});
-    expect(posix).toBe("/vault/tasks/todo");
-    const windows = resolveSplitTaskCwd(claude, "C:\\vault\\tasks\\todo\\foo.md\\\\", {});
-    expect(windows).toBe("C:\\vault\\tasks\\todo");
-  });
-});
+// resolveSplitTaskCwd was removed in the fix for issue #504; Split Task /
+// Retry Enrichment now delegate cwd resolution to
+// AgentProfileManager.resolveCwd, which is covered by
+// src/core/agents/AgentProfileManager.test.ts.

--- a/src/framework/splitTaskProfile.ts
+++ b/src/framework/splitTaskProfile.ts
@@ -1,11 +1,19 @@
 /**
- * splitTaskProfile - profile and cwd resolution helpers for action-driven
- * Claude launches (Split Task, Retry Enrichment).
+ * splitTaskProfile - profile resolution helpers for action-driven Claude
+ * launches (Split Task, Retry Enrichment).
  *
  * Issue #448 routes these actions through the agent-profile pipeline so they
  * inherit the user's configured command, args, and cwd. Resolution chains
  * are intentionally small and data-only so they can be unit-tested without
  * spinning up TerminalPanelView.
+ *
+ * Cwd resolution for these launches delegates to
+ * `AgentProfileManager.resolveCwd` so Split Task and Retry Enrichment follow
+ * the same chain as every other profile-driven launch
+ * (profile.defaultCwd -> core.defaultTerminalCwd -> "~"). See issue #504 for
+ * the history - an earlier iteration inserted the task file's parent folder
+ * ahead of `core.defaultTerminalCwd`, which silently ignored the user's
+ * configured working directory.
  *
  * ## Fallback chains
  *
@@ -24,12 +32,6 @@
  *     -> default-claude
  *     -> first Claude profile
  *     -> null
- *
- * Cwd (for both actions):
- *   1. Profile's own defaultCwd (if non-empty)
- *   2. Parent directory of the resolved task file (absolute path)
- *   3. core.defaultTerminalCwd
- *   4. "~"
  */
 import type { AgentProfile } from "../core/agents/AgentProfile";
 
@@ -133,50 +135,4 @@ function resolveProfileWithFallbacks(
   // Last resort: any Claude profile at all.
   const anyClaude = availableProfiles.find(isClaudeProfile);
   return anyClaude ?? null;
-}
-
-/**
- * Resolve the cwd for a Split Task / Retry Enrichment launch.
- *
- * Order:
- *   1. Profile's own `defaultCwd` (if non-empty) - lets power users pin a
- *      specific cwd per profile (e.g. a repo root).
- *   2. Parent directory of the task file when provided. Launching in the
- *      task's folder makes file references in the prompt relative to the
- *      task itself.
- *   3. `core.defaultTerminalCwd` - matches legacy behaviour.
- *   4. Literal "~" as an absolute-last fallback.
- *
- * `taskAbsPath` should be absolute; we only use its parent directory and
- * do NOT call expandTilde - that is the spawn layer's job.
- */
-export function resolveSplitTaskCwd(
-  profile: AgentProfile | null,
-  taskAbsPath: string | null,
-  settings: Record<string, unknown>,
-): string {
-  if (profile?.defaultCwd && profile.defaultCwd.trim()) {
-    return profile.defaultCwd.trim();
-  }
-  if (taskAbsPath) {
-    const parent = parentDirectory(taskAbsPath);
-    if (parent) return parent;
-  }
-  const coreCwd = settings["core.defaultTerminalCwd"];
-  if (typeof coreCwd === "string" && coreCwd.trim()) return coreCwd;
-  return "~";
-}
-
-/**
- * Return the parent directory portion of an absolute path, or null if the
- * path has no usable separator. Handles both POSIX (`/`) and Windows/UNC
- * (`\`) separators so it behaves correctly regardless of how the vault
- * adapter reports its base path. Uses a simple string split so this stays
- * dependency-free and trivially unit-testable.
- */
-function parentDirectory(absPath: string): string | null {
-  const trimmed = absPath.replace(/[\\/]+$/, "");
-  const idx = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
-  if (idx <= 0) return null;
-  return trimmed.slice(0, idx);
 }


### PR DESCRIPTION
Closes #504

## Summary

Split Task and Retry Enrichment now respect the user's configured **Default terminal CWD** setting, matching the behaviour of every other profile-driven launch.

## Problem

`resolveSplitTaskCwd` inserted "task file's parent directory" between `profile.defaultCwd` and `core.defaultTerminalCwd` in the fallback chain. Because the built-in "Claude (ctx)" profile ships with empty `defaultCwd`, step 2 (task parent) always won - users who set a global Default terminal CWD saw Claude start in the vault task folder instead.

The original rationale ("keep file references relative to the task folder") is moot: `ListPanel.splitTask` embeds **absolute** paths for both task files in the prompt, so Claude does not need the cwd to resolve them.

## Fix

- Delete `resolveSplitTaskCwd` and `parentDirectory` from `src/framework/splitTaskProfile.ts` entirely.
- `ListPanel.resolveSplitLaunchOverride` / `resolveRetryLaunchOverride` now delegate cwd resolution to `AgentProfileManager.resolveCwd`, which is the canonical chain used by every other profile-driven launch: `profile.defaultCwd` -> `core.defaultTerminalCwd` -> `~`.
- Drop the now-unused `taskAbsPath` argument from both helpers.

## Tests

- Removed `describe("resolveSplitTaskCwd")` from `splitTaskProfile.test.ts` (10 tests); `AgentProfileManager.resolveCwd` is already covered in `AgentProfileManager.test.ts`.
- Remaining `splitTaskProfile.test.ts`: 13 passed.
- Full suite: 62 files, 1315 tests, all passing.
- `pnpm run build`, `pnpm run lint`, `pnpm run format:check`: clean.

## Docs

- Updated the "Task splitting" section of `docs/user-guide.md` to describe the new cwd chain and note that prompt paths are already absolute.
- Added a Fixes entry under `## [Unreleased]` in `CHANGELOG.md`.

## Verification steps (manual)

1. Set **Settings > Terminal > Default terminal CWD** to e.g. `~/working/my-project`.
2. Leave Claude (ctx) profile's `defaultCwd` blank (default).
3. Right-click a task -> **Split Task**.
4. New Claude session should start in `~/working/my-project`, not in the task's vault folder.
5. Same check for **Retry Enrichment**.
