### PR TITLE
Fix #528: unpin tasks on context-menu state moves

### DIFF
--- a/src/adapters/task-agent/TaskCard.test.ts
+++ b/src/adapters/task-agent/TaskCard.test.ts
@@ -144,6 +144,8 @@ describe("TaskCard", () => {
     const item = makeItem();
     const ctx = makeContext({
       onMoveToColumn: vi.fn().mockResolvedValue(false),
+      isPinned: vi.fn(() => true),
+      onUnpin: vi.fn(),
     });
     const card = new TaskCard();
 
@@ -155,7 +157,52 @@ describe("TaskCard", () => {
     await doneAndCloseItem?.callback();
 
     expect(ctx.onMoveToColumn).toHaveBeenCalledWith("done");
+    expect(ctx.onUnpin).not.toHaveBeenCalled();
     expect(ctx.onCloseSessions).not.toHaveBeenCalled();
+  });
+
+  it("unpins pinned tasks after a Move to Done context-menu action succeeds", async () => {
+    const item = makeItem({ state: "active" });
+    const ctx = makeContext({
+      onMoveToColumn: vi.fn().mockResolvedValue(true),
+      isPinned: vi.fn(() => true),
+      onUnpin: vi.fn().mockResolvedValue(undefined),
+    });
+    const card = new TaskCard();
+
+    const menuItems = card.getContextMenuItems(item, ctx);
+    const moveToDoneItem = menuItems.find(
+      (menuItem) => (menuItem as any).title === "Move to Done",
+    ) as { callback: () => Promise<boolean> } | undefined;
+
+    expect(moveToDoneItem).toBeDefined();
+
+    await moveToDoneItem?.callback();
+
+    expect(ctx.onMoveToColumn).toHaveBeenCalledWith("done");
+    expect(ctx.onUnpin).toHaveBeenCalledTimes(1);
+  });
+
+  it("unpins pinned tasks after a Move to Active context-menu action succeeds", async () => {
+    const item = makeItem({ state: "todo" });
+    const ctx = makeContext({
+      onMoveToColumn: vi.fn().mockResolvedValue(true),
+      isPinned: vi.fn(() => true),
+      onUnpin: vi.fn().mockResolvedValue(undefined),
+    });
+    const card = new TaskCard();
+
+    const menuItems = card.getContextMenuItems(item, ctx);
+    const moveToActiveItem = menuItems.find(
+      (menuItem) => (menuItem as any).title === "Move to Active",
+    ) as { callback: () => Promise<boolean> } | undefined;
+
+    expect(moveToActiveItem).toBeDefined();
+
+    await moveToActiveItem?.callback();
+
+    expect(ctx.onMoveToColumn).toHaveBeenCalledWith("active");
+    expect(ctx.onUnpin).toHaveBeenCalledTimes(1);
   });
 
   it("still closes sessions for synchronous move callbacks", async () => {
@@ -172,6 +219,37 @@ describe("TaskCard", () => {
 
     expect(ctx.onMoveToColumn).toHaveBeenCalledWith("done");
     expect(ctx.onCloseSessions).toHaveBeenCalledTimes(1);
+  });
+
+  it("unpins pinned tasks before closing sessions from Done & Close Sessions", async () => {
+    const item = makeItem({ state: "active" });
+    const calls: string[] = [];
+    const ctx = makeContext({
+      onMoveToColumn: vi.fn(() => {
+        calls.push("move");
+        return true;
+      }),
+      isPinned: vi.fn(() => true),
+      onUnpin: vi.fn(async () => {
+        calls.push("unpin");
+      }),
+      onCloseSessions: vi.fn(() => {
+        calls.push("close");
+      }),
+    });
+    const card = new TaskCard();
+
+    const menuItems = card.getContextMenuItems(item, ctx);
+    const doneAndCloseItem = menuItems.find(
+      (menuItem) => (menuItem as any).title === "Done & Close Sessions",
+    ) as { callback: () => Promise<void> } | undefined;
+
+    await doneAndCloseItem?.callback();
+
+    expect(ctx.onMoveToColumn).toHaveBeenCalledWith("done");
+    expect(ctx.onUnpin).toHaveBeenCalledTimes(1);
+    expect(ctx.onCloseSessions).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(["move", "unpin", "close"]);
   });
 
   it("copies the exact context prompt from the framework callback", async () => {

--- a/src/adapters/task-agent/TaskCard.ts
+++ b/src/adapters/task-agent/TaskCard.ts
@@ -413,6 +413,17 @@ export class TaskCard implements CardRenderer {
     }
   }
 
+  private async moveToColumnFromMenu(ctx: CardActionContext, columnId: string): Promise<boolean> {
+    const moved = await ctx.onMoveToColumn(columnId);
+    if (moved === false) return false;
+
+    if (ctx.isPinned?.()) {
+      await ctx.onUnpin?.();
+    }
+
+    return true;
+  }
+
   getContextMenuItems(item: WorkItem, ctx: CardActionContext): MenuItem[] {
     const items: MenuItem[] = [];
 
@@ -451,7 +462,7 @@ export class TaskCard implements CardRenderer {
       if (col === item.state) continue;
       (items as any[]).push({
         title: `Move to ${COLUMN_LABELS[col]}`,
-        callback: () => ctx.onMoveToColumn(col),
+        callback: () => this.moveToColumnFromMenu(ctx, col),
       });
       // Done & Close Sessions right after Move to Done
       if (col === "done") {
@@ -460,7 +471,7 @@ export class TaskCard implements CardRenderer {
           callback: async () => {
             let moved: boolean | void;
             try {
-              moved = await ctx.onMoveToColumn("done");
+              moved = await this.moveToColumnFromMenu(ctx, "done");
             } catch (err) {
               console.error("[work-terminal] Failed to move task to done:", err);
               return;

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -219,7 +219,7 @@ export interface CardActionContext {
   /** Pin this item to the top of the kanban board. */
   onPin?(): void;
   /** Unpin this item, returning it to its real state column. */
-  onUnpin?(): void;
+  onUnpin?(): void | Promise<void>;
   /** Whether this item is currently pinned. */
   isPinned?(): boolean;
 }

--- a/src/framework/ListPanel.test.ts
+++ b/src/framework/ListPanel.test.ts
@@ -901,6 +901,48 @@ describe("ListPanel", () => {
     expect(ctx.isPinned?.()).toBe(false);
   });
 
+  it("returns an awaitable onUnpin action context callback", async () => {
+    const { panel, onSelect } = createListPanel();
+    const item = makeItem("task-1");
+    const ids = ["task-1"];
+    let resolveUnpin!: () => void;
+    const unpinFinished = new Promise<void>((resolve) => {
+      resolveUnpin = () => {
+        const idx = ids.indexOf(item.id);
+        if (idx >= 0) ids.splice(idx, 1);
+        resolve();
+      };
+    });
+    const pinStore = {
+      ...createMockPinStore(["task-1"]),
+      getPinnedIds: vi.fn(() => [...ids]),
+      isPinned: vi.fn((id: string) => ids.includes(id)),
+      unpin: vi.fn(() => unpinFinished),
+    };
+    panel.setPinStore(pinStore as any);
+    panel.render({ todo: [item] }, {});
+
+    const ctx = (panel as any).buildCardActionContext(item, "todo");
+    const unpinResult = ctx.onUnpin?.();
+
+    expect(unpinResult).toBeInstanceOf(Promise);
+    let settled = false;
+    void unpinResult.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+    expect(pinStore.unpin).toHaveBeenCalledWith("task-1");
+
+    resolveUnpin();
+    await unpinResult;
+
+    expect(settled).toBe(true);
+    expect(onSelect).toHaveBeenLastCalledWith(item);
+    expect(document.querySelector('[data-column="__pinned__"]')).toBeNull();
+  });
+
   it("rekeys pinned items when rekeyCustomOrder is called", () => {
     const { panel } = createListPanel();
     const pinStore = createMockPinStore(["old-id"]);

--- a/src/framework/ListPanel.ts
+++ b/src/framework/ListPanel.ts
@@ -759,12 +759,11 @@ export class ListPanel {
     });
   }
 
-  private unpinItem(item: WorkItem): void {
+  private async unpinItem(item: WorkItem): Promise<void> {
     if (!this.pinStore) return;
-    void this.pinStore.unpin(item.id).then(() => {
-      this.render(this.groups, this.customOrder);
-      this.selectItem(item);
-    });
+    await this.pinStore.unpin(item.id);
+    this.render(this.groups, this.customOrder);
+    this.selectItem(item);
   }
 
   setIngesting(id: string): void {


### PR DESCRIPTION
## Summary
- Unpins pinned tasks after successful context-menu state moves.
- Keeps failed moves pinned so a failed transition does not unexpectedly remove the task from the Pinned section.
- Leaves drag-drop behaviour unchanged.

## Context menu entries covered
- `Move to Priority`
- `Move to Active`
- `Move to To Do`
- `Move to Done`
- `Done & Close Sessions`

There is no `Move to Pinned` state/category entry. The existing `Pin to Top`/`Unpin` action is separate, and `Move to Top` only reorders within the current visual section.

## Implementation approach
Chose point-of-use handling in `TaskCard`: context-menu state move callbacks now route through a small helper that awaits `ctx.onMoveToColumn(...)`, then calls `ctx.onUnpin?.()` only when the move succeeds and `ctx.isPinned?.()` is true.

I did not put this in `TaskMover`, because drag-drop also uses the mover and already has its own pinned-section handling. Keeping this at the context-menu callback preserves the issue scope.

## Tests
- Added coverage for pinned task `Move to Done` clearing the pin.
- Added coverage for pinned task `Move to Active` clearing the pin.
- Added coverage that failed `Done & Close Sessions` moves do not unpin.
- Added coverage that `Done & Close Sessions` unpins before closing sessions after a successful move.

Validation:
- `pnpm exec vitest run` passed: 64 files, 1368 tests.
- `pnpm run build` passed.

Closes #528
