### PR TITLE
[TASK-20260327-1830] Preserve terminal focus on Escape

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -683,6 +683,7 @@ The API exposes session metadata, task state, and terminal references. It is dis
 
 When a terminal tab is focused, Work Terminal captures keyboard input to prevent Obsidian's hotkeys from interfering with terminal interaction. The capture handles:
 
+- **Escape** is sent to the active terminal without moving focus back to Obsidian
 - **Option+Arrow** keys for word-by-word navigation
 - **Option+B/F/D** for readline-style movement and deletion
 - **Shift+Enter** for sending literal newlines

--- a/src/core/terminal/KeyboardCapture.test.ts
+++ b/src/core/terminal/KeyboardCapture.test.ts
@@ -235,8 +235,10 @@ describe("KeyboardCapture", () => {
     expect(downEvent.defaultPrevented).toBe(true);
   });
 
-  it("sends Escape as \\x1b to PTY and prevents propagation", () => {
+  it("sends Escape as \\x1b before document capture handlers", () => {
     const write = vi.fn();
+    const documentHandler = vi.fn();
+    document.addEventListener("keydown", documentHandler, true);
     const cleanup = attachCapturePhase(
       containerEl,
       () =>
@@ -251,11 +253,13 @@ describe("KeyboardCapture", () => {
       bubbles: true,
       cancelable: true,
     });
-    document.dispatchEvent(event);
+    textareaEl.dispatchEvent(event);
 
     cleanup();
+    document.removeEventListener("keydown", documentHandler, true);
 
     expect(write).toHaveBeenCalledWith("\x1b");
+    expect(documentHandler).not.toHaveBeenCalled();
     expect(event.defaultPrevented).toBe(true);
   });
 

--- a/src/core/terminal/KeyboardCapture.ts
+++ b/src/core/terminal/KeyboardCapture.ts
@@ -5,7 +5,7 @@
  * Obsidian's bubble-phase handlers from intercepting keyboard events after
  * xterm processes them.
  *
- * Layer 2 (capture phase): intercept specific modifier combos on document
+ * Layer 2 (capture phase): intercept specific modifier combos on window
  * (capture phase) before Obsidian sees them. Synthesizes terminal escape
  * sequences directly to PTY stdin, then kills the event entirely.
  */
@@ -69,13 +69,13 @@ export function attachInputCapture(containerEl: HTMLElement): () => void {
 }
 
 /**
- * Attach capture-phase keyboard interception on document for modifier combos
- * that Obsidian steals in its own capture-phase handlers.
+ * Attach capture-phase keyboard interception on window for modifier combos
+ * before Obsidian's document-level capture handlers.
  *
  * Only acts when the terminal's hidden textarea is the active element,
  * ensuring we don't block keyboard events for other UI elements.
  *
- * @returns A cleanup function that removes the document listener.
+ * @returns A cleanup function that removes the window listener.
  */
 export function attachCapturePhase(
   containerEl: HTMLElement,
@@ -179,9 +179,9 @@ export function attachCapturePhase(
     }
   };
 
-  document.addEventListener("keydown", handler, true);
+  window.addEventListener("keydown", handler, true);
 
   return () => {
-    document.removeEventListener("keydown", handler, true);
+    window.removeEventListener("keydown", handler, true);
   };
 }


### PR DESCRIPTION
## Summary

- capture terminal keydown events on `window` before Obsidian document handlers
- keep plain Escape routed to active PTY without moving focus
- document Escape keyboard capture and cover propagation order

## Validation

- `vitest run` - 67 files, 1410 tests passed
- `node esbuild.config.mjs --production`
- ESLint on changed TypeScript files
- Prettier on changed TypeScript files

Fixes #378
