### PR TITLE
Keep launch preview plugin path aligned with runtime

### DIFF
--- a/src/core/workspace/pluginPaths.test.ts
+++ b/src/core/workspace/pluginPaths.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as path from "node:path";
+import { resolvePluginDir } from "./pluginPaths";
+
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
+});
+
+describe("resolvePluginDir", () => {
+  it("normalizes a relative vault base path before resolving the plugin directory", () => {
+    process.env.HOME = "/home/example";
+    const app = { vault: { adapter: { basePath: "Vault" } } } as any;
+
+    expect(resolvePluginDir(app, { id: "work-terminal" })).toBe(
+      path.resolve("/home/example", "Vault", ".obsidian/plugins/work-terminal"),
+    );
+  });
+
+  it("resolves tilde and getBasePath-only vault locations", () => {
+    process.env.HOME = "/home/example";
+    const tildeApp = { vault: { adapter: { basePath: "~/Vault" } } } as any;
+    const getterApp = { vault: { adapter: { getBasePath: () => "OtherVault" } } } as any;
+
+    expect(resolvePluginDir(tildeApp, { id: "work-terminal" })).toBe(
+      path.resolve("/home/example/Vault/.obsidian/plugins/work-terminal"),
+    );
+    expect(resolvePluginDir(getterApp, { id: "work-terminal" })).toBe(
+      path.resolve("/home/example/OtherVault/.obsidian/plugins/work-terminal"),
+    );
+  });
+
+  it("resolves a relative manifest directory from cwd when the vault base is empty", () => {
+    process.env.HOME = "";
+    process.env.USERPROFILE = "";
+    const app = { vault: { adapter: { basePath: "" } } } as any;
+
+    expect(resolvePluginDir(app, { id: "work-terminal" })).toBe(
+      path.resolve(".obsidian/plugins/work-terminal"),
+    );
+  });
+
+  it("keeps an absolute manifest directory unchanged", () => {
+    const app = { vault: { adapter: { basePath: "/ignored" } } } as any;
+
+    expect(resolvePluginDir(app, { id: "work-terminal", dir: "/plugins/work-terminal" })).toBe(
+      "/plugins/work-terminal",
+    );
+  });
+});

--- a/src/core/workspace/pluginPaths.ts
+++ b/src/core/workspace/pluginPaths.ts
@@ -1,0 +1,24 @@
+import type { App } from "obsidian";
+import { electronRequire, expandTilde } from "../utils";
+
+export function resolveVaultBasePath(app: App): string {
+  const path = electronRequire("path") as typeof import("path");
+  const adapter = (app as any)?.vault?.adapter;
+  let vaultPath = expandTilde(adapter?.basePath || adapter?.getBasePath?.() || "");
+  const homeDir = process.env.HOME || process.env.USERPROFILE || "";
+
+  if (vaultPath && !path.isAbsolute(vaultPath)) {
+    vaultPath = homeDir ? path.resolve(homeDir, vaultPath) : path.resolve(vaultPath);
+  }
+
+  return vaultPath;
+}
+
+export function resolvePluginDir(app: App, manifest: { id: string; dir?: string }): string {
+  const path = electronRequire("path") as typeof import("path");
+  const manifestDir = manifest.dir || `.obsidian/plugins/${manifest.id}`;
+  if (path.isAbsolute(manifestDir)) return manifestDir;
+
+  const vaultBasePath = resolveVaultBasePath(app);
+  return vaultBasePath ? path.resolve(vaultBasePath, manifestDir) : path.resolve(manifestDir);
+}

--- a/src/framework/SettingsTab.ts
+++ b/src/framework/SettingsTab.ts
@@ -78,7 +78,7 @@ import type { ViewMode, RecentThreshold } from "./ActivityTracker";
 import type { DetailViewPlacement, DetailViewSplitDirection } from "../core/detailViewPlacement";
 import { resolveDetailViewOptions } from "../core/detailViewPlacement";
 import { formatVersionForSettings } from "./version";
-import { electronRequire, expandTilde } from "../core/utils";
+import { resolvePluginDir as resolveSharedPluginDir } from "../core/workspace/pluginPaths";
 import { checkPython3Available } from "../core/terminal/PythonCheck";
 import { resolvePtyWrapperPath } from "../core/terminal/PtyLaunch";
 import {
@@ -439,12 +439,7 @@ export class WorkTerminalSettingsTab extends PluginSettingTab {
    * Agent actions dialogs.
    */
   private resolvePluginDir(): string {
-    const path = electronRequire("path") as typeof import("path");
-    const manifestDir = this.plugin.manifest.dir || `.obsidian/plugins/${this.plugin.manifest.id}`;
-    if (path.isAbsolute(manifestDir)) return manifestDir;
-    const adapter = (this.app as any)?.vault?.adapter;
-    const vaultPath = expandTilde(adapter?.basePath || adapter?.getBasePath?.() || "");
-    return path.resolve(vaultPath, manifestDir);
+    return resolveSharedPluginDir(this.app, this.plugin.manifest);
   }
 
   private renderAgentsSection(containerEl: HTMLElement, settings: SettingsSnapshot): void {

--- a/src/framework/TerminalPanelView.ts
+++ b/src/framework/TerminalPanelView.ts
@@ -43,6 +43,10 @@ import {
   type AgentLaunchConfig,
 } from "../core/agents/AgentProfile";
 import { createProfileIcon } from "../ui/ProfileIcons";
+import {
+  resolvePluginDir as resolveSharedPluginDir,
+  resolveVaultBasePath,
+} from "../core/workspace/pluginPaths";
 import { checkPython3Available } from "../core/terminal/PythonCheck";
 import { resolvePtyWrapperPath } from "../core/terminal/PtyLaunch";
 import {
@@ -1283,27 +1287,11 @@ export class TerminalPanelView {
   }
 
   private resolveVaultBasePath(): string {
-    const path = electronRequire("path") as typeof import("path");
-    const adapter = (this.plugin.app as any)?.vault?.adapter as any;
-    let vaultPath = expandTilde(adapter?.basePath || adapter?.getBasePath?.() || "");
-    const homeDir = process.env.HOME || process.env.USERPROFILE || "";
-
-    if (vaultPath && !path.isAbsolute(vaultPath)) {
-      vaultPath = homeDir ? path.resolve(homeDir, vaultPath) : path.resolve(vaultPath);
-    }
-
-    return vaultPath;
+    return resolveVaultBasePath(this.plugin.app);
   }
 
   private resolvePluginDir(): string {
-    const path = electronRequire("path") as typeof import("path");
-    const manifestDir = this.plugin.manifest.dir || `.obsidian/plugins/${this.plugin.manifest.id}`;
-    if (path.isAbsolute(manifestDir)) {
-      return manifestDir;
-    }
-
-    const vaultBasePath = this.resolveVaultBasePath();
-    return vaultBasePath ? path.resolve(vaultBasePath, manifestDir) : path.resolve(manifestDir);
+    return resolveSharedPluginDir(this.plugin.app, this.plugin.manifest);
   }
 
   private resolveWorkItemPath(itemPath: string): string {


### PR DESCRIPTION
## Summary
- share vault/plugin directory resolution between settings preview and terminal runtime
- preserve relative, tilde, getter-only, empty-base, and absolute-manifest behavior
- add focused path resolution regressions

## Validation
- `pnpm exec vitest run` (1,386 passed before final test-case additions)
- `pnpm exec vitest run src/core/workspace/pluginPaths.test.ts` (4 passed)
- `pnpm run build`
- `pnpm run lint`
- `git diff --check`

Closes #540