### PR TITLE
Add OpenCode as a first-party agent

### DIFF
--- a/docs/process-spawning.md
+++ b/docs/process-spawning.md
@@ -30,7 +30,15 @@ User-configured command (default: `copilot`) with optional `-i <prompt>`.
 - **Source**: `src/core/agents/AgentLauncher.ts` - `buildCopilotArgs()`
 - **Mechanism**: Spawned inside `pty-wrapper.py` via `TerminalTab.spawnPty()`
 
-### 4. AWS Strands
+### 4. OpenCode CLI
+
+Profile-configured command (default: `opencode`) with optional `--prompt <prompt>`. The prompt is passed as one argv value.
+
+- **Trigger**: User launches an OpenCode session via profile launch modal or tab bar button
+- **Source**: `src/core/agents/AgentProfile.ts` launch configuration and the shared `src/core/agents/AgentLauncher.ts` pipeline
+- **Mechanism**: Spawned inside `pty-wrapper.py` via `TerminalTab.spawnPty()`
+
+### 5. AWS Strands
 
 User-configured command with optional positional prompt argument. Extra args from settings are prepended.
 
@@ -38,7 +46,7 @@ User-configured command with optional positional prompt argument. Extra args fro
 - **Source**: `src/core/agents/AgentLauncher.ts` - `buildStrandsArgs()`
 - **Mechanism**: Spawned inside `pty-wrapper.py` via `TerminalTab.spawnPty()`
 
-### 5. Custom agent profiles
+### 6. Custom agent profiles
 
 User-configured command with user-configured arguments. Any executable can be launched as a custom agent type.
 
@@ -46,7 +54,7 @@ User-configured command with user-configured arguments. Any executable can be la
 - **Source**: `src/core/agents/AgentLauncher.ts` - `buildCustomArgs()`
 - **Mechanism**: Spawned inside `pty-wrapper.py` via `TerminalTab.spawnPty()`
 
-### 6. Headless agent (background enrichment)
+### 7. Headless agent (background enrichment)
 
 One-shot `claude -p <prompt> --output-format text` (or the configured enrichment profile command) for background task enrichment. Extra args from the profile are prepended.
 
@@ -54,7 +62,7 @@ One-shot `claude -p <prompt> --output-format text` (or the configured enrichment
 - **Source**: `src/core/claude/HeadlessClaude.ts` - `spawnHeadlessClaude()`
 - **Mechanism**: `child_process.spawn()` with array args (no shell interpretation)
 
-### 7. VS Code
+### 8. VS Code
 
 `code --goto "{file}:{line}"` on terminal file-link clicks (Cmd+click on file paths in terminal output). Falls back to `shell.openPath()` if VS Code is not available.
 
@@ -62,7 +70,7 @@ One-shot `claude -p <prompt> --output-format text` (or the configured enrichment
 - **Source**: `src/core/terminal/TerminalTab.ts` - link provider `activate` callback
 - **Mechanism**: `child_process.exec()` (string form, with shell interpretation)
 
-**Note**: All terminal processes (Shell, Claude, Copilot, Strands, custom agents) run inside `pty-wrapper.py`, a Python script that uses `pty.fork()` to provide a real pseudo-terminal. Electron's sandbox blocks native PTY access, so this Python wrapper is the necessary bridge between xterm.js and the child process.
+**Note**: All terminal processes (Shell, Claude, Copilot, OpenCode, Strands, custom agents) run inside `pty-wrapper.py`, a Python script that uses `pty.fork()` to provide a real pseudo-terminal. Electron's sandbox blocks native PTY access, so this Python wrapper is the necessary bridge between xterm.js and the child process.
 
 ## Filesystem access
 
@@ -113,7 +121,7 @@ Enrichment failure logs are written to `<vault>/<configDir>/plugins/work-termina
 
 ## Security properties
 
-- **All external commands are user-configured** - Shell, Claude, Copilot, and Strands commands are set in plugin settings, not hardcoded. The plugin resolves them via `resolveCommandInfo()`, which searches an augmented PATH that includes `$PATH`, the user's login shell PATH (via `$SHELL -lc 'echo $PATH'`), and nvm/fnm version-manager directories as a fallback. It validates commands exist before spawning. (`src/core/agents/AgentLauncher.ts`)
+- **External commands are profile-configurable** - Shell and agent commands can be overridden in profiles or settings; built-in types provide defaults including `claude`, `copilot`, and `opencode`. The plugin resolves them via `resolveCommandInfo()`, which searches an augmented PATH that includes `$PATH`, the user's login shell PATH (via `$SHELL -lc 'echo $PATH'`), and nvm/fnm version-manager directories as a fallback. It validates commands exist before spawning. (`src/core/agents/AgentLauncher.ts`)
 - **`child_process.spawn()` array form - no shell interpretation** - Arguments are constructed as arrays and passed to `spawn()`, which invokes executables directly without a shell. This prevents command injection. The one exception is the VS Code `code --goto` call which uses `exec()` with a quoted path. (`src/core/terminal/TerminalTab.ts`, `src/core/claude/HeadlessClaude.ts`)
 - **Zero outbound network requests from the plugin itself** - The plugin makes no network calls. Any network activity comes from the spawned processes (e.g. Claude CLI communicating with Anthropic's API).
 - **Vault modifications exclusively through Obsidian API** - Vault file operations use `app.vault.create()` / `app.vault.modify()` / `app.vault.rename()` / `app.vault.trash()`, never direct `fs.*` writes to vault files. Enrichment logs use the lower-level `app.vault.adapter.write()` but this is still within the Obsidian API surface.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -399,7 +399,7 @@ Agent profiles define reusable launch configurations for terminal sessions. Open
 Each profile includes:
 
 - **Name** - display name shown in the tab bar and launch modal
-- **Agent type** - the type of agent (Claude, Copilot, Strands, or custom)
+- **Agent type** - the type of agent (Claude, Copilot, OpenCode, Strands, or custom)
 - **Command** - the executable to run (e.g. `claude`, `copilot`, `gh`)
 - **Arguments** - command-line arguments passed to the agent
 - **Default CWD** - working directory for the session (supports `~` expansion)
@@ -407,6 +407,8 @@ Each profile includes:
 - **Context prompt** - a prompt template injected when launching with task context
 
 The per-profile **Context prompt** field is the place to configure additional context that used to live in the removed **Additional agent context prompt** setting (issue #472). Set it on each profile that should inject task context on top of the adapter prompt.
+
+**OpenCode** is available as a first-party agent type. Leave its executable blank to use `opencode`; Work Terminal resolves it through the same augmented PATH and optional login-shell flow as other agents. Contextual OpenCode profiles pass the complete prompt as `--prompt <value>` with the value kept as one argv entry, while non-context launches add no prompt flag. If the CLI is missing, install it with `brew install anomalyco/tap/opencode` or follow the [OpenCode documentation](https://opencode.ai/docs). The branded OpenCode icon is available in the profile icon picker.
 
 **Placeholders**: The **Arguments** and **Context prompt** fields support placeholder variables that expand to work item data at launch time:
 
@@ -434,7 +436,7 @@ For example, an argument string like `--file $absoluteFilePath --task $title` wo
 
 **Import/Export**: Profiles can be exported as JSON for sharing or backup, and imported from JSON to quickly set up a new installation.
 
-**Last-Claude-profile deletion guard**: The Profile Manager prevents deleting a Claude-family profile when doing so would leave zero Claude profiles. This keeps the fallback chain for **Split Task** and **Retry Enrichment** intact - both actions launch Claude specifically, so at least one Claude profile must exist. The **Delete** button on the edit modal is greyed out with a tooltip explaining that at least one Claude profile must remain for **Split Task** and **Retry Enrichment** in that situation. Non-Claude profiles (shell, Copilot, Strands, custom) are never counted towards the minimum and can always be deleted. Built-in `default-claude` and `default-claude-ctx` profiles are not specially protected - either can be deleted as long as another Claude profile remains.
+**Last-Claude-profile deletion guard**: The Profile Manager prevents deleting a Claude-family profile when doing so would leave zero Claude profiles. This keeps the fallback chain for **Split Task** and **Retry Enrichment** intact - both actions launch Claude specifically, so at least one Claude profile must exist. The **Delete** button on the edit modal is greyed out with a tooltip explaining that at least one Claude profile must remain for **Split Task** and **Retry Enrichment** in that situation. Non-Claude profiles (shell, Copilot, OpenCode, Strands, custom) are never counted towards the minimum and can always be deleted. Built-in `default-claude` and `default-claude-ctx` profiles are not specially protected - either can be deleted as long as another Claude profile remains.
 
 ### Card indicator rules
 

--- a/src/core/agents/AgentLauncher.test.ts
+++ b/src/core/agents/AgentLauncher.test.ts
@@ -65,6 +65,20 @@ describe("AgentLauncher", () => {
     ).toEqual(["--model", "gpt-5.4", "--allow-all-tools", "-i", "Review this task"]);
   });
 
+  it("builds OpenCode args with one flag-delimited prompt argument", () => {
+    const prompt = "Review this task\nKeep 'single' and \"double\" quotes";
+    expect(buildAgentArgs("opencode", "--model test", prompt)).toEqual([
+      "--model",
+      "test",
+      "--prompt",
+      prompt,
+    ]);
+  });
+
+  it("does not add an OpenCode prompt flag without context", () => {
+    expect(buildAgentArgs("opencode", "--model test")).toEqual(["--model", "test"]);
+  });
+
   it("builds agent args for strands with positional prompt injection", () => {
     expect(buildAgentArgs("strands", "--verbose --region us-east-1", "Review this task")).toEqual([
       "--verbose",
@@ -324,5 +338,12 @@ describe("AgentLauncher", () => {
 
   it("builds the Copilot missing CLI notice", () => {
     expect(buildMissingCliNotice("copilot", "copilot")).toContain("brew install copilot-cli");
+  });
+
+  it("builds OpenCode-specific missing CLI guidance", () => {
+    const notice = buildMissingCliNotice("opencode", "");
+    expect(notice).toContain('OpenCode CLI not found for "opencode"');
+    expect(notice).toContain("brew install anomalyco/tap/opencode");
+    expect(notice).toContain("https://opencode.ai/docs");
   });
 });

--- a/src/core/agents/AgentProfile.test.ts
+++ b/src/core/agents/AgentProfile.test.ts
@@ -14,6 +14,7 @@ import {
   createDefaultClaudeCtxProfile,
   createDefaultCopilotProfile,
   getBuiltInProfiles,
+  getLaunchConfig,
   validateProfilePromptInjection,
 } from "./AgentProfile";
 
@@ -29,6 +30,10 @@ describe("agentTypeToSessionType", () => {
   });
   it("maps copilot with context", () => {
     expect(agentTypeToSessionType("copilot", true)).toBe("copilot-with-context");
+  });
+  it("maps OpenCode sessions", () => {
+    expect(agentTypeToSessionType("opencode", false)).toBe("opencode");
+    expect(agentTypeToSessionType("opencode", true)).toBe("opencode-with-context");
   });
   it("maps strands without context", () => {
     expect(agentTypeToSessionType("strands", false)).toBe("strands");
@@ -54,6 +59,16 @@ describe("sessionTypeToAgentType", () => {
     expect(sessionTypeToAgentType("copilot")).toEqual({ agentType: "copilot", withContext: false });
     expect(sessionTypeToAgentType("copilot-with-context")).toEqual({
       agentType: "copilot",
+      withContext: true,
+    });
+  });
+  it("maps OpenCode session types", () => {
+    expect(sessionTypeToAgentType("opencode")).toEqual({
+      agentType: "opencode",
+      withContext: false,
+    });
+    expect(sessionTypeToAgentType("opencode-with-context")).toEqual({
+      agentType: "opencode",
       withContext: true,
     });
   });
@@ -173,6 +188,7 @@ describe("BRAND_COLORS", () => {
   it("defines colors for all branded icons", () => {
     expect(BRAND_COLORS.claude).toBe("#D97757");
     expect(BRAND_COLORS.copilot).toBe("#6E40C9");
+    expect(BRAND_COLORS.opencode).toBe("#131010");
     expect(BRAND_COLORS.aws).toBe("#FF9900");
     expect(BRAND_COLORS.skyscanner).toBe("#0770E3");
   });
@@ -203,6 +219,27 @@ describe("default profile button colors", () => {
 // ---------------------------------------------------------------------------
 // Custom agent type
 // ---------------------------------------------------------------------------
+
+describe("OpenCode agent type", () => {
+  it("uses the first-party command and prompt launch configuration", () => {
+    expect(getLaunchConfig("opencode")).toMatchObject({
+      defaultCommand: "opencode",
+      promptInjectionMode: "flag",
+      promptFlag: "--prompt",
+      cliDisplayName: "OpenCode CLI",
+      displayLabel: "OpenCode",
+    });
+  });
+
+  it("is accepted by the profile schema", () => {
+    const profile = createDefaultProfile({
+      agentType: "opencode",
+      button: { enabled: true, label: "OpenCode", icon: "opencode" },
+    });
+    expect(AGENT_TYPES).toContain("opencode");
+    expect(AgentProfileSchema.safeParse(profile).success).toBe(true);
+  });
+});
 
 describe("custom agent type", () => {
   it("is included in AGENT_TYPES", () => {

--- a/src/core/agents/AgentProfile.ts
+++ b/src/core/agents/AgentProfile.ts
@@ -32,6 +32,7 @@ export const PROFILE_ICONS = [
   // Branded
   "claude",
   "copilot",
+  "opencode",
   "aws",
   "skyscanner",
   "pi",
@@ -46,6 +47,7 @@ export type BorderStyle = (typeof BORDER_STYLES)[number];
 export const BRAND_COLORS: Partial<Record<ProfileIcon, string>> = {
   claude: "#D97757",
   copilot: "#6E40C9",
+  opencode: "#131010",
   aws: "#FF9900",
   skyscanner: "#0770E3",
   pi: "#00C853",
@@ -55,7 +57,7 @@ export const BRAND_COLORS: Partial<Record<ProfileIcon, string>> = {
 // Agent types (maps to session type families)
 // ---------------------------------------------------------------------------
 
-export const AGENT_TYPES = ["claude", "copilot", "strands", "shell", "custom"] as const;
+export const AGENT_TYPES = ["claude", "copilot", "opencode", "strands", "shell", "custom"] as const;
 export type AgentType = (typeof AGENT_TYPES)[number];
 
 // ---------------------------------------------------------------------------
@@ -247,6 +249,17 @@ const AGENT_LAUNCH_CONFIGS: Record<AgentType, AgentLaunchConfig> = {
       ],
     },
   },
+  opencode: {
+    promptInjectionMode: "flag",
+    promptFlag: "--prompt",
+    commandSettingKey: "",
+    defaultCommand: "opencode",
+    extraArgsSettingKey: "",
+    cliDisplayName: "OpenCode CLI",
+    installHint:
+      "Install it first with brew install anomalyco/tap/opencode or see https://opencode.ai/docs, then retry the profile.",
+    displayLabel: "OpenCode",
+  },
   strands: {
     promptInjectionMode: "positional",
     commandSettingKey: "core.strandsCommand",
@@ -320,6 +333,8 @@ export function agentTypeToSessionType(
       return withContext ? "claude-with-context" : "claude";
     case "copilot":
       return withContext ? "copilot-with-context" : "copilot";
+    case "opencode":
+      return withContext ? "opencode-with-context" : "opencode";
     case "strands":
       return withContext ? "strands-with-context" : "strands";
     case "shell":
@@ -362,6 +377,10 @@ export function sessionTypeToAgentType(sessionType: SessionType): {
       return { agentType: "copilot", withContext: false };
     case "copilot-with-context":
       return { agentType: "copilot", withContext: true };
+    case "opencode":
+      return { agentType: "opencode", withContext: false };
+    case "opencode-with-context":
+      return { agentType: "opencode", withContext: true };
     case "strands":
       return { agentType: "strands", withContext: false };
     case "strands-with-context":

--- a/src/core/agents/AgentProfileManager.test.ts
+++ b/src/core/agents/AgentProfileManager.test.ts
@@ -162,6 +162,8 @@ describe("AgentProfileManager", () => {
       const toImport = [
         createDefaultProfile({
           name: "Imported Agent",
+          agentType: "opencode",
+          button: { enabled: true, label: "OpenCode", icon: "opencode" },
           sortOrder: 0,
           appendContextPrompt: false,
           escapeWorkTerminalPrompt: false,
@@ -173,13 +175,16 @@ describe("AgentProfileManager", () => {
       expect(result.errors).toHaveLength(0);
       const imported = manager.getProfiles().find((p) => p.name === "Imported Agent");
       expect(imported).toMatchObject({
+        agentType: "opencode",
         appendContextPrompt: false,
         escapeWorkTerminalPrompt: false,
+        button: { icon: "opencode" },
       });
       expect(JSON.parse(manager.exportProfiles())).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             name: "Imported Agent",
+            agentType: "opencode",
             appendContextPrompt: false,
             escapeWorkTerminalPrompt: false,
           }),
@@ -273,10 +278,10 @@ describe("AgentProfileManager", () => {
     });
 
     it("resolves command for each agent type", () => {
-      for (const [agentType, settingKey, _fallback] of [
-        ["claude", "core.claudeCommand", "claude"],
-        ["copilot", "core.copilotCommand", "copilot"],
-        ["strands", "core.strandsCommand", "strands"],
+      for (const [agentType, settingKey] of [
+        ["claude", "core.claudeCommand"],
+        ["copilot", "core.copilotCommand"],
+        ["strands", "core.strandsCommand"],
       ] as const) {
         // Profile command takes priority
         const withCmd = createDefaultProfile({ command: "/custom/bin", agentType });
@@ -287,6 +292,9 @@ describe("AgentProfileManager", () => {
           "global-cmd",
         );
       }
+
+      const openCode = createDefaultProfile({ command: "", agentType: "opencode" });
+      expect(manager.resolveCommand(openCode, {})).toBe("opencode");
     });
   });
 
@@ -309,12 +317,24 @@ describe("AgentProfileManager", () => {
     });
 
     it("accepts valid stored profiles", async () => {
-      const existing = [createDefaultProfile({ name: "Valid Profile", sortOrder: 0 })];
+      const existing = [
+        createDefaultProfile({
+          name: "OpenCode",
+          agentType: "opencode",
+          command: "",
+          button: { enabled: true, label: "OpenCode", icon: "opencode" },
+          sortOrder: 0,
+        }),
+      ];
       plugin = createMockPlugin({ agentProfiles: existing });
       manager = new AgentProfileManager(plugin);
       await manager.load();
       expect(manager.getProfiles()).toHaveLength(1);
-      expect(manager.getProfiles()[0].name).toBe("Valid Profile");
+      expect(manager.getProfiles()[0]).toMatchObject({
+        name: "OpenCode",
+        agentType: "opencode",
+        button: { icon: "opencode" },
+      });
     });
 
     it("does NOT call saveData when stored profiles fail validation", async () => {

--- a/src/core/session/types.test.ts
+++ b/src/core/session/types.test.ts
@@ -70,6 +70,8 @@ describe("PersistedSession", () => {
 
   it("validates unknown session types", () => {
     expect(isSessionType("claude")).toBe(true);
+    expect(isSessionType("opencode")).toBe(true);
+    expect(isSessionType("opencode-with-context")).toBe(true);
     expect(isSessionType("unknown")).toBe(false);
     expect(isSessionType(null)).toBe(false);
   });

--- a/src/core/session/types.ts
+++ b/src/core/session/types.ts
@@ -16,6 +16,8 @@ export const KNOWN_SESSION_TYPES = [
   "claude-with-context",
   "copilot",
   "copilot-with-context",
+  "opencode",
+  "opencode-with-context",
   "strands",
   "strands-with-context",
   "custom",

--- a/src/framework/AgentProfileManagerModal.ts
+++ b/src/framework/AgentProfileManagerModal.ts
@@ -40,6 +40,7 @@ export function buildLastClaudeDeleteGuard(
 const AGENT_TYPE_LABELS: Record<string, string> = {
   claude: "Claude",
   copilot: "Copilot",
+  opencode: "OpenCode",
   strands: "Strands",
   shell: "Shell",
   custom: "Custom",

--- a/src/framework/AgentProfileModal.test.ts
+++ b/src/framework/AgentProfileModal.test.ts
@@ -263,6 +263,29 @@ function getDeleteButton(modal: AgentProfileEditModal): HTMLButtonElement | null
 describe("AgentProfileEditModal validation", () => {
   beforeEach(() => NoticeMock.mockClear());
 
+  it("offers OpenCode as an agent type and branded icon", () => {
+    const modal = new AgentProfileEditModal(
+      {} as any,
+      makeProfile({
+        id: "opencode",
+        agentType: "opencode",
+        button: { enabled: true, label: "OpenCode", icon: "opencode" },
+      }),
+      vi.fn(),
+    );
+    modal.open();
+
+    const options = Array.from(
+      (modal as any).contentEl.querySelectorAll<HTMLOptionElement>("option"),
+    );
+    expect(options).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ value: "opencode", textContent: "OpenCode" }),
+        expect.objectContaining({ value: "opencode", textContent: "OpenCode (branded)" }),
+      ]),
+    );
+  });
+
   it("blocks saving manual context injection without $workTerminalPrompt", () => {
     const onSave = vi.fn();
     const modal = new AgentProfileEditModal(

--- a/src/framework/AgentProfileModal.test.ts
+++ b/src/framework/AgentProfileModal.test.ts
@@ -284,6 +284,9 @@ describe("AgentProfileEditModal validation", () => {
         expect.objectContaining({ value: "opencode", textContent: "OpenCode (branded)" }),
       ]),
     );
+    expect((modal as any).contentEl.querySelector(".wt-command-validation-note")?.textContent).toBe(
+      "Will use the built-in default: opencode",
+    );
   });
 
   it("blocks saving manual context injection without $workTerminalPrompt", () => {

--- a/src/framework/AgentProfileModal.ts
+++ b/src/framework/AgentProfileModal.ts
@@ -33,6 +33,7 @@ export type ProfileLaunchPreviewResolver = (
 const AGENT_TYPE_LABELS: Record<AgentType, string> = {
   claude: "Claude",
   copilot: "Copilot",
+  opencode: "OpenCode",
   strands: "Strands",
   shell: "Shell",
   custom: "Custom",
@@ -64,6 +65,7 @@ const ICON_LABELS: Record<ProfileIcon, string> = {
   bee: "Bee",
   claude: "Claude (branded)",
   copilot: "Copilot (branded)",
+  opencode: "OpenCode (branded)",
   aws: "AWS (branded)",
   skyscanner: "Skyscanner (branded)",
   pi: "pi (branded)",
@@ -166,7 +168,7 @@ export class AgentProfileEditModal extends Modal {
       .setDesc(
         isCustom
           ? "Path or name of the CLI binary (required for custom profiles)."
-          : "Path or name of the CLI binary. Leave blank to use the global setting for this agent type.",
+          : "Path or name of the CLI binary. Leave blank to use the global setting or built-in default for this agent type.",
       )
       .addText((text) => {
         text

--- a/src/framework/AgentProfileModal.ts
+++ b/src/framework/AgentProfileModal.ts
@@ -581,7 +581,10 @@ export class AgentProfileEditModal extends Modal {
     if (!command) {
       badgeEl.textContent = "";
       badgeEl.className = "wt-command-status-badge";
-      noteEl.textContent = "Will use the global default for this agent type";
+      noteEl.textContent =
+        this.draft.agentType === "opencode"
+          ? "Will use the built-in default: opencode"
+          : "Will use the global default for this agent type";
       noteEl.className = "wt-command-validation-note";
       return;
     }

--- a/src/framework/CustomSessionConfig.test.ts
+++ b/src/framework/CustomSessionConfig.test.ts
@@ -63,6 +63,8 @@ describe("CustomSessionConfig", () => {
     expect(getDefaultSessionLabel("claude-with-context")).toBe("Claude (ctx)");
     expect(getDefaultSessionLabel("copilot")).toBe("Copilot");
     expect(getDefaultSessionLabel("copilot-with-context")).toBe("Copilot (ctx)");
+    expect(getDefaultSessionLabel("opencode")).toBe("OpenCode");
+    expect(getDefaultSessionLabel("opencode-with-context")).toBe("OpenCode (ctx)");
     expect(getDefaultSessionLabel("strands")).toBe("Strands");
     expect(getDefaultSessionLabel("strands-with-context")).toBe("Strands (ctx)");
   });
@@ -71,6 +73,7 @@ describe("CustomSessionConfig", () => {
     expect(isContextSession("claude-with-context")).toBe(true);
     expect(isContextSession("copilot-with-context")).toBe(true);
     expect(isContextSession("strands-with-context")).toBe(true);
+    expect(isContextSession("opencode-with-context")).toBe(true);
     expect(isContextSession("copilot")).toBe(false);
     expect(isContextSession("strands")).toBe(false);
     expect(isClaudeSession("claude")).toBe(true);
@@ -85,6 +88,7 @@ describe("CustomSessionConfig", () => {
     expect(supportsExtraArgs("shell")).toBe(false);
     expect(supportsExtraArgs("claude")).toBe(true);
     expect(supportsExtraArgs("copilot")).toBe(true);
+    expect(supportsExtraArgs("opencode")).toBe(true);
     expect(supportsExtraArgs("strands")).toBe(true);
   });
 
@@ -99,6 +103,7 @@ describe("CustomSessionConfig", () => {
     expect(isAgentTypeSession("claude", "claude")).toBe(true);
     expect(isAgentTypeSession("claude-with-context", "claude")).toBe(true);
     expect(isAgentTypeSession("copilot", "copilot")).toBe(true);
+    expect(isAgentTypeSession("opencode", "opencode")).toBe(true);
     expect(isAgentTypeSession("strands", "strands")).toBe(true);
     expect(isAgentTypeSession("shell", "shell")).toBe(true);
     expect(isAgentTypeSession("claude", "copilot")).toBe(false);

--- a/src/framework/CustomSessionConfig.ts
+++ b/src/framework/CustomSessionConfig.ts
@@ -19,6 +19,8 @@ export const CUSTOM_SESSION_TYPE_OPTIONS: Array<{ value: SessionType; label: str
   { value: "claude-with-context", label: "Claude (ctx)" },
   { value: "copilot", label: "Copilot" },
   { value: "copilot-with-context", label: "Copilot (ctx)" },
+  { value: "opencode", label: "OpenCode" },
+  { value: "opencode-with-context", label: "OpenCode (ctx)" },
   { value: "strands", label: "Strands" },
   { value: "strands-with-context", label: "Strands (ctx)" },
   { value: "custom", label: "Custom" },

--- a/src/framework/ProfileLaunchResolver.test.ts
+++ b/src/framework/ProfileLaunchResolver.test.ts
@@ -61,6 +61,38 @@ describe("profile launch resolution and preview", () => {
     expect(preview).not.toContain("Clearly");
   });
 
+  it("launches first-party OpenCode context with --prompt as one argv value", () => {
+    const contextual = resolveProfileLaunch({
+      profile: {
+        ...baseProfile,
+        agentType: "opencode",
+        command: "opencode",
+        arguments: "--model test",
+      },
+      settings: {},
+      profileManager: manager,
+      promptBuilder,
+      item: PROFILE_PREVIEW_EXAMPLE_ITEM,
+      absoluteFilePath: PROFILE_PREVIEW_EXAMPLE_ABSOLUTE_PATH,
+    });
+    expect(contextual.sessionType).toBe("opencode-with-context");
+    expect(contextual.invocation.argv.slice(-2)).toEqual(["--prompt", contextual.prompt]);
+    expect(contextual.invocation.args.filter((arg) => arg === contextual.prompt)).toHaveLength(1);
+    expect(formatProfileLaunchPreview(contextual)).toContain(
+      'Prompt placement: automatic flag "--prompt"',
+    );
+
+    const plain = resolveProfileLaunch({
+      profile: { ...baseProfile, agentType: "opencode", command: "opencode", useContext: false },
+      settings: {},
+      profileManager: manager,
+      promptBuilder,
+      item: PROFILE_PREVIEW_EXAMPLE_ITEM,
+    });
+    expect(plain.sessionType).toBe("opencode");
+    expect(plain.invocation.args).not.toContain("--prompt");
+  });
+
   it("shows flag placement and the login-shell layer without losing prompt boundaries", () => {
     const resolved = resolveProfileLaunch({
       profile: {

--- a/src/framework/TerminalPanelView.test.ts
+++ b/src/framework/TerminalPanelView.test.ts
@@ -1144,6 +1144,29 @@ describe("TerminalPanelView", () => {
     expect(mockState.notices).toContain("Session diagnostics copied to clipboard");
   });
 
+  it("renders the official OpenCode icon on profile tab-bar buttons", async () => {
+    const { panelEl, view } = createView();
+    await flushAsync();
+    (view as any).profileManager = {
+      getButtonProfiles: () => [
+        {
+          id: "opencode",
+          name: "OpenCode",
+          agentType: "opencode",
+          button: { enabled: true, label: "OpenCode", icon: "opencode" },
+        },
+      ],
+    };
+
+    (view as any).renderTabBar();
+
+    const button = panelEl.querySelector<HTMLButtonElement>(
+      '.wt-spawn-profile[aria-label="Launch OpenCode"]',
+    );
+    expect(button?.textContent).toContain("OpenCode");
+    expect(button?.querySelector("svg")?.getAttribute("viewBox")).toBe("0 0 300 300");
+  });
+
   it("resolves pluginDir from a relative vault path using USERPROFILE semantics", async () => {
     const originalHome = process.env.HOME;
     const originalUserProfile = process.env.USERPROFILE;

--- a/src/ui/ProfileIcons.test.ts
+++ b/src/ui/ProfileIcons.test.ts
@@ -34,7 +34,15 @@ describe("ProfileIcons", () => {
   });
 
   describe("branded icons", () => {
-    const brandedIcons: ProfileIcon[] = ["claude", "copilot", "aws", "skyscanner", "bee", "pi"];
+    const brandedIcons: ProfileIcon[] = [
+      "claude",
+      "copilot",
+      "opencode",
+      "aws",
+      "skyscanner",
+      "bee",
+      "pi",
+    ];
 
     for (const icon of brandedIcons) {
       it(`creates ${icon} icon with path elements`, () => {
@@ -53,6 +61,15 @@ describe("ProfileIcons", () => {
     it("copilot icon uses 24x24 viewBox", () => {
       const svg = createProfileIcon("copilot");
       expect(svg!.getAttribute("viewBox")).toBe("0 0 24 24");
+    });
+
+    it("OpenCode icon uses the official square-logo geometry", () => {
+      const svg = createProfileIcon("opencode");
+      expect(svg!.getAttribute("viewBox")).toBe("0 0 300 300");
+      const paths = svg!.querySelectorAll("path");
+      expect(paths).toHaveLength(2);
+      expect(paths[0].getAttribute("d")).toBe("M210 240H90V120H210V240Z");
+      expect(paths[1].getAttribute("d")).toBe("M210 60H90V240H210V60ZM270 300H30V0H270V300Z");
     });
 
     it("aws icon uses 24x24 viewBox", () => {

--- a/src/ui/ProfileIcons.ts
+++ b/src/ui/ProfileIcons.ts
@@ -6,6 +6,9 @@
  * Branded icon sources:
  * - Claude: Simple Icons (https://simpleicons.org/?q=claude), 24x24
  * - Copilot: Simple Icons (https://simpleicons.org/?q=github-copilot), 24x24
+ * - OpenCode: official square logo geometry from
+ *   https://github.com/anomalyco/opencode/blob/def7220bfc65b84046e597e9be772eae81f663ff/packages/console/app/src/asset/brand/opencode-logo-light-square.svg
+ *   (MIT: https://github.com/anomalyco/opencode/blob/def7220bfc65b84046e597e9be772eae81f663ff/LICENSE), adapted to currentColor
  * - AWS: Wordmark + smile-arrow (https://simpleicons.org/?q=amazon-aws), 24x24
  * - Skyscanner: Official sunrise mark extracted from Wikimedia Commons SVG
  */
@@ -84,6 +87,17 @@ function createCopilotIcon(size: number): SVGSVGElement {
     svg,
     "M23.922 16.997C23.061 18.492 18.063 22.02 12 22.02 5.937 22.02.939 18.492.078 16.997A.641.641 0 0 1 0 16.741v-2.869a.883.883 0 0 1 .053-.22c.372-.935 1.347-2.292 2.605-2.656.167-.429.414-1.055.644-1.517a10.098 10.098 0 0 1-.052-1.086c0-1.331.282-2.499 1.132-3.368.397-.406.89-.717 1.474-.952C7.255 2.937 9.248 1.98 11.978 1.98c2.731 0 4.767.957 6.166 2.093.584.235 1.077.546 1.474.952.85.869 1.132 2.037 1.132 3.368 0 .368-.014.733-.052 1.086.23.462.477 1.088.644 1.517 1.258.364 2.233 1.721 2.605 2.656a.841.841 0 0 1 .053.22v2.869a.641.641 0 0 1-.078.256Zm-11.75-5.992h-.344a4.359 4.359 0 0 1-.355.508c-.77.947-1.918 1.492-3.508 1.492-1.725 0-2.989-.359-3.782-1.259a2.137 2.137 0 0 1-.085-.104L4 11.746v6.585c1.435.779 4.514 2.179 8 2.179 3.486 0 6.565-1.4 8-2.179v-6.585l-.098-.104s-.033.045-.085.104c-.793.9-2.057 1.259-3.782 1.259-1.59 0-2.738-.545-3.508-1.492a4.359 4.359 0 0 1-.355-.508Zm2.328 3.25c.549 0 1 .451 1 1v2c0 .549-.451 1-1 1-.549 0-1-.451-1-1v-2c0-.549.451-1 1-1Zm-5 0c.549 0 1 .451 1 1v2c0 .549-.451 1-1 1-.549 0-1-.451-1-1v-2c0-.549.451-1 1-1Zm3.313-6.185c.136 1.057.403 1.913.878 2.497.442.544 1.134.938 2.344.938 1.573 0 2.292-.337 2.657-.751.384-.435.558-1.15.558-2.361 0-1.14-.243-1.847-.705-2.319-.477-.488-1.319-.862-2.824-1.025-1.487-.161-2.192.138-2.533.529-.269.307-.437.808-.438 1.578v.021c0 .265.021.562.063.893Zm-1.626 0c.042-.331.063-.628.063-.894v-.02c-.001-.77-.169-1.271-.438-1.578-.341-.391-1.046-.69-2.533-.529-1.505.163-2.347.537-2.824 1.025-.462.472-.705 1.179-.705 2.319 0 1.211.175 1.926.558 2.361.365.414 1.084.751 2.657.751 1.21 0 1.902-.394 2.344-.938.475-.584.742-1.44.878-2.497Z",
   );
+  return svg;
+}
+
+function createOpenCodeIcon(size: number): SVGSVGElement {
+  const svg = makeSvg(size, "0 0 300 300");
+  const inner = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  inner.setAttribute("fill", "currentColor");
+  inner.setAttribute("fill-opacity", "0.35");
+  inner.setAttribute("d", "M210 240H90V120H210V240Z");
+  svg.appendChild(inner);
+  addPath(svg, "M210 60H90V240H210V60ZM270 300H30V0H270V300Z");
   return svg;
 }
 
@@ -364,6 +378,7 @@ const ICON_FACTORIES: Record<ProfileIcon, (size: number) => SVGSVGElement> = {
   bee: createBeeIcon,
   claude: createClaudeIcon,
   copilot: createCopilotIcon,
+  opencode: createOpenCodeIcon,
   aws: createAwsIcon,
   skyscanner: createSkyscannerIcon,
   pi: createPiIcon,


### PR DESCRIPTION
## Summary
- add OpenCode across the shared agent/profile/session launch pipeline
- default blank commands to `opencode` and inject context as `--prompt <one argv value>`
- add OpenCode-specific guidance, profile persistence, selector/session handling, and exact launch preview support
- add official attributed OpenCode branded icon for picker and tab buttons
- update focused tests, process disclosure, and user guide

## Validation
- `pnpm exec vitest run` (1,410 passed)
- `pnpm run build`
- `pnpm run lint`
- `git diff --check`

Closes #538