### PR TITLE
Fix sub-task indent in compact card modes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2220,7 +2220,8 @@ button.wt-spawn-claude-ctx:hover svg {
 .wt-compact .wt-card-wrapper {
   --wt-card-padding-x: 6px;
   --wt-card-padding-y: 2px;
-  margin: 1px 0;
+  margin-top: 1px;
+  margin-bottom: 1px;
   border-radius: 3px;
 }
 
@@ -2367,7 +2368,8 @@ button.wt-spawn-claude-ctx:hover svg {
 .wt-comfortable .wt-card-wrapper {
   --wt-card-padding-x: 8px;
   --wt-card-padding-y: 4px;
-  margin: 2px 0;
+  margin-top: 2px;
+  margin-bottom: 2px;
   border-radius: 4px;
 }
 


### PR DESCRIPTION
## Summary
- fix sub-task nesting indentation in compact and comfortable card modes
- preserve left margin from `.wt-card-subtask` by avoiding margin shorthands that reset `margin-left`
- reproduce and verify the issue in an isolated Obsidian instance

## Root cause
Compact and comfortable mode CSS applied `margin: ...` on `.wt-card-wrapper`, which reset the `margin-left` applied by `.wt-card-subtask`. The child card still had the sub-task class, but rendered flush with its parent.

## Testing
- `pnpm exec vitest run`
- `pnpm run build`
- isolated Obsidian instance with parent + child priority tasks, verified child regains 16px left margin in comfortable mode

Closes #520