### PR TITLE
Fix active sessions filter alignment

### DIFF
--- a/src/framework/sessionFilterStyles.test.ts
+++ b/src/framework/sessionFilterStyles.test.ts
@@ -1,0 +1,30 @@
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+const stylesPath = path.join(repoRoot, "styles.css");
+
+function readRule(styles: string, selector: string): string | undefined {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return styles.match(new RegExp(`${escapedSelector}\\s*\\{([\\s\\S]*?)\\}`))?.[1];
+}
+
+describe("session filter styles", () => {
+  it("centers the active sessions filter label and balances row spacing", async () => {
+    const styles = await fs.readFile(stylesPath, "utf8");
+    const rowRule = readRule(styles, ".wt-session-filter");
+    const labelRule = readRule(styles, ".wt-session-filter-label");
+
+    expect(rowRule).toBeDefined();
+    expect(rowRule).toMatch(/display:\s*flex;/);
+    expect(rowRule).toMatch(/align-items:\s*center;/);
+    expect(rowRule).toMatch(/margin-top:\s*6px;/);
+
+    expect(labelRule).toBeDefined();
+    expect(labelRule).toMatch(/display:\s*inline-flex;/);
+    expect(labelRule).toMatch(/align-items:\s*center;/);
+    expect(labelRule).toMatch(/gap:\s*6px;/);
+    expect(labelRule).toMatch(/line-height:\s*1\.4;/);
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -76,8 +76,7 @@
 .wt-session-filter {
   display: flex;
   align-items: center;
-  gap: 6px;
-  margin-top: 4px;
+  margin-top: 6px;
 }
 
 .wt-session-filter-checkbox {
@@ -86,6 +85,10 @@
 }
 
 .wt-session-filter-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  line-height: 1.4;
   font-size: 11px;
   color: var(--text-muted);
   cursor: pointer;


### PR DESCRIPTION
## Summary
- Center the Active sessions only checkbox and label by applying flex alignment to the label that wraps both controls.
- Balance the filter row spacing by matching the row top gap to the filter container bottom padding.
- Add focused CSS regression coverage for the filter row alignment.

## Validation
- pnpm exec vitest run src/framework/sessionFilterStyles.test.ts src/framework/ListPanel.test.ts
- pnpm exec vitest run
- pnpm run build

Fixes #509