### PR TITLE
fix: harden create sub-task initialization

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -206,7 +206,7 @@ Right-click any task card to open the context menu with these options:
 - **Move to Top** - moves the card to the top of its current column
 - **Retry Enrichment** - re-runs background enrichment (shown only when enrichment previously failed)
 - **Split Task** - creates a new task linked to this one and opens a Claude session to scope it
-- **Create Sub-task...** - prompts for a focused area, then creates a normal child task with explicit parent frontmatter
+- **Create Sub-task...** - prompts for a focused area, creates a placeholder child task with explicit parent frontmatter, then opens a Claude scoping session
 - **Move to [column]** - moves the task to a different column (Priority, Active, To Do, Done, or any dynamic columns)
 - **Done & Close Sessions** - moves to Done and closes all terminal sessions for this task
 - **Copy Name** - copies the task title to clipboard
@@ -595,7 +595,7 @@ Pinned state is persisted across sessions using the task's UUID, so it survives 
 
 ### Parent tasks and sub-tasks
 
-Use **Create Sub-task...** from a task card's context menu to break a task into a focused child task without losing the relationship to the parent. The flow asks what area the child should focus on, creates a new task file in the same state column, launches a visible scoping session for the new child, and writes explicit frontmatter such as:
+Use **Create Sub-task...** from a task card's context menu to break a task into a focused child task without losing the relationship to the parent. The flow asks what area the child should focus on, creates a new placeholder task file in the same state column, launches a visible scoping session for the new child, and writes explicit frontmatter such as:
 
 ```yaml
 sub-task: true
@@ -608,7 +608,7 @@ parent:
 
 Sub-tasks are normal tasks: they can be selected, moved between states, pinned, reordered, filtered, enriched, and given terminal sessions like any other task. When a parent and child appear in the same rendered section, the child is shown indented under the parent. If the parent is pinned, a newly created sub-task is pinned immediately as well so it appears in the same visible group, nested directly underneath. If the child is in a different state (or only the child matches the current filter/view), it appears as a normal top-level card in that section so its workflow remains independent.
 
-New sub-tasks inherit useful context from their parent at creation time: non-state tags, source metadata, deadline/impact/blocker fields, and the focus area as the initial goal. When created from Activity view, the sub-task uses the parent's real task state rather than the activity recency bucket. The scoping session launched after creation uses the same agent-profile binding as Split Task, and agent profile templates can use `$parentTitle`, `$parentId`, `$parentFilePath`, and `$parentAbsoluteFilePath` to include parent context when launching sessions for sub-tasks.
+New sub-tasks inherit useful context from their parent at creation time: non-state tags, source metadata, deadline/impact/blocker fields, and explicit parent/sub-task frontmatter. The initial child title and filename are intentionally placeholders; the scoping session turns your requested focus into the final title, goal, and task content. When created from Activity view, the sub-task uses the parent's real task state rather than the activity recency bucket. The scoping session launched after creation uses the same agent-profile binding as Split Task, and agent profile templates can use `$parentTitle`, `$parentId`, `$parentFilePath`, and `$parentAbsoluteFilePath` to include parent context when launching sessions for sub-tasks.
 
 ### Task splitting
 

--- a/src/adapters/task-agent/BackgroundEnrich.test.ts
+++ b/src/adapters/task-agent/BackgroundEnrich.test.ts
@@ -1100,6 +1100,36 @@ describe("BackgroundEnrich", () => {
       expect(app.createdFiles[0].content).toContain("state: needs-review");
       expect(app.createdFiles[0].content).toContain("  - task/needs-review");
     });
+
+    it("creates sub-tasks with a placeholder title and pending filename", async () => {
+      const app = makeSubTaskApp(["2 - Areas/Tasks/todo"]);
+
+      const result = await handleSubTaskCreated(
+        app,
+        {
+          id: "parent-id",
+          title: "Parent task",
+          path: "2 - Areas/Tasks/todo/parent.md",
+          filename: "parent.md",
+        },
+        "Investigate API",
+        "todo",
+        "2 - Areas/Tasks",
+      );
+
+      expect(result.title).toBe("Sub-task from: Parent task");
+      expect(app.createdFiles[0].path).toMatch(/TASK-\d{8}-\d{4}-pending-[a-f0-9]{8}\.md$/);
+      expect(app.createdFiles[0].content).toContain('title: "Sub-task from: Parent task"');
+      expect(app.createdFiles[0].content).toContain("goal: []");
+      expect(app.createdFiles[0].content).toContain("Requested scope: Investigate API");
+      expect(result.task.parent).toEqual({
+        id: "parent-id",
+        title: "Parent task",
+        path: "2 - Areas/Tasks/todo/parent.md",
+        link: "[[parent|Parent task]]",
+      });
+      expect(result.task.isSubTask).toBe(true);
+    });
   });
 
   describe("findFileByUuid", () => {

--- a/src/adapters/task-agent/BackgroundEnrich.test.ts
+++ b/src/adapters/task-agent/BackgroundEnrich.test.ts
@@ -1128,6 +1128,7 @@ describe("BackgroundEnrich", () => {
         path: "2 - Areas/Tasks/todo/parent.md",
         link: "[[parent|Parent task]]",
       });
+      expect(result.task.source.type).toBe("prompt");
       expect(result.task.isSubTask).toBe(true);
     });
   });

--- a/src/adapters/task-agent/BackgroundEnrich.ts
+++ b/src/adapters/task-agent/BackgroundEnrich.ts
@@ -4,17 +4,14 @@ import {
   spawnHeadlessAgent,
   DEFAULT_TIMEOUT_MS,
 } from "../../core/claude/HeadlessClaude";
-import {
-  generateTaskContent,
-  generatePendingFilename,
-  generateTaskFilename,
-} from "./TaskFileTemplate";
+import { generateTaskContent, generatePendingFilename } from "./TaskFileTemplate";
 import type { SplitSource, EnrichmentMeta } from "./TaskFileTemplate";
 import { expandTilde } from "../../core/utils";
 import type { ItemCreationResult } from "../../core/interfaces";
 import {
   STATE_FOLDER_MAP,
   type KanbanColumn,
+  type TaskFile,
   type TaskParent,
   type TaskPriority,
   type TaskSource,
@@ -473,12 +470,14 @@ export async function handleSubTaskCreated(
   columnId: string,
   basePath: string,
   resolvedFolderName?: string | null,
-): Promise<{ path: string; id: string; title: string }> {
+): Promise<{ path: string; id: string; title: string; task: TaskFile }> {
   const id = crypto.randomUUID();
-  const title = focus.trim();
+  const requestedScope = focus.trim();
   const folderPath = resolveSubTaskFolderPath(parent, columnId, basePath, resolvedFolderName);
-  const filePath = await resolveAvailableTaskPath(app, folderPath, title);
+  const filename = generatePendingFilename();
+  const filePath = `${folderPath}/${filename}`;
   const parentTitle = parent.title.trim() || parent.filename.replace(/\.md$/, "");
+  const title = `Sub-task from: ${parentTitle}`;
   const parentLinkTitle = parentTitle.replace(/]/g, "");
   const parentReference: TaskParent = {
     id: parent.id,
@@ -507,12 +506,42 @@ export async function handleSubTaskCreated(
       }
     : {};
 
+  const now = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const task: TaskFile = {
+    id,
+    path: filePath,
+    filename,
+    state: columnId,
+    title,
+    tags: inheritedTags,
+    source: parent.source ?? {
+      type: "other",
+      id: "",
+      url: "",
+      captured: "",
+    },
+    priority: {
+      score: 0,
+      deadline: inheritedPriority.deadline ?? "",
+      impact: inheritedPriority.impact ?? "medium",
+      "has-blocker": inheritedPriority["has-blocker"] ?? false,
+      "blocker-context": inheritedPriority["blocker-context"] ?? "",
+    },
+    agentActionable: false,
+    goal: [],
+    parent: parentReference,
+    isSubTask: true,
+    created: now,
+    updated: now,
+    lastActive: "",
+  };
+
   const content = generateTaskContent(title, columnId, undefined, id, undefined, {
     parent: parentReference,
     tags: inheritedTags,
     source: parent.source,
     priority: inheritedPriority,
-    goal: [focus.trim()],
+    activityLogEntries: [`Requested scope: ${requestedScope}`],
   });
 
   const folder = app.vault.getAbstractFileByPath(folderPath);
@@ -523,7 +552,7 @@ export async function handleSubTaskCreated(
   await app.vault.create(filePath, content);
   console.log(`[work-terminal] Sub-task created: ${filePath} (parent ${parent.path})`);
 
-  return { path: filePath, id, title };
+  return { path: filePath, id, title, task };
 }
 
 function resolveSubTaskFolderPath(
@@ -541,22 +570,6 @@ function resolveSubTaskFolderPath(
     ? parent.path.substring(0, parent.path.lastIndexOf("/"))
     : "";
   return parentFolder || basePath;
-}
-
-async function resolveAvailableTaskPath(
-  app: App,
-  folderPath: string,
-  title: string,
-): Promise<string> {
-  const filename = generateTaskFilename(title);
-  const initialPath = `${folderPath}/${filename}`;
-  if (!(await app.vault.adapter.exists(initialPath))) {
-    return initialPath;
-  }
-
-  const suffix = crypto.randomUUID().slice(0, 8);
-  const uniqueFilename = filename.replace(/\.md$/, `-${suffix}.md`);
-  return `${folderPath}/${uniqueFilename}`;
 }
 
 const INGESTION_FAILED_NOTE =

--- a/src/adapters/task-agent/BackgroundEnrich.ts
+++ b/src/adapters/task-agent/BackgroundEnrich.ts
@@ -515,7 +515,7 @@ export async function handleSubTaskCreated(
     title,
     tags: inheritedTags,
     source: parent.source ?? {
-      type: "other",
+      type: "prompt",
       id: "",
       url: "",
       captured: "",

--- a/src/adapters/task-agent/TaskFileTemplate.test.ts
+++ b/src/adapters/task-agent/TaskFileTemplate.test.ts
@@ -139,6 +139,16 @@ describe("generateTaskContent", () => {
     expect(content).toContain('related:\n  - "[[TASK-parent|Parent Task]]"');
   });
 
+  it("adds extra activity log entries when requested", () => {
+    const content = generateTaskContent("Test", "todo", undefined, "test-id", undefined, {
+      activityLogEntries: ["Requested scope: Investigate API"],
+    });
+
+    expect(content).toContain("## Activity Log");
+    expect(content).toContain("Task created");
+    expect(content).toContain("Requested scope: Investigate API");
+  });
+
   it("includes enrichment block when enrichment metadata is provided", () => {
     const content = generateTaskContent("Test", "todo", undefined, "test-id", {
       profile: "pi",

--- a/src/adapters/task-agent/TaskFileTemplate.test.ts
+++ b/src/adapters/task-agent/TaskFileTemplate.test.ts
@@ -149,6 +149,15 @@ describe("generateTaskContent", () => {
     expect(content).toContain("Requested scope: Investigate API");
   });
 
+  it("normalizes multiline activity log entries onto one bullet", () => {
+    const content = generateTaskContent("Test", "todo", undefined, "test-id", undefined, {
+      activityLogEntries: ["Requested scope:\n  Investigate API\n now"],
+    });
+
+    expect(content).toContain("Requested scope: Investigate API now");
+    expect(content).not.toContain("Requested scope:\n");
+  });
+
   it("includes enrichment block when enrichment metadata is provided", () => {
     const content = generateTaskContent("Test", "todo", undefined, "test-id", {
       profile: "pi",

--- a/src/adapters/task-agent/TaskFileTemplate.ts
+++ b/src/adapters/task-agent/TaskFileTemplate.ts
@@ -24,6 +24,13 @@ export interface EnrichmentMeta {
   cwd: string;
 }
 
+function normaliseActivityLogEntry(entry: string): string {
+  return entry
+    .trim()
+    .replace(/\s*\r?\n\s*/g, " ")
+    .replace(/[ \t]{2,}/g, " ");
+}
+
 export function generateTaskContent(
   title: string,
   state: string,
@@ -83,7 +90,10 @@ export function generateTaskContent(
     goal.length > 0 ? `\n${goal.map((entry) => `  - ${yamlQuoteValue(entry)}`).join("\n")}` : " []";
   const activityLog = [
     `- **${dateStr}** - Task created${activitySuffix}`,
-    ...(options.activityLogEntries || []).map((entry) => `- **${dateStr}** - ${entry}`),
+    ...(options.activityLogEntries || [])
+      .map((entry) => normaliseActivityLogEntry(entry))
+      .filter((entry) => entry.length > 0)
+      .map((entry) => `- **${dateStr}** - ${entry}`),
   ].join("\n");
 
   const enrichmentSection = enrichment

--- a/src/adapters/task-agent/TaskFileTemplate.ts
+++ b/src/adapters/task-agent/TaskFileTemplate.ts
@@ -12,6 +12,7 @@ export interface TaskContentOptions {
   source?: Partial<TaskSource>;
   priority?: Partial<TaskPriority>;
   goal?: string[];
+  activityLogEntries?: string[];
 }
 
 /** Enrichment metadata to embed in the task file frontmatter. */
@@ -80,6 +81,10 @@ export function generateTaskContent(
   const goal = options.goal ?? [];
   const goalSection =
     goal.length > 0 ? `\n${goal.map((entry) => `  - ${yamlQuoteValue(entry)}`).join("\n")}` : " []";
+  const activityLog = [
+    `- **${dateStr}** - Task created${activitySuffix}`,
+    ...(options.activityLogEntries || []).map((entry) => `- **${dateStr}** - ${entry}`),
+  ].join("\n");
 
   const enrichmentSection = enrichment
     ? `enrichment:\n` +
@@ -116,7 +121,7 @@ updated: ${now}
 # ${title}
 
 ## Activity Log
-- **${dateStr}** - Task created${activitySuffix}
+${activityLog}
 `;
 }
 

--- a/src/adapters/task-agent/TaskParser.test.ts
+++ b/src/adapters/task-agent/TaskParser.test.ts
@@ -119,6 +119,53 @@ describe("TaskParser", () => {
       expect((item!.metadata as any).priority.score).toBe(0);
     });
 
+    it("uses registered transient task metadata while metadata cache is still empty", () => {
+      const file = makeFile("2 - Areas/Tasks/active/task.md");
+      const app = mockApp([file], { [file.path]: null });
+      const parser = new TaskParser(app, "", defaultSettings);
+      parser.registerTransientTask({
+        id: "child-id",
+        path: file.path,
+        filename: file.name,
+        state: "active",
+        title: "Sub-task from: Parent",
+        tags: ["task", "task/active", "sub-task"],
+        source: { type: "prompt", id: "", url: "", captured: "" },
+        priority: {
+          score: 0,
+          deadline: "",
+          impact: "medium",
+          "has-blocker": false,
+          "blocker-context": "",
+        },
+        agentActionable: false,
+        goal: [],
+        parent: {
+          id: "parent-id",
+          title: "Parent",
+          path: "2 - Areas/Tasks/active/parent.md",
+          link: "[[parent|Parent]]",
+        },
+        isSubTask: true,
+        created: "2026-05-01T11:00:00Z",
+        updated: "2026-05-01T11:00:00Z",
+        lastActive: "",
+      });
+
+      const item = parser.parse(file as unknown as TFile);
+
+      expect(item).not.toBeNull();
+      expect(item!.id).toBe("child-id");
+      expect(item!.title).toBe("Sub-task from: Parent");
+      expect((item!.metadata as any).isSubTask).toBe(true);
+      expect((item!.metadata as any).parent).toEqual({
+        id: "parent-id",
+        title: "Parent",
+        path: "2 - Areas/Tasks/active/parent.md",
+        link: "[[parent|Parent]]",
+      });
+    });
+
     it("falls back to the folder state when frontmatter state is invalid", () => {
       const file = makeFile("2 - Areas/Tasks/active/task.md");
       const app = mockApp([file], {

--- a/src/adapters/task-agent/TaskParser.ts
+++ b/src/adapters/task-agent/TaskParser.ts
@@ -19,6 +19,7 @@ export class TaskParser implements WorkItemParser {
   basePath: string;
   private static loggedFallbackPaths = new Set<string>();
   private transientIdsByPath = new Map<string, string>();
+  private transientTasksByPath = new Map<string, TaskFile>();
   private backfillPromisesByPath = new Map<string, Promise<WorkItem | null>>();
   private parentIndex: Map<string, { path: string; title: string }> | null = null;
   private stateResolver: StateResolver | null;
@@ -50,6 +51,7 @@ export class TaskParser implements WorkItemParser {
       return this.createFallbackTaskFile(file, fallbackState, transientId);
     }
 
+    this.transientTasksByPath.delete(file.path);
     if (typeof fm.id === "string" && fm.id.trim()) {
       this.transientIdsByPath.delete(file.path);
     }
@@ -431,7 +433,9 @@ export class TaskParser implements WorkItemParser {
     state: string | null,
     transientId?: string,
   ): TaskFile | null {
-    if (!state) return null;
+    const transient = this.transientTasksByPath.get(file.path);
+    const effectiveState = state || transient?.state || null;
+    if (!effectiveState) return null;
 
     if (!TaskParser.loggedFallbackPaths.has(file.path)) {
       TaskParser.loggedFallbackPaths.add(file.path);
@@ -441,31 +445,35 @@ export class TaskParser implements WorkItemParser {
     }
 
     return {
-      id: transientId || file.path,
+      id: transientId || transient?.id || file.path,
       path: file.path,
       filename: file.name,
-      state,
-      title: file.basename,
-      tags: ["task", `task/${state}`],
-      source: {
+      state: effectiveState,
+      title: transient?.title || file.basename,
+      tags: transient?.tags || ["task", `task/${effectiveState}`],
+      source: transient?.source || {
         type: "other",
         id: "",
         url: "",
         captured: "",
       },
-      priority: {
+      priority: transient?.priority || {
         score: 0,
         deadline: "",
         impact: "medium",
         "has-blocker": false,
         "blocker-context": "",
       },
-      agentActionable: false,
-      goal: [],
-      color: undefined,
-      created: "",
-      updated: "",
-      lastActive: "",
+      agentActionable: transient?.agentActionable ?? false,
+      goal: transient?.goal || [],
+      parent: transient?.parent,
+      isSubTask: transient?.isSubTask,
+      color: transient?.color,
+      icon: transient?.icon,
+      backgroundIngestion: transient?.backgroundIngestion,
+      created: transient?.created || "",
+      updated: transient?.updated || "",
+      lastActive: transient?.lastActive || "",
     };
   }
 
@@ -564,6 +572,11 @@ export class TaskParser implements WorkItemParser {
 
   private normaliseBasePath(path: string): string {
     return path.replace(/\/+$/, "");
+  }
+
+  registerTransientTask(task: TaskFile): void {
+    this.transientIdsByPath.set(task.path, task.id);
+    this.transientTasksByPath.set(task.path, task);
   }
 
   async backfillItemId(item: WorkItem): Promise<WorkItem | null> {

--- a/src/adapters/task-agent/index.ts
+++ b/src/adapters/task-agent/index.ts
@@ -40,6 +40,7 @@ export class TaskAgentAdapter extends BaseAdapter {
   private _settings: Record<string, unknown> = {};
   private detailView: TaskDetailView | null = null;
   private embeddedDetailView: EmbeddedDetailView | null = null;
+  private _parser: TaskParser | null = null;
   // Identifier of the last item we mounted into the embedded host. Used by
   // the auto-close behaviour to detach the hidden leaf when the selection
   // moves to a different item, mirroring `TaskDetailView.lastItemId`.
@@ -78,7 +79,8 @@ export class TaskAgentAdapter extends BaseAdapter {
     );
     const taskBasePath = (resolvedSettings["adapter.taskBasePath"] as string) || "2 - Areas/Tasks";
     const resolver = this.getStateResolver(taskBasePath, resolvedSettings);
-    return new TaskParser(app, basePath, resolvedSettings, resolver);
+    this._parser = new TaskParser(app, basePath, resolvedSettings, resolver);
+    return this._parser;
   }
 
   createMover(app: App, basePath: string, settings?: Record<string, unknown>): WorkItemMover {
@@ -266,7 +268,7 @@ export class TaskAgentAdapter extends BaseAdapter {
     const parentFilename = parentItem.path.split("/").pop() || parentItem.path;
     const meta = (parentItem.metadata || {}) as Record<string, any>;
 
-    return handleSubTaskCreated(
+    const result = await handleSubTaskCreated(
       this._app,
       {
         id: parentItem.id,
@@ -282,6 +284,8 @@ export class TaskAgentAdapter extends BaseAdapter {
       basePath,
       folderName,
     );
+    this._parser?.registerTransientTask(result.task);
+    return result;
   }
 
   async getRetryEnrichPrompt(item: WorkItem): Promise<string | null> {

--- a/src/framework/ListPanel.test.ts
+++ b/src/framework/ListPanel.test.ts
@@ -343,7 +343,10 @@ describe("ListPanel", () => {
       undefined,
     );
     expect(terminalPanel.spawnClaudeWithPrompt.mock.calls[0][0]).toContain(
-      "The user created the sub-task to focus on: Child focus.",
+      "The new file currently uses a temporary placeholder title and pending filename.",
+    );
+    expect(terminalPanel.spawnClaudeWithPrompt.mock.calls[0][0]).toContain(
+      "User provided this description of the intended scope for this sub-task: Child focus.",
     );
   });
 

--- a/src/framework/ListPanel.ts
+++ b/src/framework/ListPanel.ts
@@ -1055,13 +1055,13 @@ export class ListPanel {
 
     return (
       `Read the parent task file at ${parentFullPath} and the new sub-task file at ${newFullPath}. ` +
-      `The user created the sub-task to focus on: ${focus}. ` +
-      `Use that focus as the initial scope for the new task. ` +
+      `The new file currently uses a temporary placeholder title and pending filename. ` +
+      `User provided this description of the intended scope for this sub-task: ${focus}. ` +
+      `Do not assume the current title is final. ` +
       `Ask concise follow-up questions only if needed. ` +
-      `Then update the new task file in place: refine the title if helpful, ` +
-      `add a brief description with relevant context from the parent task, ` +
-      `keep the goal aligned to the requested focus, and log the scope in the activity log. ` +
-      `If you change the title, rename the file to match the convention ` +
+      `Then update the new task file in place: set the final title, add a brief description with relevant context from the parent task, ` +
+      `set or refine the goal based on the requested scope, and log the scope in the activity log. ` +
+      `Rename the file to match the convention ` +
       `TASK-YYYYMMDD-HHMM-slugified-title.md while preserving the existing date prefix.`
     );
   }


### PR DESCRIPTION
Closes #517

## Summary
- create sub-tasks with pending placeholder titles/filenames instead of pre-committing the focus text
- pass the requested scope explicitly into the scoping prompt and preserve it in the activity log
- register transient sub-task metadata so cache-lag fallback parsing still keeps parent/child nesting intact
- update user docs and regression coverage

## Validation
- pnpm exec vitest run
- pnpm run build
- pnpm exec eslint src/