### PR TITLE
fix(#531): PromptBox reads settings at submit time via getSettings callback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,9 @@ Every user-visible feature must have an appropriate settings UI or interaction s
 ### Documentation requirement
 Updates to the user guide (`docs/user-guide.md`) are always part of implementing a feature. PRs that add user-visible features or change existing behaviour must include corresponding user guide updates. Treat missing documentation the same as missing tests - the feature is not done.
 
+### Settings access pattern
+**Prefer fetching settings at the point of use over caching them at construction time.** Components that cache a settings snapshot (e.g. `this.settings = settings` in a constructor) silently use stale values after the user changes settings - a bug that is easy to introduce and hard to notice. The preferred pattern is to accept a `getSettings: () => Record<string, any>` callback and call it when settings are actually needed (e.g. at submit time). This ensures every action uses current values without requiring any "sync on change" wiring, and eliminates an entire class of stale-state bugs. `MainView` keeps a single authoritative `this.settings` that is updated on every `SETTINGS_CHANGED_EVENT`; components that need settings should read from it via a callback (`() => this.settings`) rather than receiving a one-time snapshot.
+
 ### Placeholder format
 All new placeholder variables must use the `$name` form (camelCase, dollar prefix), matching the existing `AgentContextPrompt` / profile-template resolver. Do not introduce `{{NAME}}` or `{name}` forms. When extending a resolver with a new placeholder, add it to `AgentContextPrompt.expandProfilePlaceholders` / `buildAgentContextPrompt` or the adjacent enrichment resolver rather than inventing a new parallel placeholder syntax.
 

--- a/src/framework/MainView.ts
+++ b/src/framework/MainView.ts
@@ -382,7 +382,7 @@ export class MainView extends ItemView {
       this.leftPanelEl,
       this.adapter,
       this.pluginRef,
-      settings,
+      () => this.settings,
       (path: string) => {
         // Placeholder card callback
         this.listPanel?.addPlaceholder(path);

--- a/src/framework/PromptBox.test.ts
+++ b/src/framework/PromptBox.test.ts
@@ -416,6 +416,39 @@ describe("PromptBox", () => {
     );
   });
 
+  it("resolves placeholder as unsuccessful when getSettings callback throws", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(600);
+    const parentEl = document.createElement("div");
+    document.body.appendChild(parentEl);
+    const onPlaceholderAdd = vi.fn();
+    const onPlaceholderResolve = vi.fn();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    new PromptBox(
+      parentEl,
+      makeAdapter(),
+      makePlugin(),
+      () => {
+        throw new Error("settings unavailable");
+      },
+      onPlaceholderAdd,
+      onPlaceholderResolve,
+      vi.fn(),
+    );
+    const inputEl = parentEl.querySelector(".wt-prompt-input") as HTMLTextAreaElement;
+    const sendBtn = parentEl.querySelector(".wt-prompt-send") as HTMLButtonElement;
+
+    inputEl.value = "Task with bad settings";
+    sendBtn.click();
+    await flushPromises();
+
+    expect(onPlaceholderAdd).toHaveBeenCalledWith("__pending_600");
+    expect(onPlaceholderResolve).toHaveBeenCalledWith("__pending_600", false);
+    expect(consoleError).toHaveBeenCalledWith(
+      "[work-terminal] Item creation failed:",
+      expect.any(Error),
+    );
+  });
+
   it("ignores blank titles and resolves failures as unsuccessful placeholders", async () => {
     vi.spyOn(Date, "now").mockReturnValue(555);
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/src/framework/PromptBox.test.ts
+++ b/src/framework/PromptBox.test.ts
@@ -124,7 +124,7 @@ function createPromptBox(options?: {
     parentEl,
     adapter,
     plugin,
-    settings,
+    () => settings,
     onPlaceholderAdd,
     onPlaceholderResolve,
     onNewItemCreated,
@@ -348,7 +348,15 @@ describe("PromptBox", () => {
     const parentEl = document.createElement("div");
     document.body.appendChild(parentEl);
     const adapter = makeAdapter();
-    const pb = new PromptBox(parentEl, adapter, makePlugin(), {}, vi.fn(), vi.fn(), vi.fn());
+    const pb = new PromptBox(
+      parentEl,
+      adapter,
+      makePlugin(),
+      () => ({}),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+    );
 
     const selectEl = parentEl.querySelector(".wt-prompt-column-select") as HTMLSelectElement;
     expect(selectEl.options.length).toBe(2);
@@ -367,6 +375,45 @@ describe("PromptBox", () => {
     expect(selectEl.options[0].selected).toBe(true);
     expect(selectEl.options[1].value).toBe("done");
     expect(selectEl.options[2].value).toBe("active");
+  });
+
+  it("reads settings at submit time so changes between constructions and submissions take effect", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(99);
+    const onItemCreated = vi.fn().mockResolvedValue(undefined);
+    const parentEl = document.createElement("div");
+    document.body.appendChild(parentEl);
+    let currentSettings: Record<string, unknown> = { "adapter.enrichmentMode": "background" };
+    new PromptBox(
+      parentEl,
+      makeAdapter(onItemCreated),
+      makePlugin(),
+      () => currentSettings,
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+    );
+    const inputEl = parentEl.querySelector(".wt-prompt-input") as HTMLTextAreaElement;
+    const sendBtn = parentEl.querySelector(".wt-prompt-send") as HTMLButtonElement;
+
+    // Submit with initial settings - should pass background mode
+    inputEl.value = "Task A";
+    sendBtn.click();
+    await flushPromises();
+    expect(onItemCreated).toHaveBeenLastCalledWith(
+      "Task A",
+      expect.objectContaining({ "adapter.enrichmentMode": "background" }),
+    );
+
+    // Simulate settings change (e.g. user switched to foreground mode in settings dialog)
+    currentSettings = { "adapter.enrichmentMode": "foreground" };
+
+    inputEl.value = "Task B";
+    sendBtn.click();
+    await flushPromises();
+    expect(onItemCreated).toHaveBeenLastCalledWith(
+      "Task B",
+      expect.objectContaining({ "adapter.enrichmentMode": "foreground" }),
+    );
   });
 
   it("ignores blank titles and resolves failures as unsuccessful placeholders", async () => {

--- a/src/framework/PromptBox.ts
+++ b/src/framework/PromptBox.ts
@@ -135,11 +135,12 @@ export class PromptBox {
     const placeholderPath = `__pending_${Date.now()}`;
     this.onPlaceholderAdd(placeholderPath);
 
-    // Fetch current settings at submit time so changes (e.g. switching
-    // enrichment mode) take effect without requiring a plugin reload.
-    const settings = this.getSettings();
-
     try {
+      // Fetch current settings at submit time so changes (e.g. switching
+      // enrichment mode) take effect without requiring a plugin reload.
+      // Placed inside try/catch so a throwing callback resolves the placeholder
+      // as unsuccessful rather than leaving it stuck.
+      const settings = this.getSettings();
       // Adapter handles actual file creation
       let hasCardMapping = false;
       if (this.adapter.onItemCreated) {

--- a/src/framework/PromptBox.ts
+++ b/src/framework/PromptBox.ts
@@ -1,7 +1,7 @@
 /**
  * PromptBox - inline item creation UI with title input and column selector.
  * Enter to submit, Shift+Enter for newline.
- * Coordinates with adapter.onItemCreated for background enrichment.
+ * Coordinates with adapter.onItemCreated for foreground and background enrichment.
  */
 import type { Plugin } from "obsidian";
 import { getProfileLaunchConfig, type AgentProfile } from "../core/agents/AgentProfile";
@@ -13,7 +13,7 @@ export class PromptBox {
   private columnSelect: HTMLSelectElement;
   private adapter: AdapterBundle;
   private plugin: Plugin;
-  private settings: Record<string, any>;
+  private getSettings: () => Record<string, any>;
   private onPlaceholderAdd: (path: string) => void;
   private onPlaceholderResolve: (path: string, success: boolean) => void;
   private onNewItemCreated: (result: ItemCreationResult, placeholderPath: string) => void;
@@ -23,14 +23,14 @@ export class PromptBox {
     parentEl: HTMLElement,
     adapter: AdapterBundle,
     plugin: Plugin,
-    settings: Record<string, any>,
+    getSettings: () => Record<string, any>,
     onPlaceholderAdd: (path: string) => void,
     onPlaceholderResolve: (path: string, success: boolean) => void,
     onNewItemCreated: (result: ItemCreationResult, placeholderPath: string) => void,
   ) {
     this.adapter = adapter;
     this.plugin = plugin;
-    this.settings = settings;
+    this.getSettings = getSettings;
     this.onPlaceholderAdd = onPlaceholderAdd;
     this.onPlaceholderResolve = onPlaceholderResolve;
     this.onNewItemCreated = onNewItemCreated;
@@ -135,17 +135,21 @@ export class PromptBox {
     const placeholderPath = `__pending_${Date.now()}`;
     this.onPlaceholderAdd(placeholderPath);
 
+    // Fetch current settings at submit time so changes (e.g. switching
+    // enrichment mode) take effect without requiring a plugin reload.
+    const settings = this.getSettings();
+
     try {
       // Adapter handles actual file creation
       let hasCardMapping = false;
       if (this.adapter.onItemCreated) {
         // Resolve enrichment profile if one is configured
         const enrichmentSettings: Record<string, any> = {
-          ...this.settings,
+          ...settings,
           _columnId: columnId,
           _placeholderPath: placeholderPath,
         };
-        const profileId = this.settings["adapter.enrichmentProfile"];
+        const profileId = settings["adapter.enrichmentProfile"];
         if (profileId) {
           const profileMgr = (this.plugin as any).profileManager;
           const profile = profileMgr?.getProfile?.(profileId);


### PR DESCRIPTION
## Summary

- `PromptBox` was caching a settings snapshot at construction time, causing enrichment mode changes to be silently ignored
- New tasks were always enriched via headless background agent even when foreground mode was configured, because `PromptBox.settings` never reflected post-construction settings changes
- Constructor now accepts `getSettings: () => Record<string, any>` callback; `submit()` calls it at execution time so every task creation uses current settings
- `MainView` passes `() => this.settings` which is already kept in sync by `_handleSettingsChanged`
- Added `CLAUDE.md` guidance: prefer `getSettings` callbacks over cached snapshots to avoid this class of stale-state bug

## Test plan

- [x] `pnpm exec vitest run src/framework/PromptBox.test.ts` - new test verifies settings are read at submit time
- [x] `pnpm exec vitest run` - full suite passes (3 pre-existing failures in `obsidianAutomation.test.ts` unrelated to this change)
- [x] `pnpm run build` - clean build
- [x] `pnpm run lint` - no lint errors

Fixes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)