### PR TITLE
Fix stale xterm scroll area after hidden output

### DIFF
--- a/src/core/terminal/TerminalTab.test.ts
+++ b/src/core/terminal/TerminalTab.test.ts
@@ -402,6 +402,42 @@ describe("TerminalTab hot-reload addon handling", () => {
     expect(mocks.electronShell.openExternal).toHaveBeenCalledWith("https://example.com");
   });
 
+  it("forces xterm's viewport scroll area to resync on show", () => {
+    const syncScrollArea = vi.fn();
+    const innerRefresh = vi.fn();
+    const terminal = {
+      options: {} as Record<string, unknown>,
+      refresh: vi.fn(),
+      scrollToBottom: vi.fn(),
+      focus: vi.fn(),
+      rows: 24,
+      _core: {
+        viewport: {
+          syncScrollArea,
+          _innerRefresh: innerRefresh,
+        },
+      },
+    };
+    const tab = Object.assign(Object.create(TerminalTab.prototype), {
+      terminal,
+      containerEl: {
+        removeClass: vi.fn(),
+        hasClass: vi.fn(() => false),
+        querySelectorAll: vi.fn(() => []),
+      },
+      _isDisposed: false,
+      fitAddon: { fit: vi.fn() },
+    }) as TerminalTab;
+
+    tab.show();
+
+    expect(terminal.refresh).toHaveBeenCalledWith(0, 23);
+    expect(terminal.scrollToBottom).toHaveBeenCalledTimes(1);
+    expect(syncScrollArea).toHaveBeenCalledWith(true, true);
+    expect(innerRefresh).toHaveBeenCalledTimes(1);
+    expect(terminal.focus).toHaveBeenCalledTimes(1);
+  });
+
   it("disposes the custom link provider before terminal teardown", () => {
     const order: string[] = [];
     const tab = Object.assign(Object.create(TerminalTab.prototype), {

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -52,6 +52,15 @@ type TerminalWithAddonManager = Terminal & {
   };
 };
 
+type TerminalWithViewportInternals = Terminal & {
+  _core?: {
+    viewport?: {
+      syncScrollArea?: (immediate?: boolean, force?: boolean) => void;
+      _innerRefresh?: () => void;
+    };
+  };
+};
+
 /**
  * Open a URL via Electron's shell.openExternal, with error handling.
  * Used by the OSC 8 linkHandler and WebLinksAddon to route link clicks
@@ -677,6 +686,25 @@ export class TerminalTab {
     }
   }
 
+  /**
+   * Hidden terminals can accumulate output while xterm's viewport DOM has no
+   * layout. In that state xterm may record the new buffer length without being
+   * able to update `.xterm-scroll-area`, so a later refresh/scrollToBottom is
+   * not enough to repair the native scrollbar. Force the viewport's own scroll
+   * area refresh after the terminal is visible instead of nudging rows through
+   * the public resize API.
+   */
+  private syncViewportScrollArea(): void {
+    try {
+      if (this._isDisposed) return;
+      const viewport = (this.terminal as TerminalWithViewportInternals)._core?.viewport;
+      viewport?.syncScrollArea?.(true, true);
+      viewport?._innerRefresh?.();
+    } catch {
+      /* ignore private viewport errors during visibility/layout transitions */
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // File path link provider
   // ---------------------------------------------------------------------------
@@ -938,6 +966,7 @@ export class TerminalTab {
         // renderer draws the buffer content.
         this.terminal.refresh(0, this.terminal.rows - 1);
         this.terminal.scrollToBottom();
+        this.syncViewportScrollArea();
         this.terminal.focus();
         requestAnimationFrame(() => {
           if (this._isDisposed) return;


### PR DESCRIPTION
## Summary
- Force xterm's viewport scroll area to resync when a terminal tab is shown again
- Use the viewport sync/refresh internals instead of row resize nudging
- Add a TerminalTab unit test covering the show-time viewport resync

## Validation
- pnpm exec vitest run
- pnpm run build

Fixes #524