### PR TITLE
Add parent/sub-task task support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ GitHub release notes should mirror these entries rather than pasting the raw aut
 
 ## [Unreleased]
 
+### Improvements
+- **Added first-class parent/sub-task support for task files.** Task cards now offer **Create Sub-task...**, child files get explicit readable `sub-task`/`parent` frontmatter, useful parent metadata is inherited at creation time, sub-tasks render indented under their parent when they appear in the same section, and agent profile templates can reference parent context with `$parentTitle`, `$parentId`, `$parentFilePath`, and `$parentAbsoluteFilePath`. (#508)
+
 ### Fixes
 - **Split Task and Retry Enrichment now respect the configured Default terminal CWD.** These actions previously launched Claude in the parent folder of the task file (inside the vault), silently overriding the user's `core.defaultTerminalCwd` setting and any global working-directory configuration. Cwd resolution now delegates to the same path every other profile-driven launch uses (`profile.defaultCwd` -> `core.defaultTerminalCwd` -> `~`). The split-scope prompt already contains absolute paths for both task files, so Claude can resolve them from any cwd. (#504)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ GitHub release notes should mirror these entries rather than pasting the raw aut
 - **Added first-class parent/sub-task support for task files.** Task cards now offer **Create Sub-task...**, child files get explicit readable `sub-task`/`parent` frontmatter, useful parent metadata is inherited at creation time, sub-tasks render indented under their parent when they appear in the same section, and agent profile templates can reference parent context with `$parentTitle`, `$parentId`, `$parentFilePath`, and `$parentAbsoluteFilePath`. (#508)
 
 ### Fixes
+- **Create Sub-task now uses the task's real state from Activity view.** Activity recency buckets such as `recent` are no longer written as task state/tag metadata, and dynamic/custom states no longer silently fall back to the `todo` folder when a safer folder can be resolved. (#508)
 - **Split Task and Retry Enrichment now respect the configured Default terminal CWD.** These actions previously launched Claude in the parent folder of the task file (inside the vault), silently overriding the user's `core.defaultTerminalCwd` setting and any global working-directory configuration. Cwd resolution now delegates to the same path every other profile-driven launch uses (`profile.defaultCwd` -> `core.defaultTerminalCwd` -> `~`). The split-scope prompt already contains absolute paths for both task files, so Claude can resolve them from any cwd. (#504)
 
 ## [0.5.2] - 2026-04-27

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -38,6 +38,7 @@ Work Terminal turns your Obsidian vault into a work item board with per-item tab
   - [Core settings](#core-settings)
 - [Advanced features](#advanced-features)
   - [Pinning tasks](#pinning-tasks)
+  - [Parent tasks and sub-tasks](#parent-tasks-and-sub-tasks)
   - [Task splitting](#task-splitting)
   - [Guided tour](#guided-tour)
   - [Debug API](#debug-api)
@@ -205,6 +206,7 @@ Right-click any task card to open the context menu with these options:
 - **Move to Top** - moves the card to the top of its current column
 - **Retry Enrichment** - re-runs background enrichment (shown only when enrichment previously failed)
 - **Split Task** - creates a new task linked to this one and opens a Claude session to scope it
+- **Create Sub-task...** - prompts for a focused area, then creates a normal child task with explicit parent frontmatter
 - **Move to [column]** - moves the task to a different column (Priority, Active, To Do, Done, or any dynamic columns)
 - **Done & Close Sessions** - moves to Done and closes all terminal sessions for this task
 - **Copy Name** - copies the task title to clipboard
@@ -414,6 +416,10 @@ The per-profile **Context prompt** field is the place to configure additional co
 | `$state` | Work item state (e.g. "priority", "active") |
 | `$filePath` | Vault-relative file path |
 | `$absoluteFilePath` | Fully resolved absolute filesystem path (useful for agents that need to read files directly) |
+| `$parentTitle` | Parent task title for sub-tasks, otherwise empty |
+| `$parentId` | Parent task UUID for sub-tasks, otherwise empty |
+| `$parentFilePath` | Parent task vault-relative file path for sub-tasks, otherwise empty |
+| `$parentAbsoluteFilePath` | Parent task absolute filesystem path when resolvable, otherwise the parent vault-relative path or empty |
 | `$id` | Work item UUID |
 | `$sessionId` | Agent session ID (assigned at launch) |
 | `$workTerminalPrompt` | The fully assembled context prompt (only meaningful in arguments, not in the context template itself) |
@@ -586,15 +592,32 @@ In **standard mode**, pinned cards show a state label badge (e.g. "Active", "To 
 
 Pinned state is persisted across sessions using the task's UUID, so it survives file renames and moves.
 
+### Parent tasks and sub-tasks
+
+Use **Create Sub-task...** from a task card's context menu to break a task into a focused child task without losing the relationship to the parent. The flow asks what area the child should focus on, creates a new task file in the same state column, and writes explicit frontmatter such as:
+
+```yaml
+sub-task: true
+parent:
+  id: parent-task-uuid
+  title: Parent task title
+  path: 2 - Areas/Tasks/active/TASK-parent.md
+  link: "[[TASK-parent|Parent task title]]"
+```
+
+Sub-tasks are normal tasks: they can be selected, moved between states, pinned, reordered, filtered, enriched, and given terminal sessions like any other task. When a parent and child appear in the same rendered section, the child is shown indented under the parent. If the child is in a different state (or only the child matches the current filter/view), it appears as a normal top-level card in that section so its workflow remains independent.
+
+New sub-tasks inherit useful context from their parent at creation time: non-state tags, source metadata, deadline/impact/blocker fields, and the focus area as the initial goal. Agent profile templates can use `$parentTitle`, `$parentId`, `$parentFilePath`, and `$parentAbsoluteFilePath` to include parent context when launching sessions for sub-tasks.
+
 ### Task splitting
 
 Split a complex task into smaller pieces using the **Split Task** context menu option. This:
 
 1. Creates a new task file with a reference back to the original task
 2. Places the new task in the specified column
-3. Launches a Claude session scoped to the new sub-task
+3. Launches a Claude session scoped to the new split task
 
-The split task includes metadata linking it to the parent task, making it easy to trace the relationship.
+Split Task remains available for agent-assisted scoping. For a direct parent/child relationship that creates the child immediately from a user-provided focus area, use **Create Sub-task...** instead.
 
 The Claude session launched by Split Task runs through the same agent-profile pipeline as the **Claude (ctx)** tab bar button. This means the session inherits your configured command, arguments, login-shell wrapping, working directory, and any custom profile flags (e.g. `--dangerously-skip-permissions`, `--allowedTools`, `--model`). The working directory resolves as `profile.defaultCwd` (if set) -> the global **Default terminal CWD** (Settings > Terminal) -> `~`, the same chain every other profile-driven launch uses. Both file paths in the split scope prompt are passed as absolute paths, so the session does not need to start in the task folder to resolve them. To override the profile for Split Task specifically, see [Agent actions settings](#agent-actions-settings).
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -607,7 +607,7 @@ parent:
 
 Sub-tasks are normal tasks: they can be selected, moved between states, pinned, reordered, filtered, enriched, and given terminal sessions like any other task. When a parent and child appear in the same rendered section, the child is shown indented under the parent. If the child is in a different state (or only the child matches the current filter/view), it appears as a normal top-level card in that section so its workflow remains independent.
 
-New sub-tasks inherit useful context from their parent at creation time: non-state tags, source metadata, deadline/impact/blocker fields, and the focus area as the initial goal. Agent profile templates can use `$parentTitle`, `$parentId`, `$parentFilePath`, and `$parentAbsoluteFilePath` to include parent context when launching sessions for sub-tasks.
+New sub-tasks inherit useful context from their parent at creation time: non-state tags, source metadata, deadline/impact/blocker fields, and the focus area as the initial goal. When created from Activity view, the sub-task uses the parent's real task state rather than the activity recency bucket. Agent profile templates can use `$parentTitle`, `$parentId`, `$parentFilePath`, and `$parentAbsoluteFilePath` to include parent context when launching sessions for sub-tasks.
 
 ### Task splitting
 

--- a/src/adapters/task-agent/BackgroundEnrich.test.ts
+++ b/src/adapters/task-agent/BackgroundEnrich.test.ts
@@ -20,6 +20,7 @@ vi.mock("./EnrichmentLogger", () => ({
 
 import {
   handleItemCreated,
+  handleSubTaskCreated,
   insertIngestionFailedFlag,
   prepareRetryEnrichment,
   findFileByUuid,
@@ -986,6 +987,84 @@ describe("BackgroundEnrich", () => {
       await result.enrichmentDone;
 
       expect(writeEnrichmentLogMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("handleSubTaskCreated", () => {
+    function makeSubTaskApp(existingFolders: string[] = []) {
+      const existingPaths = new Set(existingFolders);
+      const createdFolders: string[] = [];
+      const createdFiles: Array<{ path: string; content: string }> = [];
+
+      return {
+        vault: {
+          adapter: {
+            exists: vi.fn().mockResolvedValue(false),
+          },
+          getAbstractFileByPath(path: string) {
+            return existingPaths.has(path) ? { path } : null;
+          },
+          async createFolder(path: string) {
+            existingPaths.add(path);
+            createdFolders.push(path);
+            return { path };
+          },
+          async create(path: string, content: string) {
+            existingPaths.add(path);
+            createdFiles.push({ path, content });
+            return { path, content };
+          },
+        },
+        createdFolders,
+        createdFiles,
+      } as any;
+    }
+
+    it("uses a resolved folder mapping for custom sub-task states", async () => {
+      const app = makeSubTaskApp();
+
+      await handleSubTaskCreated(
+        app,
+        {
+          id: "parent-id",
+          title: "Parent task",
+          path: "2 - Areas/Tasks/todo/parent.md",
+          filename: "parent.md",
+          tags: ["task", "task/todo", "jira/ABC-123"],
+        },
+        "Review contract",
+        "blocked",
+        "2 - Areas/Tasks",
+        "blocked-work",
+      );
+
+      expect(app.createdFolders).toEqual(["2 - Areas/Tasks/blocked-work"]);
+      expect(app.createdFiles[0].path).toContain("2 - Areas/Tasks/blocked-work/");
+      expect(app.createdFiles[0].content).toContain("state: blocked");
+      expect(app.createdFiles[0].content).toContain("  - task/blocked");
+      expect(app.createdFiles[0].content).toContain("  - jira/ABC-123");
+    });
+
+    it("falls back to the parent folder for dynamic states without a folder mapping", async () => {
+      const app = makeSubTaskApp(["2 - Areas/Tasks/custom-folder"]);
+
+      await handleSubTaskCreated(
+        app,
+        {
+          id: "parent-id",
+          title: "Parent task",
+          path: "2 - Areas/Tasks/custom-folder/parent.md",
+          filename: "parent.md",
+        },
+        "Investigate API",
+        "needs-review",
+        "2 - Areas/Tasks",
+      );
+
+      expect(app.createdFolders).toEqual([]);
+      expect(app.createdFiles[0].path).toContain("2 - Areas/Tasks/custom-folder/");
+      expect(app.createdFiles[0].content).toContain("state: needs-review");
+      expect(app.createdFiles[0].content).toContain("  - task/needs-review");
     });
   });
 

--- a/src/adapters/task-agent/BackgroundEnrich.ts
+++ b/src/adapters/task-agent/BackgroundEnrich.ts
@@ -4,10 +4,20 @@ import {
   spawnHeadlessAgent,
   DEFAULT_TIMEOUT_MS,
 } from "../../core/claude/HeadlessClaude";
-import { generateTaskContent, generatePendingFilename } from "./TaskFileTemplate";
+import {
+  generateTaskContent,
+  generatePendingFilename,
+  generateTaskFilename,
+} from "./TaskFileTemplate";
 import type { SplitSource, EnrichmentMeta } from "./TaskFileTemplate";
 import { expandTilde } from "../../core/utils";
-import { STATE_FOLDER_MAP, type KanbanColumn } from "./types";
+import {
+  STATE_FOLDER_MAP,
+  type KanbanColumn,
+  type TaskParent,
+  type TaskPriority,
+  type TaskSource,
+} from "./types";
 import { writeEnrichmentLog, type EnrichmentLogParams } from "./EnrichmentLogger";
 
 /**
@@ -399,6 +409,16 @@ export async function handleItemCreated(
   return { id, columnId, enrichmentDone };
 }
 
+export interface SubTaskParentSource {
+  id: string;
+  title: string;
+  path: string;
+  filename: string;
+  source?: TaskSource;
+  priority?: TaskPriority;
+  tags?: string[];
+}
+
 export async function handleSplitTaskCreated(
   app: App,
   title: string,
@@ -422,6 +442,82 @@ export async function handleSplitTaskCreated(
   console.log(`[work-terminal] Split task created: ${filePath} (from ${splitFrom.filename})`);
 
   return { path: filePath, id };
+}
+
+export async function handleSubTaskCreated(
+  app: App,
+  parent: SubTaskParentSource,
+  focus: string,
+  columnId: KanbanColumn,
+  basePath: string,
+): Promise<{ path: string; id: string; title: string }> {
+  const id = crypto.randomUUID();
+  const title = focus.trim();
+  const folderName = STATE_FOLDER_MAP[columnId] || "todo";
+  const folderPath = `${basePath}/${folderName}`;
+  const filePath = await resolveAvailableTaskPath(app, folderPath, title);
+  const parentTitle = parent.title.trim() || parent.filename.replace(/\.md$/, "");
+  const parentLinkTitle = parentTitle.replace(/]/g, "");
+  const parentReference: TaskParent = {
+    id: parent.id,
+    title: parentTitle,
+    path: parent.path,
+    link: `[[${parent.filename.replace(/\.md$/, "")}|${parentLinkTitle}]]`,
+  };
+
+  const inheritedTags = Array.from(
+    new Set([
+      "task",
+      `task/${columnId}`,
+      "sub-task",
+      ...(parent.tags || []).filter(
+        (tag) => tag !== "task" && !tag.startsWith("task/") && tag !== "sub-task",
+      ),
+    ]),
+  );
+
+  const inheritedPriority: Partial<TaskPriority> = parent.priority
+    ? {
+        deadline: parent.priority.deadline,
+        impact: parent.priority.impact,
+        "has-blocker": parent.priority["has-blocker"],
+        "blocker-context": parent.priority["blocker-context"],
+      }
+    : {};
+
+  const content = generateTaskContent(title, columnId, undefined, id, undefined, {
+    parent: parentReference,
+    tags: inheritedTags,
+    source: parent.source,
+    priority: inheritedPriority,
+    goal: [focus.trim()],
+  });
+
+  const folder = app.vault.getAbstractFileByPath(folderPath);
+  if (!folder) {
+    await app.vault.createFolder(folderPath);
+  }
+
+  await app.vault.create(filePath, content);
+  console.log(`[work-terminal] Sub-task created: ${filePath} (parent ${parent.path})`);
+
+  return { path: filePath, id, title };
+}
+
+async function resolveAvailableTaskPath(
+  app: App,
+  folderPath: string,
+  title: string,
+): Promise<string> {
+  const filename = generateTaskFilename(title);
+  const initialPath = `${folderPath}/${filename}`;
+  if (!(await app.vault.adapter.exists(initialPath))) {
+    return initialPath;
+  }
+
+  const suffix = crypto.randomUUID().slice(0, 8);
+  const uniqueFilename = filename.replace(/\.md$/, `-${suffix}.md`);
+  return `${folderPath}/${uniqueFilename}`;
 }
 
 const INGESTION_FAILED_NOTE =

--- a/src/adapters/task-agent/BackgroundEnrich.ts
+++ b/src/adapters/task-agent/BackgroundEnrich.ts
@@ -448,13 +448,13 @@ export async function handleSubTaskCreated(
   app: App,
   parent: SubTaskParentSource,
   focus: string,
-  columnId: KanbanColumn,
+  columnId: string,
   basePath: string,
+  resolvedFolderName?: string | null,
 ): Promise<{ path: string; id: string; title: string }> {
   const id = crypto.randomUUID();
   const title = focus.trim();
-  const folderName = STATE_FOLDER_MAP[columnId] || "todo";
-  const folderPath = `${basePath}/${folderName}`;
+  const folderPath = resolveSubTaskFolderPath(parent, columnId, basePath, resolvedFolderName);
   const filePath = await resolveAvailableTaskPath(app, folderPath, title);
   const parentTitle = parent.title.trim() || parent.filename.replace(/\.md$/, "");
   const parentLinkTitle = parentTitle.replace(/]/g, "");
@@ -502,6 +502,23 @@ export async function handleSubTaskCreated(
   console.log(`[work-terminal] Sub-task created: ${filePath} (parent ${parent.path})`);
 
   return { path: filePath, id, title };
+}
+
+function resolveSubTaskFolderPath(
+  parent: SubTaskParentSource,
+  columnId: string,
+  basePath: string,
+  resolvedFolderName?: string | null,
+): string {
+  const folderName = resolvedFolderName || STATE_FOLDER_MAP[columnId as KanbanColumn];
+  if (folderName) {
+    return `${basePath}/${folderName}`;
+  }
+
+  const parentFolder = parent.path.includes("/")
+    ? parent.path.substring(0, parent.path.lastIndexOf("/"))
+    : "";
+  return parentFolder || basePath;
 }
 
 async function resolveAvailableTaskPath(

--- a/src/adapters/task-agent/TaskCard.ts
+++ b/src/adapters/task-agent/TaskCard.ts
@@ -437,6 +437,13 @@ export class TaskCard implements CardRenderer {
       callback: () => ctx.onSplitTask(item),
     });
 
+    if (ctx.onCreateSubTask) {
+      (items as any[]).push({
+        title: "Create Sub-task...",
+        callback: () => ctx.onCreateSubTask?.(item),
+      });
+    }
+
     (items as any[]).push({ separator: true });
 
     // Move to other columns

--- a/src/adapters/task-agent/TaskFileTemplate.test.ts
+++ b/src/adapters/task-agent/TaskFileTemplate.test.ts
@@ -108,6 +108,37 @@ describe("generateTaskContent", () => {
     expect(content).not.toContain('related: []\n  - "[[TASK-20260327-1200-source-task]]"');
   });
 
+  it("writes explicit readable parent frontmatter for sub-tasks", () => {
+    const content = generateTaskContent("Auth tests", "todo", undefined, "child-id", undefined, {
+      parent: {
+        id: "parent-id",
+        title: "Parent Task",
+        path: "2 - Areas/Tasks/active/TASK-parent.md",
+        link: "[[TASK-parent|Parent Task]]",
+      },
+      tags: ["task", "task/todo", "sub-task", "jira/ABC-123"],
+      source: { type: "jira", id: "ABC-123", url: "https://jira/ABC-123", captured: "ABC-123" },
+      priority: {
+        deadline: "2026-06-01",
+        impact: "high",
+        "has-blocker": true,
+        "blocker-context": "Waiting",
+      },
+      goal: ["Auth tests"],
+    });
+
+    expect(content).toContain("sub-task: true");
+    expect(content).toContain("parent:\n  id: parent-id");
+    expect(content).toContain("  title: Parent Task");
+    expect(content).toContain("  path: 2 - Areas/Tasks/active/TASK-parent.md");
+    expect(content).toContain('  link: "[[TASK-parent|Parent Task]]"');
+    expect(content).toContain("  - sub-task");
+    expect(content).toContain("source:\n  type: jira");
+    expect(content).toContain("deadline: 2026-06-01");
+    expect(content).toContain("goal:\n  - Auth tests");
+    expect(content).toContain('related:\n  - "[[TASK-parent|Parent Task]]"');
+  });
+
   it("includes enrichment block when enrichment metadata is provided", () => {
     const content = generateTaskContent("Test", "todo", undefined, "test-id", {
       profile: "pi",

--- a/src/adapters/task-agent/TaskFileTemplate.ts
+++ b/src/adapters/task-agent/TaskFileTemplate.ts
@@ -1,9 +1,17 @@
 import { slugify, yamlQuoteValue } from "../../core/utils";
-import type { KanbanColumn } from "./types";
+import type { KanbanColumn, TaskParent, TaskPriority, TaskSource } from "./types";
 
 export interface SplitSource {
   filename: string;
   title: string;
+}
+
+export interface TaskContentOptions {
+  parent?: TaskParent;
+  tags?: string[];
+  source?: Partial<TaskSource>;
+  priority?: Partial<TaskPriority>;
+  goal?: string[];
 }
 
 /** Enrichment metadata to embed in the task file frontmatter. */
@@ -21,6 +29,7 @@ export function generateTaskContent(
   splitFrom?: SplitSource,
   existingId?: string,
   enrichment?: EnrichmentMeta,
+  options: TaskContentOptions = {},
 ): string {
   const id = existingId || crypto.randomUUID();
   const now = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
@@ -29,19 +38,48 @@ export function generateTaskContent(
   // Quote the title to handle special characters in YAML
   const safeTitle = `"${title.replace(/"/g, '\\"')}"`;
 
-  const relatedField = splitFrom
-    ? `related:\n  - "[[${splitFrom.filename.replace(/\.md$/, "")}]]"`
-    : "related: []";
-  const activitySuffix = splitFrom
-    ? ` (split from [[${splitFrom.filename.replace(/\.md$/, "")}]])`
-    : "";
+  const parentLink =
+    options.parent?.link || (splitFrom ? `[[${splitFrom.filename.replace(/\.md$/, "")}]]` : "");
+  const relatedField = parentLink ? `related:\n  - ${yamlQuoteValue(parentLink)}` : "related: []";
+  const activitySuffix = options.parent
+    ? ` (sub-task of ${options.parent.link || options.parent.title})`
+    : splitFrom
+      ? ` (split from [[${splitFrom.filename.replace(/\.md$/, "")}]])`
+      : "";
 
   // Quote a YAML string value, escaping embedded quotes
   const yamlQuote = (s: string): string =>
     `"${s.replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/"/g, '\\"')}"`;
 
   const safeState = yamlQuoteValue(state);
-  const safeTagState = yamlQuoteValue(`task/${state}`);
+  const taskTags =
+    options.tags && options.tags.length > 0 ? options.tags : ["task", `task/${state}`];
+  const tagsSection = taskTags.map((tag) => `  - ${yamlQuoteValue(tag)}`).join("\n");
+  const parentSection = options.parent
+    ? `sub-task: true\n` +
+      `parent:\n` +
+      `  id: ${yamlQuoteValue(options.parent.id)}\n` +
+      `  title: ${yamlQuoteValue(options.parent.title)}\n` +
+      `  path: ${yamlQuoteValue(options.parent.path)}\n` +
+      `  link: ${yamlQuoteValue(options.parent.link)}\n`
+    : "";
+
+  const source = {
+    type: options.source?.type || "prompt",
+    id: options.source?.id ?? (splitFrom ? `split-${now.replace(/[:.]/g, "")}` : ""),
+    url: options.source?.url ?? "",
+    captured: options.source?.captured ?? now,
+  };
+  const priority = {
+    score: options.priority?.score ?? 0,
+    deadline: options.priority?.deadline ?? "",
+    impact: options.priority?.impact ?? "medium",
+    "has-blocker": options.priority?.["has-blocker"] ?? false,
+    "blocker-context": options.priority?.["blocker-context"] ?? "",
+  };
+  const goal = options.goal ?? [];
+  const goalSection =
+    goal.length > 0 ? `\n${goal.map((entry) => `  - ${yamlQuoteValue(entry)}`).join("\n")}` : " []";
 
   const enrichmentSection = enrichment
     ? `enrichment:\n` +
@@ -55,25 +93,24 @@ export function generateTaskContent(
   return `---
 id: ${id}
 tags:
-  - task
-  - ${safeTagState}
+${tagsSection}
 state: ${safeState}
 title: ${safeTitle}
 source:
-  type: prompt
-  id: "${splitFrom ? `split-${now.replace(/[:.]/g, "")}` : ""}"
-  url: ""
-  captured: ${now}
+  type: ${yamlQuoteValue(source.type)}
+  id: ${yamlQuoteValue(source.id)}
+  url: ${yamlQuoteValue(source.url)}
+  captured: ${yamlQuoteValue(source.captured)}
 priority:
-  score: 0
-  deadline: ""
-  impact: medium
-  has-blocker: false
-  blocker-context: ""
+  score: ${priority.score}
+  deadline: ${yamlQuoteValue(priority.deadline)}
+  impact: ${yamlQuoteValue(priority.impact)}
+  has-blocker: ${priority["has-blocker"]}
+  blocker-context: ${yamlQuoteValue(priority["blocker-context"])}
 agent-actionable: false
-goal: []
+goal:${goalSection}
 ${relatedField}
-${enrichmentSection ? enrichmentSection + (enrichmentSection.endsWith("\n") ? "" : "\n") : ""}created: ${now}
+${parentSection}${enrichmentSection ? enrichmentSection + (enrichmentSection.endsWith("\n") ? "" : "\n") : ""}created: ${now}
 updated: ${now}
 ---
 # ${title}

--- a/src/adapters/task-agent/TaskFileTemplate.ts
+++ b/src/adapters/task-agent/TaskFileTemplate.ts
@@ -1,5 +1,5 @@
 import { slugify, yamlQuoteValue } from "../../core/utils";
-import type { KanbanColumn, TaskParent, TaskPriority, TaskSource } from "./types";
+import type { TaskParent, TaskPriority, TaskSource } from "./types";
 
 export interface SplitSource {
   filename: string;
@@ -25,7 +25,7 @@ export interface EnrichmentMeta {
 
 export function generateTaskContent(
   title: string,
-  state: KanbanColumn,
+  state: string,
   splitFrom?: SplitSource,
   existingId?: string,
   enrichment?: EnrichmentMeta,

--- a/src/adapters/task-agent/TaskParser.test.ts
+++ b/src/adapters/task-agent/TaskParser.test.ts
@@ -754,6 +754,36 @@ describe("TaskParser", () => {
         state: "todo",
       });
     });
+
+    it("indexes parent IDs once per load instead of rescanning for each sub-task", async () => {
+      const parent = makeFile("2 - Areas/Tasks/active/parent.md");
+      const childA = makeFile("2 - Areas/Tasks/active/child-a.md");
+      const childB = makeFile("2 - Areas/Tasks/active/child-b.md");
+      const app = mockApp([parent, childA, childB], {
+        [parent.path]: makeFrontmatter({ id: "parent-uuid", title: "Resolved Parent" }),
+        [childA.path]: makeFrontmatter({
+          id: "child-a",
+          parent: { id: "parent-uuid", title: "Parent" },
+        }),
+        [childB.path]: makeFrontmatter({
+          id: "child-b",
+          parent: { id: "parent-uuid", title: "Parent" },
+        }),
+      });
+      const getMarkdownFiles = vi.spyOn(app.vault, "getMarkdownFiles");
+      const parser = new TaskParser(app, "", defaultSettings);
+
+      const items = await parser.loadAll();
+
+      expect(items).toHaveLength(3);
+      expect(getMarkdownFiles).toHaveBeenCalledTimes(5);
+      expect((items.find((item) => item.id === "child-a")!.metadata as any).parent.path).toBe(
+        parent.path,
+      );
+      expect((items.find((item) => item.id === "child-b")!.metadata as any).parent.path).toBe(
+        parent.path,
+      );
+    });
   });
 
   describe("backfillItemId", () => {

--- a/src/adapters/task-agent/TaskParser.test.ts
+++ b/src/adapters/task-agent/TaskParser.test.ts
@@ -153,6 +153,35 @@ describe("TaskParser", () => {
       expect(item!.title).toBe("my-task");
     });
 
+    it("parses parent frontmatter and marks sub-tasks", () => {
+      const parent = makeFile("2 - Areas/Tasks/active/parent.md");
+      const child = makeFile("2 - Areas/Tasks/active/child.md");
+      const app = mockApp([parent, child], {
+        [parent.path]: makeFrontmatter({ id: "parent-uuid", title: "Resolved Parent" }),
+        [child.path]: makeFrontmatter({
+          id: "child-uuid",
+          title: "Child Task",
+          "sub-task": true,
+          parent: {
+            id: "parent-uuid",
+            title: "Stored Parent",
+            path: "old/path.md",
+            link: "[[parent|Stored Parent]]",
+          },
+        }),
+      });
+      const parser = new TaskParser(app, "", defaultSettings);
+      const item = parser.parse(child as unknown as TFile);
+
+      expect((item!.metadata as any).isSubTask).toBe(true);
+      expect((item!.metadata as any).parent).toEqual({
+        id: "parent-uuid",
+        title: "Stored Parent",
+        path: parent.path,
+        link: "[[parent|Stored Parent]]",
+      });
+    });
+
     it("uses file.path as the ID when frontmatter id is missing", () => {
       const file = makeFile("2 - Areas/Tasks/active/task-without-id.md");
       const app = mockApp([file], {

--- a/src/adapters/task-agent/TaskParser.ts
+++ b/src/adapters/task-agent/TaskParser.ts
@@ -3,6 +3,7 @@ import type { WorkItem, WorkItemParser, StateResolver } from "../../core/interfa
 import { extractYamlFrontmatterString } from "../../core/frontmatter";
 import {
   type TaskFile,
+  type TaskParent,
   type TaskPriority,
   type TaskSource,
   type TaskState,
@@ -58,6 +59,8 @@ export class TaskParser implements WorkItemParser {
     const priority = this.resolvePriority(fm);
     const tags = this.normaliseTags(fm.tags);
     const goal: string[] = Array.isArray(fm.goal) ? fm.goal : fm.goal ? [fm.goal] : [];
+    const parent = this.resolveParent(fm);
+    const isSubTask = fm["sub-task"] === true || fm.subtask === true || !!parent;
 
     const bgIngestion = fm["background-ingestion"];
     const backgroundIngestion =
@@ -74,6 +77,8 @@ export class TaskParser implements WorkItemParser {
       priority,
       agentActionable: fm["agent-actionable"] ?? false,
       goal,
+      parent,
+      isSubTask,
       color: fm.color || undefined,
       icon: typeof fm.icon === "string" && fm.icon.trim() ? fm.icon.trim() : undefined,
       backgroundIngestion,
@@ -118,6 +123,92 @@ export class TaskParser implements WorkItemParser {
       return [rawTags.trim()];
     }
     return [];
+  }
+
+  private resolveParent(fm: Record<string, any>): TaskParent | undefined {
+    const parentRaw = fm.parent;
+    const flatPath = typeof fm["parent.path"] === "string" ? fm["parent.path"].trim() : "";
+    const flatId = typeof fm["parent.id"] === "string" ? fm["parent.id"].trim() : "";
+    const flatTitle = typeof fm["parent.title"] === "string" ? fm["parent.title"].trim() : "";
+    const flatLink = typeof fm["parent.link"] === "string" ? fm["parent.link"].trim() : "";
+
+    let id = flatId;
+    let title = flatTitle;
+    let path = flatPath;
+    let link = flatLink;
+
+    if (typeof parentRaw === "string") {
+      link = link || parentRaw.trim();
+      title = title || this.extractLinkTitle(parentRaw);
+      path = path || this.extractLinkPath(parentRaw);
+    } else if (parentRaw && typeof parentRaw === "object") {
+      const parent = parentRaw as Record<string, unknown>;
+      id = id || (typeof parent.id === "string" ? parent.id.trim() : "");
+      title = title || (typeof parent.title === "string" ? parent.title.trim() : "");
+      path = path || (typeof parent.path === "string" ? parent.path.trim() : "");
+      link = link || (typeof parent.link === "string" ? parent.link.trim() : "");
+      if (!link && typeof parent.file === "string") {
+        link = parent.file.trim();
+      }
+      if (!path && typeof parent.file === "string") {
+        path = this.extractLinkPath(parent.file);
+      }
+      if (!title && typeof parent.file === "string") {
+        title = this.extractLinkTitle(parent.file);
+      }
+    }
+
+    const resolved = id ? this.findParentById(id) : null;
+    if (resolved) {
+      path = resolved.path;
+      title = title || resolved.title;
+    }
+
+    if (!id && !title && !path && !link) return undefined;
+    if (!link) link = path ? this.buildWikiLink(path, title) : title;
+    if (!title) title = this.extractLinkTitle(link) || this.basenameWithoutExtension(path);
+    if (!path) path = this.extractLinkPath(link);
+
+    return { id, title, path, link };
+  }
+
+  private findParentById(id: string): { path: string; title: string } | null {
+    const normalizedBase = `${this.basePath}/`;
+    for (const file of this.app.vault.getMarkdownFiles()) {
+      if (!file.path.startsWith(normalizedBase)) continue;
+      const cache = this.app.metadataCache.getFileCache(file);
+      if (cache?.frontmatter?.id !== id) continue;
+      return {
+        path: file.path,
+        title:
+          typeof cache.frontmatter.title === "string" && cache.frontmatter.title.trim()
+            ? cache.frontmatter.title.trim()
+            : file.basename,
+      };
+    }
+    return null;
+  }
+
+  private extractLinkTitle(value: string): string {
+    const match = value.match(/^\[\[([^\]|]+)(?:\|([^\]]+))?\]\]$/);
+    if (!match) return "";
+    return (match[2] || this.basenameWithoutExtension(match[1]) || match[1]).trim();
+  }
+
+  private extractLinkPath(value: string): string {
+    const match = value.match(/^\[\[([^\]|]+)(?:\|[^\]]+)?\]\]$/);
+    return match ? match[1].trim() : "";
+  }
+
+  private buildWikiLink(path: string, title: string): string {
+    const basename = this.basenameWithoutExtension(path);
+    if (!basename) return path;
+    return title && title !== basename ? `[[${basename}|${title}]]` : `[[${basename}]]`;
+  }
+
+  private basenameWithoutExtension(path: string): string {
+    const filename = path.split("/").pop() || path;
+    return filename.replace(/\.md$/, "");
   }
 
   private resolvePriority(fm: Record<string, any>): TaskPriority {
@@ -363,6 +454,8 @@ export class TaskParser implements WorkItemParser {
         priority: task.priority,
         agentActionable: task.agentActionable,
         goal: task.goal,
+        parent: task.parent,
+        isSubTask: task.isSubTask,
         color: task.color,
         icon: task.icon,
         backgroundIngestion: task.backgroundIngestion,

--- a/src/adapters/task-agent/TaskParser.ts
+++ b/src/adapters/task-agent/TaskParser.ts
@@ -20,6 +20,7 @@ export class TaskParser implements WorkItemParser {
   private static loggedFallbackPaths = new Set<string>();
   private transientIdsByPath = new Map<string, string>();
   private backfillPromisesByPath = new Map<string, Promise<WorkItem | null>>();
+  private parentIndex: Map<string, { path: string; title: string }> | null = null;
   private stateResolver: StateResolver | null;
 
   constructor(
@@ -173,6 +174,13 @@ export class TaskParser implements WorkItemParser {
   }
 
   private findParentById(id: string): { path: string; title: string } | null {
+    if (this.parentIndex) {
+      return this.parentIndex.get(id) ?? null;
+    }
+    return this.scanParentById(id);
+  }
+
+  private scanParentById(id: string): { path: string; title: string } | null {
     const normalizedBase = `${this.basePath}/`;
     for (const file of this.app.vault.getMarkdownFiles()) {
       if (!file.path.startsWith(normalizedBase)) continue;
@@ -187,6 +195,26 @@ export class TaskParser implements WorkItemParser {
       };
     }
     return null;
+  }
+
+  private buildParentIndex(): Map<string, { path: string; title: string }> {
+    const index = new Map<string, { path: string; title: string }>();
+    const normalizedBase = `${this.basePath}/`;
+    for (const file of this.app.vault.getMarkdownFiles()) {
+      if (!file.path.startsWith(normalizedBase)) continue;
+      const cache = this.app.metadataCache.getFileCache(file);
+      const frontmatter = cache?.frontmatter;
+      const id = typeof frontmatter?.id === "string" ? frontmatter.id.trim() : "";
+      if (!id) continue;
+      index.set(id, {
+        path: file.path,
+        title:
+          typeof frontmatter?.title === "string" && frontmatter.title.trim()
+            ? frontmatter.title.trim()
+            : file.basename,
+      });
+    }
+    return index;
   }
 
   private extractLinkTitle(value: string): string {
@@ -469,20 +497,25 @@ export class TaskParser implements WorkItemParser {
   async loadAll(): Promise<WorkItem[]> {
     const items: WorkItem[] = [];
     const folders = ["priority", "todo", "active", "archive"];
+    this.parentIndex = this.buildParentIndex();
 
-    for (const folder of folders) {
-      const folderPath = `${this.basePath}/${folder}`;
-      const abstractFile = this.app.vault.getAbstractFileByPath(folderPath);
-      if (!abstractFile) continue;
+    try {
+      for (const folder of folders) {
+        const folderPath = `${this.basePath}/${folder}`;
+        const abstractFile = this.app.vault.getAbstractFileByPath(folderPath);
+        if (!abstractFile) continue;
 
-      const files = this.app.vault
-        .getMarkdownFiles()
-        .filter((f) => f.path.startsWith(folderPath + "/") && f.extension === "md");
+        const files = this.app.vault
+          .getMarkdownFiles()
+          .filter((f) => f.path.startsWith(folderPath + "/") && f.extension === "md");
 
-      for (const file of files) {
-        const item = this.parse(file);
-        if (item) items.push(item);
+        for (const file of files) {
+          const item = this.parse(file);
+          if (item) items.push(item);
+        }
       }
+    } finally {
+      this.parentIndex = null;
     }
 
     return items;

--- a/src/adapters/task-agent/TaskPromptBuilder.test.ts
+++ b/src/adapters/task-agent/TaskPromptBuilder.test.ts
@@ -88,6 +88,22 @@ describe("TaskPromptBuilder", () => {
     expect(prompt).toContain("Task: Fix: the 'auth' bug");
   });
 
+  it("includes parent context for sub-tasks", () => {
+    const item = makeItem(
+      {},
+      {
+        parent: {
+          id: "parent-id",
+          title: "Parent task",
+          path: "2 - Areas/Tasks/active/parent.md",
+        },
+      },
+    );
+    const prompt = builder.buildPrompt(item, "/path");
+    expect(prompt).toContain("Parent: Parent task");
+    expect(prompt).toContain("Parent file: 2 - Areas/Tasks/active/parent.md");
+  });
+
   it("handles missing metadata gracefully", () => {
     const item: WorkItem = {
       id: "test",
@@ -107,6 +123,8 @@ describe("TaskPromptBuilder", () => {
     expect(description).toContain("$title");
     expect(description).toContain("$state");
     expect(description).toContain("$filePath");
+    expect(description).toContain("$parentTitle");
+    expect(description).toContain("$parentFilePath");
     expect(description).toContain("$deadline");
     expect(description).toContain("$blocker");
     // Should not regress to older brace-style placeholders.

--- a/src/adapters/task-agent/TaskPromptBuilder.ts
+++ b/src/adapters/task-agent/TaskPromptBuilder.ts
@@ -6,6 +6,17 @@ export class TaskPromptBuilder implements WorkItemPromptBuilder {
     const priority = meta.priority || {};
 
     let prompt = `Task: ${item.title}\nState: ${item.state}\nFile: ${fullPath}`;
+    const parent = meta.parent;
+    if (parent && typeof parent === "object") {
+      const parentTitle = typeof parent.title === "string" ? parent.title : "";
+      const parentPath = typeof parent.path === "string" ? parent.path : "";
+      if (parentTitle) {
+        prompt += `\nParent: ${parentTitle}`;
+      }
+      if (parentPath) {
+        prompt += `\nParent file: ${parentPath}`;
+      }
+    }
 
     if (priority.deadline) {
       prompt += `\nDeadline: ${priority.deadline}`;
@@ -22,6 +33,6 @@ export class TaskPromptBuilder implements WorkItemPromptBuilder {
     // This string is a non-editable descriptor shown in the profile UI, not a
     // user-editable template. It is cosmetic only; `buildPrompt` is the
     // single source of truth for the actual adapter prompt contents.
-    return "Task: $title\nState: $state\nFile: $filePath\nDeadline: $deadline (if set)\nBlocker: $blocker (if set)";
+    return "Task: $title\nState: $state\nFile: $filePath\nParent: $parentTitle (for sub-tasks)\nParent file: $parentFilePath (for sub-tasks)\nDeadline: $deadline (if set)\nBlocker: $blocker (if set)";
   }
 }

--- a/src/adapters/task-agent/index.ts
+++ b/src/adapters/task-agent/index.ts
@@ -263,6 +263,8 @@ export class TaskAgentAdapter extends BaseAdapter {
     if (!trimmedFocus) return null;
 
     const basePath = settings["adapter.taskBasePath"] || "2 - Areas/Tasks";
+    const stateResolver = this.getStateResolver(basePath, settings);
+    const folderName = stateResolver.getFolderForState?.(columnId) ?? null;
     const parentFilename = parentItem.path.split("/").pop() || parentItem.path;
     const meta = (parentItem.metadata || {}) as Record<string, any>;
 
@@ -278,8 +280,9 @@ export class TaskAgentAdapter extends BaseAdapter {
         tags: Array.isArray(meta.tags) ? meta.tags : [],
       },
       trimmedFocus,
-      columnId as KanbanColumn,
+      columnId,
       basePath,
+      folderName,
     );
   }
 

--- a/src/adapters/task-agent/index.ts
+++ b/src/adapters/task-agent/index.ts
@@ -21,6 +21,7 @@ import { resolveDetailViewOptions } from "../../core/detailViewPlacement";
 import {
   handleItemCreated,
   handleSplitTaskCreated,
+  handleSubTaskCreated,
   prepareRetryEnrichment,
   type EnrichmentProfileOverride,
 } from "./BackgroundEnrich";
@@ -247,6 +248,39 @@ export class TaskAgentAdapter extends BaseAdapter {
       filename: sourceFilename,
       title: sourceItem.title,
     });
+  }
+
+  async onCreateSubTask(
+    parentItem: WorkItem,
+    focus: string,
+    columnId: string,
+    settings: Record<string, any>,
+  ): Promise<{ path: string; id: string; title: string } | null> {
+    if (!this._app) {
+      throw new Error("TaskAgentAdapter: app not available (no view opened yet)");
+    }
+    const trimmedFocus = focus.trim();
+    if (!trimmedFocus) return null;
+
+    const basePath = settings["adapter.taskBasePath"] || "2 - Areas/Tasks";
+    const parentFilename = parentItem.path.split("/").pop() || parentItem.path;
+    const meta = (parentItem.metadata || {}) as Record<string, any>;
+
+    return handleSubTaskCreated(
+      this._app,
+      {
+        id: parentItem.id,
+        title: parentItem.title,
+        path: parentItem.path,
+        filename: parentFilename,
+        source: meta.source,
+        priority: meta.priority,
+        tags: Array.isArray(meta.tags) ? meta.tags : [],
+      },
+      trimmedFocus,
+      columnId as KanbanColumn,
+      basePath,
+    );
   }
 
   async getRetryEnrichPrompt(item: WorkItem): Promise<string | null> {

--- a/src/adapters/task-agent/types.ts
+++ b/src/adapters/task-agent/types.ts
@@ -13,6 +13,13 @@ export interface TaskPriority {
   "blocker-context": string;
 }
 
+export interface TaskParent {
+  id: string;
+  title: string;
+  path: string;
+  link: string;
+}
+
 export type TaskState = "priority" | "todo" | "active" | "done" | "abandoned";
 
 /** Known kanban column IDs. Dynamic columns use arbitrary string IDs. */
@@ -30,6 +37,8 @@ export interface TaskFile {
   priority: TaskPriority;
   agentActionable: boolean;
   goal: string[];
+  parent?: TaskParent;
+  isSubTask?: boolean;
   color?: string;
   /** Custom icon - Lucide icon name or emoji string. */
   icon?: string;

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -206,6 +206,8 @@ export interface CardActionContext {
   onInsertAfter(existingId: string, newItem: WorkItem): void;
   /** Split this item: create a new task with a related reference, then spawn Claude (ctx) to scope it. */
   onSplitTask(sourceItem: WorkItem): void;
+  /** Create a child task linked to this item as its parent. */
+  onCreateSubTask?(parentItem: WorkItem): void;
   /** Delete this item (moves to trash). */
   onDelete(): void;
   /** Close all terminal sessions for this item. */
@@ -322,6 +324,17 @@ export interface AdapterBundle {
     settings: Record<string, unknown>,
   ): Promise<{ path: string; id: string } | null>;
   /**
+   * Create a child task linked to an existing parent item. The returned item
+   * remains a normal work item and is rendered nested by the framework when
+   * its parent appears in the same section.
+   */
+  onCreateSubTask?(
+    parentItem: WorkItem,
+    focus: string,
+    columnId: string,
+    settings: Record<string, unknown>,
+  ): Promise<{ path: string; id: string; title: string } | null>;
+  /**
    * Transform a detected agent session rename label before applying it.
    * Called when Claude outputs "Session renamed to: <name>".
    * Return the label to use (default: return detectedLabel unchanged).
@@ -413,6 +426,15 @@ export abstract class BaseAdapter implements AdapterBundle {
     _columnId: string,
     _settings: Record<string, unknown>,
   ): Promise<{ path: string; id: string } | null> {
+    return null;
+  }
+
+  async onCreateSubTask(
+    _parentItem: WorkItem,
+    _focus: string,
+    _columnId: string,
+    _settings: Record<string, unknown>,
+  ): Promise<{ path: string; id: string; title: string } | null> {
     return null;
   }
 

--- a/src/framework/AgentContextPrompt.test.ts
+++ b/src/framework/AgentContextPrompt.test.ts
@@ -78,6 +78,43 @@ describe("expandProfilePlaceholders", () => {
     expect(result).toBe("--task Fix prompt sync --ctx full context here --id task-123");
   });
 
+  it("expands parent placeholders for sub-tasks", () => {
+    const child: WorkItem = {
+      ...item,
+      metadata: {
+        parent: {
+          id: "parent-123",
+          title: "Parent task",
+          path: "2 - Areas/Tasks/active/parent.md",
+        },
+      },
+    };
+
+    const result = expandProfilePlaceholders(
+      "$parentTitle|$parentId|$parentFilePath|$parentAbsoluteFilePath",
+      child,
+      "sess-abc",
+      undefined,
+      "/vault/2 - Areas/Tasks/priority/task.md",
+    );
+
+    expect(result).toBe(
+      "Parent task|parent-123|2 - Areas/Tasks/active/parent.md|/vault/2 - Areas/Tasks/active/parent.md",
+    );
+  });
+
+  it("expands parent placeholders to empty strings for top-level tasks", () => {
+    const result = expandProfilePlaceholders(
+      "$parentTitle|$parentId|$parentFilePath|$parentAbsoluteFilePath",
+      item,
+      "sess-abc",
+      undefined,
+      "/vault/2 - Areas/Tasks/priority/task.md",
+    );
+
+    expect(result).toBe("|||");
+  });
+
   it("returns template unchanged when no placeholders present", () => {
     const result = expandProfilePlaceholders("--verbose --model opus", item, "sess-abc");
     expect(result).toBe("--verbose --model opus");

--- a/src/framework/AgentContextPrompt.ts
+++ b/src/framework/AgentContextPrompt.ts
@@ -52,6 +52,33 @@ function resolveAbsoluteFilePath(item: WorkItem, absolutePath?: string): string 
   return item.path;
 }
 
+function getParentMetadata(item: WorkItem): Record<string, string> | null {
+  const parent = (item.metadata as Record<string, any> | undefined)?.parent;
+  if (!parent || typeof parent !== "object") return null;
+  return {
+    id: typeof parent.id === "string" ? parent.id : "",
+    title: typeof parent.title === "string" ? parent.title : "",
+    path: typeof parent.path === "string" ? parent.path : "",
+  };
+}
+
+function resolveParentAbsoluteFilePath(
+  item: WorkItem,
+  parentPath: string,
+  absolutePath?: string,
+): string {
+  if (!parentPath) return "";
+  if (!absolutePath || !isAbsolutePath(absolutePath)) return parentPath;
+
+  const normalizedAbsolute = absolutePath.replace(/\\/g, "/");
+  const normalizedItemPath = item.path.replace(/\\/g, "/");
+  if (!normalizedAbsolute.endsWith(normalizedItemPath)) return parentPath;
+
+  const base = absolutePath.slice(0, absolutePath.length - item.path.length).replace(/[\\/]$/, "");
+  const separator = absolutePath.includes("\\") ? "\\" : "/";
+  return `${base}${separator}${parentPath.replace(/[\\/]/g, separator)}`;
+}
+
 /**
  * Expand placeholder variables in a profile template string.
  *
@@ -59,6 +86,11 @@ function resolveAbsoluteFilePath(item: WorkItem, absolutePath?: string): string 
  * - $title             - Work item title
  * - $state             - Work item state (e.g. "priority", "active")
  * - $filePath          - Work item file path (vault-relative)
+ * - $parentTitle       - Parent task title for sub-tasks, otherwise ""
+ * - $parentId          - Parent task UUID for sub-tasks, otherwise ""
+ * - $parentFilePath    - Parent task file path (vault-relative) for sub-tasks, otherwise ""
+ * - $parentAbsoluteFilePath - Fully resolved absolute filesystem path to the parent task file
+ *                        when available, otherwise the vault-relative parent path or ""
  * - $absoluteFilePath  - Fully resolved absolute filesystem path to the work item file.
  *                        Falls back to the vault-relative `item.path` (with a console warning)
  *                        when no `absoluteFilePath` is supplied.
@@ -80,10 +112,19 @@ export function expandProfilePlaceholders(
 ): string {
   const needsAbsolute = /\$absoluteFilePath/.test(template);
   const absolute = needsAbsolute ? resolveAbsoluteFilePath(item, absoluteFilePath) : item.path;
+  const parent = getParentMetadata(item);
+  const parentPath = parent?.path ?? "";
+  const parentAbsolute = /\$parentAbsoluteFilePath/.test(template)
+    ? resolveParentAbsoluteFilePath(item, parentPath, absoluteFilePath)
+    : parentPath;
 
   return template
     .replace(/\$workTerminalPrompt/g, contextPrompt ?? "")
+    .replace(/\$parentAbsoluteFilePath/g, parentAbsolute)
     .replace(/\$absoluteFilePath/g, absolute)
+    .replace(/\$parentFilePath/g, parentPath)
+    .replace(/\$parentTitle/g, parent?.title ?? "")
+    .replace(/\$parentId/g, parent?.id ?? "")
     .replace(/\$title/g, item.title)
     .replace(/\$state/g, item.state)
     .replace(/\$filePath/g, item.path)

--- a/src/framework/ListPanel.test.ts
+++ b/src/framework/ListPanel.test.ts
@@ -246,6 +246,47 @@ describe("ListPanel", () => {
     dom.window.close();
   });
 
+  it("renders sub-tasks immediately after their parent with nested styling", () => {
+    const { panel } = createListPanel();
+    const parent = makeItem("parent", "Parent");
+    const child: WorkItem = {
+      ...makeItem("child", "Child"),
+      metadata: { parent: { id: "parent", title: "Parent", path: "Tasks/parent.md" } },
+    };
+    const sibling = makeItem("sibling", "Sibling");
+
+    panel.render({ todo: [child, sibling, parent] }, { todo: ["sibling", "parent", "child"] });
+
+    const ids = Array.from(document.querySelectorAll(".wt-card-wrapper")).map((el) =>
+      el.getAttribute("data-item-id"),
+    );
+    expect(ids).toEqual(["sibling", "parent", "child"]);
+    const childEl = document.querySelector('[data-item-id="child"]') as HTMLElement;
+    expect(childEl.classList.contains("wt-card-subtask")).toBe(true);
+    expect(childEl.style.getPropertyValue("--wt-subtask-depth")).toBe("1");
+  });
+
+  it("renders matching sub-tasks as top-level when their parent is filtered out", () => {
+    const { panel, parentEl } = createListPanel();
+    const parent = makeItem("parent", "Unrelated parent");
+    const child: WorkItem = {
+      ...makeItem("child", "Needle child"),
+      metadata: { parent: { id: "parent", title: "Unrelated parent", path: "Tasks/parent.md" } },
+    };
+
+    panel.render({ todo: [parent, child] }, { todo: ["parent", "child"] });
+    const input = parentEl.querySelector(".wt-filter-input") as HTMLInputElement;
+    input.value = "needle";
+    input.dispatchEvent(new window.Event("input"));
+    vi.advanceTimersByTime(100);
+
+    const parentElCard = document.querySelector('[data-item-id="parent"]') as HTMLElement;
+    const childEl = document.querySelector('[data-item-id="child"]') as HTMLElement;
+    expect(parentElCard.style.display).toBe("none");
+    expect(childEl.style.display).toBe("");
+    expect(childEl.classList.contains("wt-card-subtask-orphaned")).toBe(true);
+  });
+
   it("keeps success animation pending until the new card renders", () => {
     const { panel } = createListPanel();
     panel.render({ todo: [] }, {});

--- a/src/framework/ListPanel.test.ts
+++ b/src/framework/ListPanel.test.ts
@@ -94,6 +94,7 @@ function createListPanel(
     mover?: { move: ReturnType<typeof vi.fn> };
     onCustomOrderChange?: ReturnType<typeof vi.fn>;
     onSessionFilterChange?: ReturnType<typeof vi.fn>;
+    onCreateSubTask?: ReturnType<typeof vi.fn>;
     cardClasses?: string[];
     includeMetaRow?: boolean;
     itemName?: string;
@@ -118,6 +119,7 @@ function createListPanel(
       columns,
       creationColumns,
     },
+    onCreateSubTask: options.onCreateSubTask,
   };
 
   const cardRenderer = {
@@ -285,6 +287,33 @@ describe("ListPanel", () => {
     expect(parentElCard.style.display).toBe("none");
     expect(childEl.style.display).toBe("");
     expect(childEl.classList.contains("wt-card-subtask-orphaned")).toBe(true);
+  });
+
+  it("creates sub-tasks from activity sections using the parent task state", async () => {
+    const onCreateSubTask = vi.fn().mockResolvedValue({
+      id: "child",
+      path: "Tasks/active/child.md",
+      title: "Child focus",
+    });
+    const { panel } = createListPanel({
+      columns: [
+        { id: "todo", label: "To Do", folderName: "todo" },
+        { id: "active", label: "Active", folderName: "active" },
+      ],
+      settings: { "core.viewMode": "activity" },
+      onCreateSubTask,
+    });
+    const parent = { ...makeItem("parent", "Parent"), state: "active" };
+
+    panel.render({ active: [parent] }, {});
+    await (panel as any).createSubTask(parent, "recent", "Child focus");
+
+    expect(onCreateSubTask).toHaveBeenCalledWith(
+      parent,
+      "Child focus",
+      "active",
+      expect.any(Object),
+    );
   });
 
   it("keeps success animation pending until the new card renders", () => {

--- a/src/framework/ListPanel.ts
+++ b/src/framework/ListPanel.ts
@@ -3,8 +3,8 @@
  * drag-drop reordering, filtering, selection, session badges, and
  * agent state indicators.
  */
-import { Menu, Notice } from "obsidian";
-import type { Plugin, TFile } from "obsidian";
+import { Menu, Modal, Notice, Setting } from "obsidian";
+import type { App, Plugin, TFile } from "obsidian";
 import type {
   AdapterBundle,
   WorkItem,
@@ -32,6 +32,66 @@ import {
 
 /** Virtual column ID for the pinned section. Not a real adapter column. */
 const PINNED_COLUMN_ID = "__pinned__";
+
+class SubTaskFocusModal extends Modal {
+  private value = "";
+
+  constructor(
+    app: App,
+    private parentTitle: string,
+    private onSubmit: (focus: string) => void,
+  ) {
+    super(app);
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.createEl("h2", { text: "Create sub-task" });
+    contentEl.createEl("p", {
+      text: `What area of “${this.parentTitle}” should this sub-task focus on?`,
+    });
+
+    const input = contentEl.createEl("textarea", {
+      cls: "wt-subtask-focus-input",
+      attr: { rows: "4", placeholder: "Describe the focused area or outcome..." },
+    });
+    input.addEventListener("input", () => {
+      this.value = input.value;
+    });
+    input.addEventListener("keydown", (event) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+        event.preventDefault();
+        this.submit();
+      }
+    });
+
+    new Setting(contentEl)
+      .addButton((button) =>
+        button.setButtonText("Cancel").onClick(() => {
+          this.close();
+        }),
+      )
+      .addButton((button) =>
+        button
+          .setButtonText("Create sub-task")
+          .setCta()
+          .onClick(() => this.submit()),
+      );
+
+    input.focus();
+  }
+
+  private submit(): void {
+    const focus = this.value.trim();
+    if (!focus) {
+      new Notice("Enter a focus area for the sub-task");
+      return;
+    }
+    this.close();
+    this.onSubmit(focus);
+  }
+}
 
 export class ListPanel {
   private containerEl: HTMLElement;
@@ -419,15 +479,25 @@ export class ListPanel {
 
     const displayMode = this.getDisplayMode();
 
-    for (const item of items) {
+    const renderedItems = this.orderItemsForNestedRendering(items);
+
+    for (const { item, depth } of renderedItems) {
       // For pinned items, use the pinned column as the visual column
       // but track the real column for move operations
       const effectiveColumn = isPinnedSection ? PINNED_COLUMN_ID : columnId;
       const ctx = this.buildCardActionContext(item, effectiveColumn);
       const cardEl = this.cardRenderer.render(item, ctx, displayMode);
       cardEl.addClass("wt-card-wrapper");
+      if (depth > 0) {
+        cardEl.addClass("wt-card-subtask");
+        cardEl.style.setProperty("--wt-subtask-depth", String(Math.min(depth, 4)));
+      }
       cardEl.setAttribute("data-item-id", item.id);
       cardEl.setAttribute("draggable", "true");
+      const parentId = this.getParentId(item);
+      if (parentId) {
+        cardEl.setAttribute("data-parent-id", parentId);
+      }
 
       // State badge for pinned items - shows the real column/state
       if (isPinnedSection) {
@@ -516,6 +586,60 @@ export class ListPanel {
     }
   }
 
+  private orderItemsForNestedRendering(
+    items: WorkItem[],
+  ): Array<{ item: WorkItem; depth: number }> {
+    const itemIds = new Set(items.map((item) => item.id));
+    const childrenByParent = new Map<string, WorkItem[]>();
+    const roots: WorkItem[] = [];
+
+    for (const item of items) {
+      const parentId = this.getParentId(item);
+      if (parentId && itemIds.has(parentId) && parentId !== item.id) {
+        const children = childrenByParent.get(parentId) || [];
+        children.push(item);
+        childrenByParent.set(parentId, children);
+      } else {
+        roots.push(item);
+      }
+    }
+
+    const ordered: Array<{ item: WorkItem; depth: number }> = [];
+    const visiting = new Set<string>();
+    const visited = new Set<string>();
+
+    const append = (item: WorkItem, depth: number) => {
+      if (visited.has(item.id)) return;
+      if (visiting.has(item.id)) {
+        ordered.push({ item, depth: 0 });
+        visited.add(item.id);
+        return;
+      }
+
+      visiting.add(item.id);
+      ordered.push({ item, depth });
+      visited.add(item.id);
+      for (const child of childrenByParent.get(item.id) || []) {
+        append(child, depth + 1);
+      }
+      visiting.delete(item.id);
+    };
+
+    for (const root of roots) {
+      append(root, 0);
+    }
+    for (const item of items) {
+      append(item, 0);
+    }
+
+    return ordered;
+  }
+
+  private getParentId(item: WorkItem): string {
+    const parent = (item.metadata as Record<string, any> | undefined)?.parent;
+    return typeof parent?.id === "string" ? parent.id : "";
+  }
+
   private sortItems(items: WorkItem[], columnId: string): WorkItem[] {
     const order = this.customOrder[columnId] || [];
     if (order.length === 0) return [...items];
@@ -550,6 +674,9 @@ export class ListPanel {
       },
       onSplitTask: (sourceItem: WorkItem) => {
         this.splitTask(sourceItem, currentColumn);
+      },
+      onCreateSubTask: (parentItem: WorkItem) => {
+        this.promptCreateSubTask(parentItem, currentColumn);
       },
       onDelete: () => this.deleteItem(item),
       onCloseSessions: () => this.terminalPanel.closeAllSessions(item.id),
@@ -731,6 +858,72 @@ export class ListPanel {
       console.log(`[work-terminal] Split task created: "${newItem.title}" after ${existingId}`);
     } catch (err) {
       console.error("[work-terminal] Split task creation failed:", err);
+    }
+  }
+
+  private promptCreateSubTask(parentItem: WorkItem, columnId: string): void {
+    new SubTaskFocusModal(this.app, parentItem.title, (focus) => {
+      void this.createSubTask(parentItem, columnId, focus);
+    }).open();
+  }
+
+  private async createSubTask(
+    parentItem: WorkItem,
+    columnId: string,
+    focus: string,
+  ): Promise<void> {
+    const effectiveColumnId = columnId === PINNED_COLUMN_ID ? parentItem.state : columnId;
+    if (!this.adapter.onCreateSubTask) {
+      console.warn("[work-terminal] createSubTask: adapter has no onCreateSubTask");
+      return;
+    }
+
+    try {
+      const result = await this.adapter.onCreateSubTask(
+        parentItem,
+        focus,
+        effectiveColumnId,
+        this.settings,
+      );
+      if (!result) return;
+
+      const existingOrder = this.customOrder[effectiveColumnId] || [];
+      const baseOrder =
+        existingOrder.length > 0
+          ? existingOrder
+          : this.sortItems(this.groups[effectiveColumnId] || [], effectiveColumnId).map(
+              (item) => item.id,
+            );
+      const withoutChild = baseOrder.filter((id) => id !== result.id);
+      const parentIndex = withoutChild.indexOf(parentItem.id);
+      if (parentIndex >= 0) {
+        withoutChild.splice(parentIndex + 1, 0, result.id);
+        this.customOrder[effectiveColumnId] = withoutChild;
+        this.onCustomOrderChange(this.customOrder);
+      }
+
+      const newItem: WorkItem = {
+        id: result.id,
+        path: result.path,
+        title: result.title,
+        state: effectiveColumnId,
+        metadata: {
+          parent: {
+            id: parentItem.id,
+            title: parentItem.title,
+            path: parentItem.path,
+          },
+          isSubTask: true,
+        },
+      };
+      this.groups[effectiveColumnId] = [...(this.groups[effectiveColumnId] || []), newItem];
+      this.items.push(newItem);
+      this.render(this.groups, this.customOrder);
+      this.selectItem(newItem);
+      new Notice(`Created sub-task: ${result.title}`);
+    } catch (err) {
+      console.error("[work-terminal] createSubTask failed:", err);
+      new Notice("Failed to create sub-task. See console for details.");
     }
   }
 
@@ -1128,14 +1321,32 @@ export class ListPanel {
       const cards = section.querySelectorAll(".wt-card-wrapper");
       let visibleCount = 0;
 
+      const matches = new Map<Element, boolean>();
       for (const card of Array.from(cards)) {
         const textMatch =
           !this.filterTerm || (card.textContent?.toLowerCase() || "").includes(this.filterTerm);
         const sessionMatch =
           !sessionItemIds || sessionItemIds.has(card.getAttribute("data-item-id") || "");
-        const match = textMatch && sessionMatch;
-        (card as HTMLElement).style.display = match ? "" : "none";
-        if (match) visibleCount++;
+        matches.set(card, textMatch && sessionMatch);
+      }
+
+      for (const card of Array.from(cards)) {
+        const match = matches.get(card) ?? false;
+        const cardEl = card as HTMLElement;
+        cardEl.style.display = match ? "" : "none";
+        cardEl.removeClass("wt-card-subtask-orphaned");
+        if (match) {
+          const parentId = card.getAttribute("data-parent-id");
+          const parentCard = parentId
+            ? Array.from(cards).find(
+                (candidate) => candidate.getAttribute("data-item-id") === parentId,
+              )
+            : null;
+          if (parentId && (!parentCard || matches.get(parentCard) === false)) {
+            cardEl.addClass("wt-card-subtask-orphaned");
+          }
+          visibleCount++;
+        }
       }
 
       // Hide section if all cards filtered out

--- a/src/framework/ListPanel.ts
+++ b/src/framework/ListPanel.ts
@@ -842,8 +842,7 @@ export class ListPanel {
     newItem: WorkItem,
     columnId: string,
   ): Promise<void> {
-    // For pinned items, resolve to the real column for file creation
-    const effectiveColumnId = columnId === PINNED_COLUMN_ID ? newItem.state : columnId;
+    const effectiveColumnId = this.resolveCreationColumnId(newItem, columnId);
     if (!this.adapter.onItemCreated) {
       console.warn("[work-terminal] insertAfter: adapter has no onItemCreated");
       return;
@@ -867,12 +866,22 @@ export class ListPanel {
     }).open();
   }
 
+  private isVirtualCreationColumn(columnId: string): boolean {
+    return (
+      columnId === PINNED_COLUMN_ID || (ACTIVITY_BUCKETS as readonly string[]).includes(columnId)
+    );
+  }
+
+  private resolveCreationColumnId(item: WorkItem, columnId: string): string {
+    return this.isVirtualCreationColumn(columnId) ? item.state : columnId;
+  }
+
   private async createSubTask(
     parentItem: WorkItem,
     columnId: string,
     focus: string,
   ): Promise<void> {
-    const effectiveColumnId = columnId === PINNED_COLUMN_ID ? parentItem.state : columnId;
+    const effectiveColumnId = this.resolveCreationColumnId(parentItem, columnId);
     if (!this.adapter.onCreateSubTask) {
       console.warn("[work-terminal] createSubTask: adapter has no onCreateSubTask");
       return;
@@ -928,8 +937,7 @@ export class ListPanel {
   }
 
   private async splitTask(sourceItem: WorkItem, columnId: string): Promise<void> {
-    // For pinned items, use the real state column for the split
-    const effectiveColumnId = columnId === PINNED_COLUMN_ID ? sourceItem.state : columnId;
+    const effectiveColumnId = this.resolveCreationColumnId(sourceItem, columnId);
     if (!this.adapter.onSplitItem) {
       console.warn("[work-terminal] splitTask: adapter has no onSplitItem");
       return;
@@ -1322,11 +1330,15 @@ export class ListPanel {
       let visibleCount = 0;
 
       const matches = new Map<Element, boolean>();
+      const cardByItemId = new Map<string, Element>();
       for (const card of Array.from(cards)) {
+        const itemId = card.getAttribute("data-item-id");
+        if (itemId) {
+          cardByItemId.set(itemId, card);
+        }
         const textMatch =
           !this.filterTerm || (card.textContent?.toLowerCase() || "").includes(this.filterTerm);
-        const sessionMatch =
-          !sessionItemIds || sessionItemIds.has(card.getAttribute("data-item-id") || "");
+        const sessionMatch = !sessionItemIds || (itemId ? sessionItemIds.has(itemId) : false);
         matches.set(card, textMatch && sessionMatch);
       }
 
@@ -1337,11 +1349,7 @@ export class ListPanel {
         cardEl.removeClass("wt-card-subtask-orphaned");
         if (match) {
           const parentId = card.getAttribute("data-parent-id");
-          const parentCard = parentId
-            ? Array.from(cards).find(
-                (candidate) => candidate.getAttribute("data-item-id") === parentId,
-              )
-            : null;
+          const parentCard = parentId ? cardByItemId.get(parentId) : null;
           if (parentId && (!parentCard || matches.get(parentCard) === false)) {
             cardEl.addClass("wt-card-subtask-orphaned");
           }

--- a/styles.css
+++ b/styles.css
@@ -181,7 +181,6 @@
 
 .wt-card-subtask {
   margin-left: calc(var(--wt-subtask-depth, 1) * 16px);
-  border-left-color: var(--background-modifier-border);
 }
 
 .wt-card-subtask::before {

--- a/styles.css
+++ b/styles.css
@@ -179,6 +179,29 @@
   opacity: 0.4;
 }
 
+.wt-card-subtask {
+  margin-left: calc(var(--wt-subtask-depth, 1) * 16px);
+  border-left-color: var(--background-modifier-border);
+}
+
+.wt-card-subtask::before {
+  content: "";
+  position: absolute;
+  left: calc(-1 * var(--wt-subtask-depth, 1) * 16px + 6px);
+  top: 0;
+  bottom: 0;
+  border-left: 1px solid var(--background-modifier-border);
+  opacity: 0.8;
+}
+
+.wt-card-subtask-orphaned {
+  margin-left: 0;
+}
+
+.wt-card-subtask-orphaned::before {
+  display: none;
+}
+
 /* Card title row */
 .wt-card-title-row {
   position: relative;


### PR DESCRIPTION
## Summary
- Adds explicit parent/sub-task metadata for task-agent task files (`sub-task: true` plus a readable `parent` block with id/title/path/link).
- Adds Create Sub-task card action with a focus prompt, inherited parent context, and child-file creation.
- Renders sub-tasks indented under their parent when both appear in the same section, while keeping child tasks independently movable/filterable/pinnable.
- Adds parent context prompt placeholders and updates docs/changelog.

## Test plan
- `pnpm exec vitest run src/framework/ListPanel.test.ts src/adapters/task-agent/TaskFileTemplate.test.ts src/adapters/task-agent/TaskParser.test.ts src/framework/AgentContextPrompt.test.ts src/adapters/task-agent/TaskPromptBuilder.test.ts src/adapters/task-agent/TaskCard.test.ts`
- `pnpm exec vitest run`
- `pnpm run build`

Fixes #508
