### PR TITLE
Fix Done & Close Sessions move ordering

### DIFF
--- a/src/adapters/task-agent/TaskCard.test.ts
+++ b/src/adapters/task-agent/TaskCard.test.ts
@@ -103,6 +103,77 @@ describe("TaskCard", () => {
     });
   });
 
+  it("waits for move-to-done before closing sessions", async () => {
+    const item = makeItem();
+    const calls: string[] = [];
+    let resolveMove!: (value: boolean) => void;
+    const movePromise = new Promise<boolean>((resolve) => {
+      resolveMove = resolve;
+    });
+    const ctx = makeContext({
+      onMoveToColumn: vi.fn(() => {
+        calls.push("move");
+        return movePromise;
+      }),
+      onCloseSessions: vi.fn(() => {
+        calls.push("close");
+      }),
+    });
+    const card = new TaskCard();
+
+    const menuItems = card.getContextMenuItems(item, ctx);
+    const doneAndCloseItem = menuItems.find(
+      (menuItem) => (menuItem as any).title === "Done & Close Sessions",
+    ) as { callback: () => Promise<void> } | undefined;
+
+    expect(doneAndCloseItem).toBeDefined();
+
+    const callbackPromise = doneAndCloseItem!.callback();
+
+    expect(ctx.onMoveToColumn).toHaveBeenCalledWith("done");
+    expect(ctx.onCloseSessions).not.toHaveBeenCalled();
+
+    resolveMove(true);
+    await callbackPromise;
+
+    expect(calls).toEqual(["move", "close"]);
+    expect(ctx.onCloseSessions).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not close sessions when move-to-done fails", async () => {
+    const item = makeItem();
+    const ctx = makeContext({
+      onMoveToColumn: vi.fn().mockResolvedValue(false),
+    });
+    const card = new TaskCard();
+
+    const menuItems = card.getContextMenuItems(item, ctx);
+    const doneAndCloseItem = menuItems.find(
+      (menuItem) => (menuItem as any).title === "Done & Close Sessions",
+    ) as { callback: () => Promise<void> } | undefined;
+
+    await doneAndCloseItem?.callback();
+
+    expect(ctx.onMoveToColumn).toHaveBeenCalledWith("done");
+    expect(ctx.onCloseSessions).not.toHaveBeenCalled();
+  });
+
+  it("still closes sessions for synchronous move callbacks", async () => {
+    const item = makeItem();
+    const ctx = makeContext();
+    const card = new TaskCard();
+
+    const menuItems = card.getContextMenuItems(item, ctx);
+    const doneAndCloseItem = menuItems.find(
+      (menuItem) => (menuItem as any).title === "Done & Close Sessions",
+    ) as { callback: () => Promise<void> } | undefined;
+
+    await doneAndCloseItem?.callback();
+
+    expect(ctx.onMoveToColumn).toHaveBeenCalledWith("done");
+    expect(ctx.onCloseSessions).toHaveBeenCalledTimes(1);
+  });
+
   it("copies the exact context prompt from the framework callback", async () => {
     const item = makeItem();
     const ctx = makeContext();

--- a/src/adapters/task-agent/TaskCard.ts
+++ b/src/adapters/task-agent/TaskCard.ts
@@ -450,8 +450,15 @@ export class TaskCard implements CardRenderer {
       if (col === "done") {
         (items as any[]).push({
           title: "Done & Close Sessions",
-          callback: () => {
-            ctx.onMoveToColumn("done");
+          callback: async () => {
+            let moved: boolean | void;
+            try {
+              moved = await ctx.onMoveToColumn("done");
+            } catch (err) {
+              console.error("[work-terminal] Failed to move task to done:", err);
+              return;
+            }
+            if (moved === false) return;
             try {
               ctx.onCloseSessions();
             } catch (err) {

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -200,8 +200,8 @@ export interface CardActionContext {
   onSelect(): void;
   /** Move this item to the top of its current section. */
   onMoveToTop(): void;
-  /** Move this item to a different column (triggers WorkItemMover). */
-  onMoveToColumn(columnId: string): void;
+  /** Move this item to a different column (triggers WorkItemMover). Returns false when the move fails. */
+  onMoveToColumn(columnId: string): void | Promise<boolean>;
   /** Insert a new item immediately after an existing one in custom order. */
   onInsertAfter(existingId: string, newItem: WorkItem): void;
   /** Split this item: create a new task with a related reference, then spawn Claude (ctx) to scope it. */


### PR DESCRIPTION
## Summary
- Wait for the Done & Close Sessions move-to-done operation before closing terminal sessions.
- Skip closing sessions if the move fails, preserving the user's active sessions rather than masking the failure.
- Add focused TaskCard regression coverage for async move ordering, failed moves, and sync callbacks.

Fixes #502

## Validation
- `pnpm exec vitest run src/adapters/task-agent/TaskCard.test.ts`
- `pnpm exec vitest run`
- `pnpm run build`
