### PR TITLE
Fix #527: address missed Copilot comments from PRs #525 and #526

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ src/
       types.ts               # TaskFile, TaskState, KanbanColumn, STATE_FOLDER_MAP
       TaskAgentConfig.ts     # PluginConfig: columns, creationColumns, settings, itemName
       TaskParser.ts          # MetadataCache parsing, abandoned filtering, goal normalisation
-      TaskMover.ts           # Regex frontmatter updates, write-then-move, activity log
+      TaskMover.ts           # Regex frontmatter/tag updates, timestamp refresh, write-then-move
       TaskCard.ts            # Source/score/goal/blocker badges, compound context menu
       TaskFileTemplate.ts    # UUID + YAML frontmatter + slug filename generation
       TaskPromptBuilder.ts   # Title/state/path + conditional deadline/blocker

--- a/src/core/terminal/TerminalTab.test.ts
+++ b/src/core/terminal/TerminalTab.test.ts
@@ -152,7 +152,7 @@ vi.mock("./PythonCheck", () => ({
     "Python 3 is required for terminal tabs. Install Python 3.7+ and ensure `python3` is on your PATH.",
 }));
 
-import { resolvePtyWrapperPath, TerminalTab } from "./TerminalTab";
+import { __resetViewportResyncWarnOnce, resolvePtyWrapperPath, TerminalTab } from "./TerminalTab";
 
 class FakeElement {
   appendChild = vi.fn();
@@ -191,6 +191,7 @@ describe("TerminalTab hot-reload addon handling", () => {
       return 1;
     }) as typeof requestAnimationFrame);
     vi.spyOn(console, "warn").mockImplementation(() => {});
+    __resetViewportResyncWarnOnce();
     vi.spyOn(TerminalTab.prototype as never, "startStateTracking").mockImplementation(() => {});
   });
 
@@ -407,6 +408,7 @@ describe("TerminalTab hot-reload addon handling", () => {
     expect(console.warn).toHaveBeenCalledTimes(1);
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining("xterm viewport scroll area internals unavailable"),
+      expect.any(Error),
     );
   });
 

--- a/src/core/terminal/TerminalTab.test.ts
+++ b/src/core/terminal/TerminalTab.test.ts
@@ -372,6 +372,44 @@ describe("TerminalTab hot-reload addon handling", () => {
     expect(terminal.options.linkHandler).toBe(existingHandler);
   });
 
+  it("falls back to terminal.resize once and warns once when viewport internals are missing", () => {
+    const makeTab = () => {
+      const terminal = {
+        options: {} as Record<string, unknown>,
+        refresh: vi.fn(),
+        scrollToBottom: vi.fn(),
+        focus: vi.fn(),
+        resize: vi.fn(),
+        cols: 80,
+        rows: 24,
+      };
+      const tab = Object.assign(Object.create(TerminalTab.prototype), {
+        terminal,
+        containerEl: {
+          removeClass: vi.fn(),
+          hasClass: vi.fn(() => false),
+          querySelectorAll: vi.fn(() => []),
+        },
+        _isDisposed: false,
+        fitAddon: { fit: vi.fn() },
+      }) as TerminalTab;
+      return { tab, terminal };
+    };
+
+    const first = makeTab();
+    const second = makeTab();
+
+    first.tab.show();
+    second.tab.show();
+
+    expect(first.terminal.resize).toHaveBeenCalledWith(80, 24);
+    expect(second.terminal.resize).toHaveBeenCalledWith(80, 24);
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("xterm viewport scroll area internals unavailable"),
+    );
+  });
+
   it("backfills linkHandler on show() for live terminals missing the handler", () => {
     const tab = Object.assign(Object.create(TerminalTab.prototype), {
       terminal: {

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -94,7 +94,13 @@ function warnViewportResyncFallback(err: unknown): void {
   hasWarnedViewportResync = true;
   console.warn(
     `[work-terminal] xterm viewport scroll area internals unavailable or failed; using terminal.resize() fallback. ${errorMessage(err)}`,
+    err,
   );
+}
+
+/** @internal Test helper for deterministic warn-once assertions. */
+export function __resetViewportResyncWarnOnce(): void {
+  hasWarnedViewportResync = false;
 }
 
 export function resolvePtyWrapperPath(pluginDir?: string): string {

--- a/src/core/terminal/TerminalTab.ts
+++ b/src/core/terminal/TerminalTab.ts
@@ -38,6 +38,7 @@ export type AgentState = AgentRuntimeState;
 export type ClaudeState = AgentState;
 
 let sessionCounter = 0;
+let hasWarnedViewportResync = false;
 const TERMINAL_SCROLLBACK = 5000;
 
 type TerminalWithAddonManager = Terminal & {
@@ -82,6 +83,18 @@ function shouldPreservePrintableOptionCombo(event: KeyboardEvent): boolean {
   if (!event.altKey || event.ctrlKey || event.metaKey) return false;
   if (event.getModifierState?.("AltGraph")) return false;
   return /^Digit\d$/.test(event.code);
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error && err.message ? err.message : String(err);
+}
+
+function warnViewportResyncFallback(err: unknown): void {
+  if (hasWarnedViewportResync) return;
+  hasWarnedViewportResync = true;
+  console.warn(
+    `[work-terminal] xterm viewport scroll area internals unavailable or failed; using terminal.resize() fallback. ${errorMessage(err)}`,
+  );
 }
 
 export function resolvePtyWrapperPath(pluginDir?: string): string {
@@ -690,18 +703,34 @@ export class TerminalTab {
    * Hidden terminals can accumulate output while xterm's viewport DOM has no
    * layout. In that state xterm may record the new buffer length without being
    * able to update `.xterm-scroll-area`, so a later refresh/scrollToBottom is
-   * not enough to repair the native scrollbar. Force the viewport's own scroll
-   * area refresh after the terminal is visible instead of nudging rows through
-   * the public resize API.
+   * not enough to repair the native scrollbar. Prefer xterm's viewport refresh
+   * internals after the terminal is visible, with a public resize fallback for
+   * xterm upgrades or renderer states where those internals are unavailable.
    */
   private syncViewportScrollArea(): void {
+    if (this._isDisposed) return;
+
     try {
-      if (this._isDisposed) return;
       const viewport = (this.terminal as TerminalWithViewportInternals)._core?.viewport;
-      viewport?.syncScrollArea?.(true, true);
-      viewport?._innerRefresh?.();
+      if (
+        typeof viewport?.syncScrollArea !== "function" ||
+        typeof viewport._innerRefresh !== "function"
+      ) {
+        throw new Error("xterm viewport scroll area internals unavailable");
+      }
+      viewport.syncScrollArea(true, true);
+      viewport._innerRefresh();
+      return;
+    } catch (err) {
+      warnViewportResyncFallback(err);
+    }
+
+    try {
+      const resize = this.terminal.resize;
+      if (typeof resize !== "function") return;
+      resize.call(this.terminal, this.terminal.cols, this.terminal.rows);
     } catch {
-      /* ignore private viewport errors during visibility/layout transitions */
+      /* ignore resize fallback errors during visibility/layout transitions */
     }
   }
 


### PR DESCRIPTION
## Summary
- Syncs the contributor-facing `TaskMover.ts` description in `CLAUDE.md` with current behaviour after routine board-move activity log writes were removed.
- Hardens `TerminalTab.show()` viewport resync by falling back to a public `terminal.resize(cols, rows)` nudge when xterm private viewport internals are missing or throw.
- Adds warn-once diagnostics for the fallback path so future xterm internal changes are visible without noisy repeated logs.
- Adds unit coverage for the fallback and warn-once behaviour. Existing coverage still verifies the primary private-internals path.

## Process fix
The autopilot process fix is handled at the skill layer rather than in this repo. The loaded `issue-autopilot` workflow now requires fetching inline PR comments, building a terminal-state checklist, and blocking merge until each substantive inline comment is addressed, deferred with a follow-up issue, or documented as non-actionable.

## Validation
- `pnpm exec vitest run` passed after each commit
- `pnpm run build` passed

Closes #527
