### PR TITLE
Stop logging board moves in task files

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,7 +51,7 @@ src/
       types.ts               # TaskFile, TaskState, KanbanColumn, STATE_FOLDER_MAP
       TaskAgentConfig.ts     # PluginConfig: columns, creationColumns, settings, itemName
       TaskParser.ts          # MetadataCache parsing, abandoned filtering, goal normalisation
-      TaskMover.ts           # Regex frontmatter updates, write-then-move, activity log
+      TaskMover.ts           # Regex frontmatter updates, updated timestamp, write-then-move
       TaskCard.ts            # Source/score/goal/blocker badges, compound context menu
       TaskFileTemplate.ts    # UUID + YAML frontmatter + slug filename generation
       TaskPromptBuilder.ts   # Title/state/path + conditional deadline/blocker

--- a/docs/regression-tests.md
+++ b/docs/regression-tests.md
@@ -244,8 +244,8 @@ no layout-invariant contract yet.
 | UD-14 | Task parser: backfill IDs | Task without UUID in frontmatter | ID backfilled on load (only processes tasks without existing UUID). | | |
 | UD-15 | Task mover: regex preserves spacing | Move a task with custom frontmatter spacing | State/tag updates via regex preserve original YAML spacing. | | |
 | UD-16 | Task mover: ISO without milliseconds | Move a task, check `updated` timestamp | Format: `2025-03-26T14:15:30Z` (not `.123Z`). | | |
-| UD-17 | Task mover: activity log position | Move a task with existing sections below activity log | New activity log entry inserts before next `##` section, not at end of file. | | |
-| UD-18 | Task mover: write-then-move | Move a task to a different column, observe file operations | Content modified first (state/tags/timestamp/activity), THEN file renamed to new folder. | | |
+| UD-17 | Task mover: no automatic activity-log entry | Move a task with or without an existing `## Activity Log` section | State/tag/timestamp update still happens, but no `Moved to ... (via kanban board)` entry is added and no new activity-log section is created. | | |
+| UD-18 | Task mover: write-then-move | Move a task to a different column, observe file operations | Content modified first (state/tags/timestamp), THEN file renamed to new folder. | | |
 | UD-19 | pty-wrapper.py: stdin buffering | Send input to terminal | Only holds back potential resize sequence starts (`ESC ]`). Regular CSI escapes (`ESC [`) pass through immediately (prevents deadlock). | | |
 | UD-20 | pty-wrapper.py: login shell wrapping | Check how non-shell commands are spawned | Wrapped with `-l -i` for .zprofile/.zshrc sourcing (ensures PATH). | | |
 | UD-21 | pty-wrapper.py: 50ms select timeout | Check pty-wrapper select loop | Non-blocking 50ms timeout (not blocking select). Enables responsive signal handling. | | |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -260,7 +260,7 @@ When the placement is set to anything other than **Split**, a small document-sty
 
 Tasks within a column can be reordered by dragging. Grab a card and drag it to a new position within the same column. The custom sort order is persisted and survives plugin reloads.
 
-You can also drag a task between columns to change its state. Dropping a task from "To Do" into "Active" will move the underlying file to the `active/` folder and update the frontmatter accordingly. Dropping a task into a dynamic column (one without a folder mapping) updates the frontmatter `state` field but leaves the file in its current folder.
+You can also drag a task between columns to change its state. Dropping a task from "To Do" into "Active" will move the underlying file to the `active/` folder and update the frontmatter accordingly. Dropping a task into a dynamic column (one without a folder mapping) updates the frontmatter `state` field but leaves the file in its current folder. These board moves do not append automatic `Moved to ...` entries to the task's activity log.
 
 ### Filtering
 

--- a/src/adapters/task-agent/TaskMover.test.ts
+++ b/src/adapters/task-agent/TaskMover.test.ts
@@ -75,7 +75,7 @@ describe("TaskMover", () => {
     expect(match![1]).not.toMatch(/\.\d{3}Z/);
   });
 
-  it("appends activity log entry", async () => {
+  it("does not append activity log entries for board moves", async () => {
     const { app, modify } = createMockApp();
     const mover = new TaskMover(app, "", defaultSettings);
     const file = { path: "2 - Areas/Tasks/todo/task.md", name: "task.md" } as TFile;
@@ -83,10 +83,12 @@ describe("TaskMover", () => {
     await mover.move(file, "active");
 
     const content = modify.mock.calls[0][1] as string;
-    expect(content).toMatch(/Moved to active \(via kanban board\)/);
+    expect(content).toContain("## Activity Log");
+    expect(content).toContain("Task created");
+    expect(content).not.toMatch(/Moved to active \(via kanban board\)/);
   });
 
-  it("inserts activity log before next section", async () => {
+  it("leaves later sections untouched when no activity log entry is added", async () => {
     const contentWithNextSection = SAMPLE_CONTENT.trimEnd() + "\n\n## Notes\nSome notes\n";
     const { app, modify, read } = createMockApp();
     read.mockResolvedValue(contentWithNextSection);
@@ -96,12 +98,11 @@ describe("TaskMover", () => {
     await mover.move(file, "active");
 
     const content = modify.mock.calls[0][1] as string;
-    const logIdx = content.indexOf("Moved to active");
-    const notesIdx = content.indexOf("## Notes");
-    expect(logIdx).toBeLessThan(notesIdx);
+    expect(content).toContain("## Notes\nSome notes");
+    expect(content).not.toContain("Moved to active");
   });
 
-  it("creates activity log section when missing", async () => {
+  it("does not create an activity log section when one is missing", async () => {
     const contentNoLog = `---
 id: abc-123
 tags:
@@ -122,8 +123,8 @@ created: 2026-03-26T00:00:00Z
     await mover.move(file, "active");
 
     const content = modify.mock.calls[0][1] as string;
-    expect(content).toContain("## Activity Log");
-    expect(content).toMatch(/Moved to active \(via kanban board\)/);
+    expect(content).not.toContain("## Activity Log");
+    expect(content).not.toContain("Moved to active");
   });
 
   it("returns true on successful move", async () => {
@@ -277,7 +278,7 @@ created: 2026-03-26T00:00:00Z
       expect(content).toMatch(/- task\/review/);
     });
 
-    it("appends activity log entry for dynamic state move", async () => {
+    it("does not append activity log entries for dynamic state moves", async () => {
       const { app, modify } = createMockApp();
       const mover = new TaskMover(app, "", defaultSettings);
       const file = { path: "2 - Areas/Tasks/todo/task.md", name: "task.md" } as TFile;
@@ -285,7 +286,7 @@ created: 2026-03-26T00:00:00Z
       await mover.move(file, "blocked-upstream");
 
       const content = modify.mock.calls[0][1] as string;
-      expect(content).toContain("Moved to blocked-upstream (via kanban board)");
+      expect(content).not.toContain("Moved to blocked-upstream (via kanban board)");
     });
 
     it("with resolver: skips applyState for dynamic state (no folder mapping)", async () => {

--- a/src/adapters/task-agent/TaskMover.ts
+++ b/src/adapters/task-agent/TaskMover.ts
@@ -66,26 +66,8 @@ export class TaskMover implements WorkItemMover {
       const now = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
       updated = updated.replace(/^updated:\s*.+$/m, `updated: ${now}`);
 
-      // Append to activity log
-      const dateStr = this.formatActivityDate(new Date());
-      const logEntry = `- **${dateStr}** - Moved to ${newColumn} (via kanban board)`;
-
-      const logIndex = updated.indexOf("## Activity Log");
-      if (logIndex !== -1) {
-        const afterLog = updated.substring(logIndex + "## Activity Log".length);
-        const nextSection = afterLog.search(/\n## /);
-        const insertPos =
-          nextSection !== -1 ? logIndex + "## Activity Log".length + nextSection : updated.length;
-        updated =
-          updated.substring(0, insertPos).trimEnd() +
-          "\n" +
-          logEntry +
-          "\n" +
-          updated.substring(insertPos);
-      } else {
-        // Create Activity Log section if missing
-        updated = updated.trimEnd() + "\n\n## Activity Log\n" + logEntry + "\n";
-      }
+      // Intentionally do not append automatic activity-log entries here.
+      // Routine board moves should update state metadata without adding note noise.
 
       // Write updated content first (write-then-move pattern)
       await this.app.vault.modify(file, updated);
@@ -138,14 +120,5 @@ export class TaskMover implements WorkItemMover {
 
   private escapeRegex(s: string): string {
     return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  }
-
-  private formatActivityDate(date: Date): string {
-    const y = date.getFullYear();
-    const m = String(date.getMonth() + 1).padStart(2, "0");
-    const d = String(date.getDate()).padStart(2, "0");
-    const h = String(date.getHours()).padStart(2, "0");
-    const min = String(date.getMinutes()).padStart(2, "0");
-    return `${y}-${m}-${d} ${h}:${min}`;
   }
 }

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -182,8 +182,8 @@ export interface WorkItemParser {
 }
 
 /**
- * Moves a work item between columns (states). Handles frontmatter updates,
- * file renames, and activity log entries.
+ * Moves a work item between columns (states). Handles frontmatter updates
+ * and file renames.
  */
 export interface WorkItemMover {
   /** Move an item file to the target column, updating state/tags/timestamps. Returns true on success, false on failure. */


### PR DESCRIPTION
## Summary
- stop appending automatic `Moved to ... (via kanban board)` entries when tasks are moved between kanban columns
- keep state, `task/<state>` tag, and `updated` timestamp changes so board moves still behave correctly
- update tests and docs to make the quieter task-file behavior explicit

## Programmatic task-file write audit
Kept because they add user or system value:
- task creation frontmatter and initial `Task created` entry
- split/sub-task requested-scope log entries
- `updated` timestamp on moves, because default unordered sorting still uses it as a tiebreaker
- UUID backfill, icon edits, and background-ingestion markers

Removed because it adds noise without useful task context:
- routine kanban move activity-log entries

## Testing
- `pnpm exec vitest run`
- `pnpm run build`

Fixes #523