### PR TITLE
fix: add Fallow config for Obsidian false positives

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,0 +1,25 @@
+{
+  "entry": ["src/main.ts", "cdp.js"],
+  "dynamicallyLoaded": ["styles.css"],
+  "ignorePatterns": ["docs/**", ".claude/**"],
+  "ignoreExports": [
+    {
+      "file": "src/__mocks__/**",
+      "exports": ["*"]
+    }
+  ],
+  "usedClassMembers": [
+    {
+      "extends": "Modal",
+      "members": ["onOpen", "onClose"]
+    },
+    {
+      "extends": "ItemView",
+      "members": ["getViewType", "getDisplayText", "getIcon", "onOpen", "onClose", "onPaneMenu"]
+    },
+    {
+      "extends": "Plugin",
+      "members": ["onload", "onunload"]
+    }
+  ]
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,12 +7,29 @@
 ```bash
 pnpm run build          # production build
 pnpm run dev            # watch mode with CDP hot-reload
-pnpm exec vitest run         # run tests
+pnpm exec vitest run    # run tests
 ```
 
 - **Output**: esbuild outputs `main.js` to repo root. `manifest.json` and `styles.css` already at repo root.
 - **Vault link**: `.obsidian/plugins/work-terminal` is a symlink to this repo directory. No copy step.
 - When packaging or distributing the plugin, keep `pty-wrapper.py` in the plugin directory alongside `main.js`, `manifest.json`, and `styles.css`.
+
+## Running Fallow
+
+Use Fallow for dead code, duplication, and complexity scans:
+
+```bash
+npx fallow --quiet
+npx fallow --summary
+npx fallow dead-code --format json
+```
+
+The repo's `.fallowrc.json` suppresses known project-specific false positives so the report stays actionable:
+
+- `src/main.ts` and `cdp.js` are treated as manual entry points
+- `styles.css` is treated as a runtime-loaded asset
+- Obsidian lifecycle overrides like `Modal.onOpen()`, `Modal.onClose()`, `ItemView.getViewType()`, `ItemView.getIcon()`, `ItemView.getDisplayText()`, `ItemView.onOpen()`, `ItemView.onClose()`, `Plugin.onload()`, and `Plugin.onunload()` are treated as framework-used members
+- `src/__mocks__/**` exports are ignored because Vitest consumes them indirectly
 
 ## Hot reload
 


### PR DESCRIPTION
## Summary
- add a repo `.fallowrc.json` for the Work Terminal and Obsidian runtime conventions that static analysis cannot infer
- suppress false positives for `src/main.ts`, `cdp.js`, `styles.css`, `src/__mocks__/**`, and Obsidian lifecycle overrides on `Modal`, `ItemView`, and `Plugin` subclasses
- document the local Fallow workflow in `docs/development.md`

## Fallow results
Before (`npx fallow --summary`):
- 91 dead-code issues total
- 5 unused files
- 40 unused class members

After:
- 57 dead-code issues total
- 2 unused files
- 18 unused class members

This removes the known false positives from issue #506 and leaves the remaining findings visible for follow-up cleanup.

## Validation
- `pnpm run build`
- `pnpm exec vitest run`
- `npx fallow --summary`

Fixes #506
